### PR TITLE
Tweaking 'selectedOptions' binding so it works with int arrays.

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -270,6 +270,13 @@ ko.bindingHandlers['selectedOptions'] = {
         var newValue = ko.utils.unwrapObservable(valueAccessor());
         if (newValue && typeof newValue.length == "number") {
             var nodes = element.childNodes;
+            
+            // If the newValue array is an int array, convert it to a string array so it can be compared
+            // against the string value of the select options.
+            if (newValue.length > 0 && typeof newValue[0] == "number")
+                for (var i = 0; i < newValue.length; i++)
+                    newValue[i] += '';
+
             for (var i = 0, j = nodes.length; i < j; i++) {
                 var node = nodes[i];
                 if (node.tagName == "OPTION")


### PR DESCRIPTION
Hi Steve, thanks for writing this kick ass product! :D

I've noticed a bit of an inconsistency between how single select, and multi select controls set their selected item(s) when binding to ints in the view model.  If you bind the 'value' of a single select "select" element to a JSON int field, then knockout sets the selected item fine.  If you bind the 'selectedOptions' of a multi select "select" element to a JSON int array, knockout wont set the selection because the int values in the array are not === to the string values of the options in the select element.  This inconsistency is demonstrated here: 

http://jsfiddle.net/duckaroy/3CPe7/54/

So why am I using ints in my view model? I am generating the knockout view model from my MVC model, and I generally use ints for IDs in my model.  Working with ints in my presentation layer is cleaner than having to convert to and from int to string all the time (That's the job of the MVC model binder anyways!).  

As for knockout setting the view model with the select control's selected value(s); I'm aware that knockout sets the selected value(s) as strings on the view model and not ints, and I understand the reason for this.  These strings are automatically converted to ints when they hit the model binder of my MVC website, so it all works peachy on the server side.  Having said that though, if I set the options and selectedOptions for a multi select control to bind to int arrays in the view model, it would be nice if knockout could set the selected options on the view model as ints as opposed to strings.  Perhaps a solution to this problem is to specify a "DataType" attribute in the data-bind string of a control so knockout knows how it should convert the control's value(s) before setting the view model. Just a thought anyways.

Thanks muchly!

Lucas
