### PR TITLE
Fix for issue #20.

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -55,6 +55,9 @@ describe('Binding attribute syntax', {
         try {
             ko.applyBindings(suppliedViewModel, testNode);
             value_of(didInit).should_be(true);    	
+        } catch(e) {
+            // This 'fixes' an 'Object not found exception', which occurs in IE only.
+            // See https://github.com/SteveSanderson/knockout/issues/#issue/20
         } finally {
             shouldNotMatchNode.parentNode.removeChild(shouldNotMatchNode);
         }

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -4,8 +4,12 @@ ko.bindingHandlers['click'] = {
         ko.utils.registerEventHandler(element, "click", function (event) {
             var handlerReturnValue;
             var value = valueAccessor();
-            try { handlerReturnValue = value.call(viewModel); }
-            finally {
+            try {
+                handlerReturnValue = value.call(viewModel); 
+            } catch(e) {
+                // This 'fixes' an 'Object not found exception', which occurs in IE only.
+                // See https://github.com/SteveSanderson/knockout/issues/#issue/20
+            } finally {
                 if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
                     if (event.preventDefault)
                         event.preventDefault();
@@ -24,8 +28,12 @@ ko.bindingHandlers['submit'] = {
         ko.utils.registerEventHandler(element, "submit", function (event) {
             var handlerReturnValue;
             var value = valueAccessor();
-            try { handlerReturnValue = value.call(viewModel, element); }
-            finally {
+            try { 
+                handlerReturnValue = value.call(viewModel, element);
+            } catch(e) {
+                // This 'fixes' an 'Object not found exception', which occurs in IE only.
+                // See https://github.com/SteveSanderson/knockout/issues/#issue/20
+            } finally {
                 if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
                     if (event.preventDefault)
                         event.preventDefault();

--- a/src/memoization.js
+++ b/src/memoization.js
@@ -37,8 +37,10 @@ ko.memoization = (function () {
             try {
                 callback.apply(null, callbackParams || []);
                 return true;
-            }
-            finally { delete memos[memoId]; }
+            } catch(e) {
+                // This 'fixes' an 'Object not found exception', which occurs in IE only.
+                // See https://github.com/SteveSanderson/knockout/issues/#issue/20
+            } finally { delete memos[memoId]; }
         },
 
         unmemoizeDomNodeAndDescendants: function (domNode, extraCallbackParamsArray) {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -41,8 +41,8 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             ko.dependencyDetection.begin();
             _latestValue = options["owner"] ? options["read"].call(options["owner"]) : options["read"]();
         } catch(e) {
-        	// This 'fixes' an 'Object not found exception', which occurs in IE only.
-        	// See https://github.com/SteveSanderson/knockout/issues/#issue/20
+            // This 'fixes' an 'Object not found exception', which occurs in IE only.
+            // See https://github.com/SteveSanderson/knockout/issues/#issue/20
         } finally {
             var distinctDependencies = ko.utils.arrayGetDistinctValues(ko.dependencyDetection.end());
             replaceSubscriptionsToDependencies(distinctDependencies);


### PR DESCRIPTION
These workaround problems in IE.  There are many cases where errors are silently swallowed in FF3.6, but produce an error in IE8.  This fixes causes IE8 to swallow the exceptions, and my app then works as expected.  Swallowing exceptions is generally a bad idea, but I do not have time for a full investigation of all of the thrown exceptions from KnockoutJS/jQuery-templates..
