### PR TITLE
innerText fix for Firefox

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -1,4 +1,3 @@
-
 function prepareTestNode() {
     var existingNode = document.getElementById("testNode");
     if (existingNode != null)
@@ -142,9 +141,12 @@ describe('Binding: HTML', {
         var tr = testNode.childNodes[0].childNodes[0];
         if (tr.tagName == 'TBODY')
             tr = tr.childNodes[0];
+
+        var td = tr.childNodes[0];
+
         value_of(tr.tagName).should_be("TR");
-        value_of(tr.childNodes[0].tagName).should_be("TD");
-        value_of(tr.childNodes[0].innerText).should_be("hello");
+        value_of(td.tagName).should_be("TD");
+        value_of('innerText' in td ? td.innerText : td.textContent).should_be("hello");
     }
 });
 


### PR DESCRIPTION
Test uses textContent if innerText undefined. (fix for Firefox)
(Spec: 'Should be able to write arbitrary HTML, including <tr> elements into tables')
