### PR TITLE
fixed regex to allow data-* attributes besides data-bind to fix http://js

### DIFF
--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -1,6 +1,6 @@
 
 ko.templateRewriting = (function () {
-    var memoizeBindingAttributeSyntaxRegex = /(<[a-z]+\d*(\s+(?!data-bind=)[a-z0-9]+(=(\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind=(["'])([\s\S]*?)\5/gi;
+    var memoizeBindingAttributeSyntaxRegex = /(<[a-z]+\d*(\s+(?!data-bind=)[a-z0-9\-]+(=(\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind=(["'])([\s\S]*?)\5/gi;
 
     return {
         ensureTemplateIsRewritten: function (template, templateEngine) {


### PR DESCRIPTION
fixed regex to allow data-\* attributes besides data-bind to fix http://jsfiddle.net/PeyNN/1/
necessary for some work I'm playing with using knockout and jquery mobile (more to come later) since that uses data attributes all over the place
