### PR TITLE
cache the data-bind attributes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -177,19 +177,6 @@ ko.utils = new (function () {
             return new Function("sc", functionBody);
         },
         
-        evalWithinScope: function (expression /*, scope1, scope2, scope3... */) {
-            // Build the source for a function that evaluates "expression"
-            // For each scope variable, add an extra level of "with" nesting
-            // Example result: with(sc[1]) { with(sc[0]) { return (expression) } }
-            var scopes = Array.prototype.slice.call(arguments, 1);
-            var functionBody = "return (" + expression + ")";
-            for (var i = 0; i < scopes.length; i++) {
-                if (scopes[i] && typeof scopes[i] == "object")
-                    functionBody = "with(sc[" + i + "]) { " + functionBody + " } ";
-            }
-            return (new Function("sc", functionBody))(scopes);
-        },
-
         domNodeIsContainedBy: function (node, containedByNode) {
             if (containedByNode.compareDocumentPosition)
                 return (containedByNode.compareDocumentPosition(node) & 16) == 16;


### PR DESCRIPTION
Especially when something like 'foreach' is used, there will multiple instances of the same data-bind string, with just the context being different. Since each data-bind string results in the same compiled JavaScript code, it can be cached and used for subsequent bindings.
