### PR TITLE
Closure compiler wrapko

### DIFF
--- a/build/build-linux
+++ b/build/build-linux
@@ -1,12 +1,18 @@
 #!/bin/sh
 
+OutDebugFile='output/knockout-latest.debug.js'
+OutMinFile='output/knockout-latest.js'
+
 SourceFiles=`grep js < source-references.js | # Find JS references 
              sed "s/[ \',]//g" |              # Strip off JSON fluff (whitespace, commas, quotes)
              sed -e 's/.*/..\/&/' |           # Fix the paths by prefixing with ../
              tr '\n' ' '`                     # Combine into single line
 
-cat version-header.js $SourceFiles > output/knockout-latest.debug.js # Concatenate all the files
+cp version-header.js $OutDebugFile
+echo "(function(window,undefined){" >> $OutDebugFile
+cat $SourceFiles                    >> $OutDebugFile
+echo "})(window);"                  >> $OutDebugFile
 
 # Now call Google Closure Compiler to produce a minified version
-cp version-header.js output/knockout-latest.js
-curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@output/knockout-latest.debug.js "http://closure-compiler.appspot.com/compile" >> output/knockout-latest.js
+cp version-header.js $OutMinFile
+curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@$OutDebugFile "http://closure-compiler.appspot.com/compile" >> $OutMinFile

--- a/build/build-windows.bat
+++ b/build/build-windows.bat
@@ -1,4 +1,6 @@
 @echo off 
+set OutDebugFile=output\knockout-latest.debug.js
+set OutMinFile=output\knockout-latest.js
 set AllFiles=
 for /f "eol=] skip=1 delims=' " %%i in (source-references.js) do set Filename=%%i& call :Concatenate 
 
@@ -7,13 +9,16 @@ goto :Combine
     if /i "%AllFiles%"=="" ( 
         set AllFiles=..\%Filename:/=\%
     ) else ( 
-        set AllFiles=%AllFiles%+..\%Filename:/=\%
+        set AllFiles=%AllFiles% ..\%Filename:/=\%
     ) 
 goto :EOF 
 
 :Combine
-copy /A /B version-header.js+%AllFiles% output\knockout-latest.debug.js
+copy /y version-header.js %OutDebugFile%
+echo (function(window,undefined){ >> %OutDebugFile%
+type %AllFiles%                   >> %OutDebugFile%
+echo })(window);                  >> %OutDebugFile%
 
 @rem Now call Google Closure Compiler to produce a minified version
-copy /y version-header.js output\knockout-latest.js
-tools\curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@output\knockout-latest.debug.js "http://closure-compiler.appspot.com/compile" >> output\knockout-latest.js
+copy /y version-header.js %OutMinFile%
+tools\curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@%OutDebugFile% "http://closure-compiler.appspot.com/compile" >> %OutMinFile%


### PR DESCRIPTION
Someone in the forum voiced concern regarding the beginning code block of the minimized version of Knockout produced by the Google's closure compiler.  Code is exposed as a single variable  (ex. - "r = window.ko{}") that can be overwritten by other javascript. This fix encapsulates it.

I chose to "echo" the function wrapper via the compiler scripts due to how the scripts are combined.  Next rev may pull from simple text files for both header/footer data, if it becomes necessary to add additional code.

NOTE: I was going to include a minor optimization in "namespaces.js" to give document a local reference as well ( document = windows.document).  However, this would cause JSSpec to fail since it loads up the knockout source scripts individually.  JSSpec doesn't get the function wrapper.
