### PR TITLE
getTemplateNode accepts fallbacks

### DIFF
--- a/build/output/knockout-latest.debug.js
+++ b/build/output/knockout-latest.debug.js
@@ -1736,7 +1736,15 @@ ko.jqueryTmplTemplateEngine = function () {
     })();
 
     function getTemplateNode(template) {
-        var templateNode = document.getElementById(template);
+        var templateNode;
+        if (template instanceof Array) {
+            for (var i = 0, l = template.length; i < l; i += 1) {
+                templateNode = document.getElementById(template[i]);
+                if (templateNode) return templateNode;
+            }
+        } else {
+            templateNode = document.getElementById(template);
+        }
         if (templateNode == null)
             throw new Error("Cannot find template with ID=" + template);
         return templateNode;

--- a/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
+++ b/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
@@ -11,7 +11,15 @@ ko.jqueryTmplTemplateEngine = function () {
     })();
 
     function getTemplateNode(template) {
-        var templateNode = document.getElementById(template);
+        var templateNode;
+        if (template instanceof Array) {
+            for (var i = 0, l = template.length; i < l; i += 1) {
+                templateNode = document.getElementById(template[i]);
+                if (templateNode) return templateNode;
+            }
+        } else {
+            templateNode = document.getElementById(template);
+        }
         if (templateNode == null)
             throw new Error("Cannot find template with ID=" + template);
         return templateNode;


### PR DESCRIPTION
Hi!

`getTemplateNode()` made to take also array of template names, which will be looked up in sequence before `getTemplateNode()` gives up. E.g. `getTemplateNode(['tmpl-list-Entity', 'tmpl-list-generic'])` will try to find `#tmpl-list-Entity`, then if failed `#tmpl-list-generic`, then throw if failed. Useful to make reused templates

Please, consider applying

TIA,
--Vladimir
