### PR TITLE
Allow optionsText parameter on options binding to accept function

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -154,7 +154,7 @@ ko.bindingHandlers['options'] = {
             for (var i = 0, j = value.length; i < j; i++) {
                 var option = document.createElement("OPTION");
                 var optionValue = typeof allBindings['optionsValue'] == "string" ? value[i][allBindings['optionsValue']] : value[i];
-                var optionText = typeof allBindings['optionsText'] == "string" ? value[i][allBindings['optionsText']] : optionValue;
+                var optionText = typeof allBindings['optionsText'] == "function" ? allBindings['optionsText'](value[i]) : (typeof allBindings['optionsText'] == "string" ? value[i][allBindings['optionsText']] : optionValue);
                 optionValue = ko.utils.unwrapObservable(optionValue);
                 optionText = ko.utils.unwrapObservable(optionText);
                 ko.selectExtensions.writeValue(option, optionValue);


### PR DESCRIPTION
I'm really new to git, github and knockout, so sorry if my pull request is incorrectly formatted, improper or stupid. I had a desire to create a custom options text in my select boxes rather than simply one of the values in my JavaScript object. This is a small patch to allow optionsText to accept a function.
