### PR TITLE
Patch for using natives when they exist and jquery externalization

### DIFF
--- a/build/fragments/source-references.js
+++ b/build/fragments/source-references.js
@@ -2,6 +2,8 @@ knockoutDebugCallback([
     'src/namespace.js',
     'src/google-closure-compiler-utils.js',
     'src/version.js',
+    'src/adapters/adapter.js',
+    'src/adapters/jquery.adapter.js',
     'src/utils.js',
     'src/utils.domData.js',
     'src/utils.domNodeDisposal.js',
@@ -14,6 +16,7 @@ knockoutDebugCallback([
     'src/subscribables/observableArray.js',
     'src/subscribables/dependentObservable.js',
     'src/subscribables/mappingHelpers.js',
+    'src/subscribables/dirtyFlag.js',
     'src/binding/selectExtensions.js',
     'src/binding/jsonExpressionRewriting.js',
     'src/virtualElements.js',
@@ -27,5 +30,6 @@ knockoutDebugCallback([
     'src/binding/editDetection/compareArrays.js',
     'src/binding/editDetection/arrayToDomNodeChildren.js',
     'src/templating/native/nativeTemplateEngine.js',
-    'src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js'
+    'src/mapping.js'
+ //   'src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js'
 ]);

--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -1,0 +1,4 @@
+(function() {
+    ko.adapter= {};
+    ko.exportSymbol("adapter",ko.adapter);
+})();

--- a/src/adapters/jquery.adapter.js
+++ b/src/adapters/jquery.adapter.js
@@ -1,0 +1,27 @@
+(function() {
+    ko.adapter.parseHtmlFragment = function(html) {
+        var elems = jQuery['clean']([html]);
+
+        // As of jQuery 1.7.1, jQuery parses the HTML by appending it to some dummy parent nodes held in an in-memory document fragment.
+        // Unfortunately, it never clears the dummy parent nodes from the document fragment, so it leaks memory over time.
+        // Fix this by finding the top-most dummy parent element, and detaching it from its owner fragment.
+        if (elems && elems[0]) {
+            // Find the top-most parent element that's a direct child of a document fragment
+            var elem = elems[0];
+            while (elem.parentNode && elem.parentNode.nodeType !== 11 /* i.e., DocumentFragment */)
+                elem = elem.parentNode;
+            // ... then detach it
+            if (elem.parentNode)
+                elem.parentNode.removeChild(elem);
+        }
+        
+        return elems;
+    };
+
+    ko.adapter.setHtml = function(node,html) {
+        jQuery(node)['html'](html);
+    };
+
+    ko.exportSymbol("adapter.parseHtmlFragment",ko.adapter.parseHtmlFragment);
+    ko.exportSymbol("adapter.setHtml",ko.adapter.setHtml);
+})();

--- a/src/adapters/native.adapter.js
+++ b/src/adapters/native.adapter.js
@@ -1,0 +1,41 @@
+adapter.parseHtmlFragment = function(html) {
+        // Based on jQuery's "clean" function, but only accounting for table-related elements.
+        // If you have referenced jQuery, this won't be used anyway - KO will use jQuery's "clean" function directly
+
+        // Note that there's still an issue in IE < 9 whereby it will discard comment nodes that are the first child of
+        // a descendant node. For example: "<div><!-- mycomment -->abc</div>" will get parsed as "<div>abc</div>"
+        // This won't affect anyone who has referenced jQuery, and there's always the workaround of inserting a dummy node
+        // (possibly a text node) in front of the comment. So, KO does not attempt to workaround this IE issue automatically at present.
+        
+        // Trim whitespace, otherwise indexOf won't work as expected
+        var tags = ko.utils.stringTrim(html).toLowerCase(), div = document.createElement("div");
+
+        // Finds the first match from the left column, and returns the corresponding "wrap" data from the right column
+        var wrap = tags.match(/^<(thead|tbody|tfoot)/)              && [1, "<table>", "</table>"] ||
+                   !tags.indexOf("<tr")                             && [2, "<table><tbody>", "</tbody></table>"] ||
+                   (!tags.indexOf("<td") || !tags.indexOf("<th"))   && [3, "<table><tbody><tr>", "</tr></tbody></table>"] ||
+                   /* anything else */                                 [0, "", ""];
+
+        // Go to html and back, then peel off extra wrappers
+        // Note that we always prefix with some dummy text, because otherwise, IE<9 will strip out leading comment nodes in descendants. Total madness.
+        var markup = "ignored<div>" + wrap[1] + html + wrap[2] + "</div>";
+        if (typeof window['innerShiv'] == "function") {
+            div.appendChild(window['innerShiv'](markup));
+        } else {
+            div.innerHTML = markup;
+        }
+
+        // Move to the right depth
+        while (wrap[0]--)
+            div = div.lastChild;
+
+        return ko.utils.makeArray(div.lastChild.childNodes);
+};
+
+adapter.setHtml = function(node,html) {
+        // ... otherwise, use KO's own parsing logic.
+        var parsedNodes = ko.utils.parseHtmlFragment(html);
+        for (var i = 0; i < parsedNodes.length; i++)
+            node.appendChild(parsedNodes[i]);
+}
+

--- a/src/utils.domData.js
+++ b/src/utils.domData.js
@@ -1,4 +1,3 @@
-
 ko.utils.domData = new (function () {
     var uniqueId = 0;
     var dataStoreKeyExpandoPropertyName = "__ko__" + (new Date).getTime();

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -1,63 +1,7 @@
 (function () {
     var leadingCommentRegex = /^(\s*)<!--(.*?)-->/;
 
-    function simpleHtmlParse(html) {
-        // Based on jQuery's "clean" function, but only accounting for table-related elements.
-        // If you have referenced jQuery, this won't be used anyway - KO will use jQuery's "clean" function directly
-
-        // Note that there's still an issue in IE < 9 whereby it will discard comment nodes that are the first child of
-        // a descendant node. For example: "<div><!-- mycomment -->abc</div>" will get parsed as "<div>abc</div>"
-        // This won't affect anyone who has referenced jQuery, and there's always the workaround of inserting a dummy node
-        // (possibly a text node) in front of the comment. So, KO does not attempt to workaround this IE issue automatically at present.
-        
-        // Trim whitespace, otherwise indexOf won't work as expected
-        var tags = ko.utils.stringTrim(html).toLowerCase(), div = document.createElement("div");
-
-        // Finds the first match from the left column, and returns the corresponding "wrap" data from the right column
-        var wrap = tags.match(/^<(thead|tbody|tfoot)/)              && [1, "<table>", "</table>"] ||
-                   !tags.indexOf("<tr")                             && [2, "<table><tbody>", "</tbody></table>"] ||
-                   (!tags.indexOf("<td") || !tags.indexOf("<th"))   && [3, "<table><tbody><tr>", "</tr></tbody></table>"] ||
-                   /* anything else */                                 [0, "", ""];
-
-        // Go to html and back, then peel off extra wrappers
-        // Note that we always prefix with some dummy text, because otherwise, IE<9 will strip out leading comment nodes in descendants. Total madness.
-        var markup = "ignored<div>" + wrap[1] + html + wrap[2] + "</div>";
-        if (typeof window['innerShiv'] == "function") {
-            div.appendChild(window['innerShiv'](markup));
-        } else {
-            div.innerHTML = markup;
-        }
-
-        // Move to the right depth
-        while (wrap[0]--)
-            div = div.lastChild;
-
-        return ko.utils.makeArray(div.lastChild.childNodes);
-    }
-
-    function jQueryHtmlParse(html) {
-        var elems = jQuery['clean']([html]);
-
-        // As of jQuery 1.7.1, jQuery parses the HTML by appending it to some dummy parent nodes held in an in-memory document fragment.
-        // Unfortunately, it never clears the dummy parent nodes from the document fragment, so it leaks memory over time.
-        // Fix this by finding the top-most dummy parent element, and detaching it from its owner fragment.
-        if (elems && elems[0]) {
-            // Find the top-most parent element that's a direct child of a document fragment
-            var elem = elems[0];
-            while (elem.parentNode && elem.parentNode.nodeType !== 11 /* i.e., DocumentFragment */)
-                elem = elem.parentNode;
-            // ... then detach it
-            if (elem.parentNode)
-                elem.parentNode.removeChild(elem);
-        }
-        
-        return elems;
-    }
-    
-    ko.utils.parseHtmlFragment = function(html) {
-        return typeof jQuery != 'undefined' ? jQueryHtmlParse(html)   // As below, benefit from jQuery's optimisations where possible
-                                            : simpleHtmlParse(html);  // ... otherwise, this simple logic will do in most common cases.
-    };
+    ko.utils.parseHtmlFragment = ko.adapter.parseHtmlFragment;
     
     ko.utils.setHtml = function(node, html) {
         ko.utils.emptyDomNode(node);
@@ -66,17 +10,7 @@
             if (typeof html != 'string')
                 html = html.toString();
             
-            // jQuery contains a lot of sophisticated code to parse arbitrary HTML fragments,
-            // for example <tr> elements which are not normally allowed to exist on their own.
-            // If you've referenced jQuery we'll use that rather than duplicating its code.
-            if (typeof jQuery != 'undefined') {
-                jQuery(node)['html'](html);
-            } else {
-                // ... otherwise, use KO's own parsing logic.
-                var parsedNodes = ko.utils.parseHtmlFragment(html);
-                for (var i = 0; i < parsedNodes.length; i++)
-                    node.appendChild(parsedNodes[i]);
-            }            
+            ko.adapter.setHtml(node,html);
         }    	
     };
 })();

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,23 +34,50 @@ ko.utils = new (function () {
         var inputType = element.type.toLowerCase();
         return (inputType == "checkbox") || (inputType == "radio");
     }
+
+    function nativeOrShim(proto,prop,shim) {
+        if (typeof(proto.prototype[prop])==="function") {
+            return function(obj,arg){return proto.prototype[prop].call(obj,arg);};
+        } else {
+            return shim;
+        }
+    }
     
+    var 
+        forEach = nativeOrShim(Array,"forEach",
+                function(array,action) {
+                    for (var i = 0, j = array.length; i < j; i++)
+                    action(array[i]);
+                }),
+        indexOf = nativeOrShim(Array,"indexOf",
+                function(array,item) {
+                    for (var i = 0, j = array.length; i < j; i++)
+                        if (array[i] === item) return i;
+                    return -1;
+                }),
+        map = nativeOrShim(Array,"map",
+                function(array,mapping) {
+                    array = array || [];
+                    var result = [];
+                    for (var i = 0, j = array.length; i < j; i++) result.push(mapping(array[i]));
+                    return result;
+                }),
+        filter = nativeOrShim(Array,"filter",
+                function(array,predicate) {
+                    array = array || [];
+                    var result = [];
+                    for (var i = 0, j = array.length; i < j; i++)
+                        if (predicate(array[i]))
+                            result.push(array[i]);
+                    return result;
+                });
+
     return {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
         
-        arrayForEach: function (array, action) {
-            for (var i = 0, j = array.length; i < j; i++)
-                action(array[i]);
-        },
+        arrayForEach: forEach,
 
-        arrayIndexOf: function (array, item) {
-            if (typeof Array.prototype.indexOf == "function")
-                return Array.prototype.indexOf.call(array, item);
-            for (var i = 0, j = array.length; i < j; i++)
-                if (array[i] === item)
-                    return i;
-            return -1;
-        },
+        arrayIndexOf: indexOf,
 
         arrayFirst: function (array, predicate, predicateOwner) {
             for (var i = 0, j = array.length; i < j; i++)
@@ -75,22 +102,9 @@ ko.utils = new (function () {
             return result;
         },        
 
-        arrayMap: function (array, mapping) {
-            array = array || [];
-            var result = [];
-            for (var i = 0, j = array.length; i < j; i++)
-                result.push(mapping(array[i]));
-            return result;
-        },
+        arrayMap: map,
 
-        arrayFilter: function (array, predicate) {
-            array = array || [];
-            var result = [];
-            for (var i = 0, j = array.length; i < j; i++)
-                if (predicate(array[i]))
-                    result.push(array[i]);
-            return result;
-        },
+        arrayFilter: filter,
         
         arrayPushAll: function (array, valuesToPush) {
             if (valuesToPush instanceof Array)


### PR DESCRIPTION
Changes in utils.js 

arrayForEach/IndexOf/Map/Filter use the natives if they exist

Changed in utils.domManipulation.js

Moved the functionality to external files, under "adapters" folder, spliting the jquery/native functionality
