### PR TITLE
inline templates should perform as well as or better than named templates

### DIFF
--- a/src/templating/native/nativeTemplateEngine.js
+++ b/src/templating/native/nativeTemplateEngine.js
@@ -4,12 +4,12 @@ ko.nativeTemplateEngine = function () {
 
 ko.nativeTemplateEngine.prototype = new ko.templateEngine();
 ko.nativeTemplateEngine.prototype['renderTemplateSource'] = function (templateSource, bindingContext, options) {
-    var useFragmentIfAvailable = !(ko.utils.ieVersion < 9), // IE<9 cloneNode doesn't work properly
-        templateFragFunc = useFragmentIfAvailable ? templateSource['fragment'] : null,
-        templateFrag = templateFragFunc ? templateSource['fragment']() : null;
+    var useNodesIfAvailable = !(ko.utils.ieVersion < 9), // IE<9 cloneNode doesn't work properly
+        templateNodesFunc = useNodesIfAvailable ? templateSource['nodes'] : null,
+        templateNodes = templateNodesFunc ? templateSource['nodes']() : null;
 
-    if (templateFrag) {
-        return ko.utils.makeArray(templateFrag.cloneNode(true).childNodes);
+    if (templateNodes) {
+        return ko.utils.makeArray(templateNodes.cloneNode(true).childNodes);
     } else {
         var templateText = templateSource['text']();
         return ko.utils.parseHtmlFragment(templateText);

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -162,8 +162,8 @@
             if ((typeof bindingValue != "string") && (!bindingValue['name']) && (element.nodeType == 1 || element.nodeType == 8)) {
                 // It's an anonymous template - store the element contents, then clear the element
                 var templateNodes = element.nodeType == 1 ? ko.utils.makeArray(element.childNodes) : ko.virtualElements.childNodes(element),
-                    frag = ko.utils.moveNodesToDocumentFragment(templateNodes); // This also removes the nodes from their current parent
-                new ko.templateSources.anonymousTemplate(element)['fragment'](frag);
+                    container = ko.utils.moveNodesToContainerElement(templateNodes); // This also removes the nodes from their current parent
+                new ko.templateSources.anonymousTemplate(element)['nodes'](container);
             }
             return { 'controlsDescendantBindings': true };
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,11 +116,11 @@ ko.utils = new (function () {
             }
         },
 
-        moveNodesToDocumentFragment: function(nodesArray) {
-            var docFrag = document.createDocumentFragment();
+        moveNodesToContainerElement: function(nodesArray) {
+            var container = document.createElement('div');
             for (var i = 0, j = nodesArray.length; i < j; i++)
-                docFrag.appendChild(nodesArray[i]);
-            return docFrag;
+                container.appendChild(nodesArray[i]);
+            return container;
         },
 
         setDomNodeChildren: function (domNode, childNodes) {


### PR DESCRIPTION
With the current implementation, inline (anonymous) templates perform more poorly than named templates (especially for templates within templates).

The main problem with making inline templates perform better is that they don't have a unique name. A simple solution would be to allow the user to provide a unique identifier as part of the template binding (or as a separate binding) that would be used to index the template (instead of using the element object as is done now):

```
<div data-bind="foreach: myData, templateId: 'outerLoop'"> 
```

or

```
<div data-bind="foreach: {data: myData, id: 'outerLoop'}"> 
```
