### PR TITLE
Add optionsAttr binding which allows setting arbitrary attributes on the...

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -401,17 +401,26 @@ describe('Binding: Options', {
         value_of(displayedOptions).should_be(["A", "B", "C"]);
     },
     
-    'Should accept optionsText and optionsValue params to display subproperties of the model values': function() {
+    'Should accept optionsText, optionsValue and optionsAttr params to display subproperties of the model values': function() {
         var modelValues = new ko.observableArray([
-            { name: 'bob', id: ko.observable(6) }, // Note that subproperties can be observable
-            { name: ko.observable('frank'), id: 13 }
-        ]);	
-        testNode.innerHTML = "<select data-bind='options:myValues, optionsText: \"name\", optionsValue: \"id\"'><option>should be deleted</option></select>";
-        ko.applyBindings({ myValues: modelValues }, testNode);
+            { name: 'bob', id: ko.observable(6), hobby: 'chess' }, // Note that subproperties can be observable
+            { name: ko.observable('frank'), id: 13, hobby: 'mancala' }
+        ]);
+        var hello = function(item) {
+            return 'I like ' + item.hobby;
+        };
+        testNode.innerHTML = "<select data-bind='options:myValues, optionsText: \"name\", optionsValue: \"id\", optionsAttr: {firstAttribute: \"hobby\", \"second-attribute\": true, thirdAttribute: hello}'><option>should be deleted</option></select>";
+        ko.applyBindings({ myValues: modelValues, hello: hello }, testNode);
         var displayedText = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.innerHTML; });	
         var displayedValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.value; });	
+        var firstAttributeValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.getAttribute("firstAttribute"); });
+        var secondAttributeValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.getAttribute("second-attribute"); });
+        var thirdAttributeValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.getAttribute("thirdAttribute"); });
         value_of(displayedText).should_be(["bob", "frank"]);
         value_of(displayedValues).should_be([6, 13]);
+        value_of(firstAttributeValues).should_be(["chess", "mancala"]);
+        value_of(secondAttributeValues).should_be(["true", "true"]);
+        value_of(thirdAttributeValues).should_be(["I like chess", "I like mancala"]);
     },
 
     'Should accept function in optionsText param to display subproperties of the model values': function() {

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -238,6 +238,32 @@ ko.bindingHandlers['options'] = {
                 if ((optionText === null) || (optionText === undefined))
                     optionText = "";                                    
 
+                // Apply some attributes to the option element
+                var optionsAttrValue = allBindings['optionsAttr'];
+                if (typeof optionsAttrValue === "object") {
+                    for (var attrName in optionsAttrValue) {
+                        if (typeof attrName == "string") {
+                            var attrValue = ko.utils.unwrapObservable(optionsAttrValue[attrName]);
+
+                            var attrResult;
+                            if (typeof attrValue == "function")
+                                attrResult = attrValue(value[i]); // Given a function; run it against the data value
+                            else if (typeof attrValue == "string")
+                                attrResult = value[i][attrValue]; // Given a string; treat it as a property name on the data value
+                            else
+                                attrResult = attrValue;				    // Given no optionsText arg; use the data value itself
+
+                            // To cover cases like "attr: { checked:someProp }", we want to remove the attribute entirely
+                            // when someProp is a "no value"-like value (strictly null, false, or undefined)
+                            // (because the absence of the "checked" attr is how to mark an element as not checked, etc.)
+                            if ((attrResult === false) || (attrResult === null) || (attrResult === undefined))
+                                option.removeAttribute(attrName);
+                            else
+                                option.setAttribute(attrName, attrResult.toString());
+                        }
+                    }
+                }
+
                 ko.utils.setTextContent(option, optionText);
 
                 element.appendChild(option);


### PR DESCRIPTION
... options in a select, similar to the attr binding.

I had an earlier pull request which added an optionsTitle binding (https://github.com/SteveSanderson/knockout/pull/196) that hasn't gone through. This is an improved version of that pull request, allowing you to set arbitrary attributes on the options in a select. I'd mentioned I was thinking of doing this in that earlier request, and worldspawn +1'd the idea, so here it is just in time for New Year's.
