### PR TITLE
Fix for the 'checked' binding updating the observable twice.

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -263,24 +263,31 @@ ko.bindingHandlers['uniqueName'].currentIndex = 0;
 
 ko.bindingHandlers['checked'] = {
     'init': function (element, valueAccessor, allBindingsAccessor) {
+        var queuedUpdate;
         var updateHandler = function() {
-            var value = valueAccessor();
-            if (ko.isWriteableObservable(value)) {
-                if (element.type == "checkbox") {
-                    value(element.checked);
-                } else if ((element.type == "radio") && (element.checked)) {
-                    value(element.value);
-                }
-            } else {
-                var allBindings = allBindingsAccessor();
-                if (allBindings['_ko_property_writers'] && allBindings['_ko_property_writers']['checked']) {
+            if(typeof(queuedUpdate) === 'number') {
+                clearTimeout(queuedUpdate);
+            }
+            queuedUpdate = setTimeout(function() {
+                var value = valueAccessor();
+                if (ko.isWriteableObservable(value)) {
                     if (element.type == "checkbox") {
-                        allBindings['_ko_property_writers']['checked'](element.checked);
+                        value(element.checked);
                     } else if ((element.type == "radio") && (element.checked)) {
-                        allBindings['_ko_property_writers']['checked'](element.value);
+                        value(element.value);
+                    }
+                } else {
+                    var allBindings = allBindingsAccessor();
+                    if (allBindings['_ko_property_writers'] && allBindings['_ko_property_writers']['checked']) {
+                        if (element.type == "checkbox") {
+                            allBindings['_ko_property_writers']['checked'](element.checked);
+                        } else if ((element.type == "radio") && (element.checked)) {
+                            allBindings['_ko_property_writers']['checked'](element.value);
+                        }
                     }
                 }
-            }
+                queuedUpdate = null;
+            }, 0);
         };
         ko.utils.registerEventHandler(element, "change", updateHandler);
         ko.utils.registerEventHandler(element, "click", updateHandler);


### PR DESCRIPTION
Hi there,

Since the 'checked' binding registers for 'change' and 'click' events, the observable ends up getting updated twice.  Usually it's not a problem, but there are at least two scenarios when it is undesirable: an explicit subscription to the observable (e.g. to do an ajax update), and having a complex form with lots of templates which ends up being expensive (in terms of cpu cycles) to re-render twice.

P.S. github's diff view of the commit is showing the change as much more complex than it actually is.
