### PR TITLE
Support named templates in textarea tags

### DIFF
--- a/spec/nativeTemplateEngineBehaviors.js
+++ b/spec/nativeTemplateEngineBehaviors.js
@@ -15,6 +15,7 @@ describe('Native template engine', {
         
         window.testDivTemplate = ensureNodeExistsAndIsEmpty("testDivTemplate");
         window.testScriptTemplate = ensureNodeExistsAndIsEmpty("testScriptTemplate", "script");        
+        window.testTextAreaTemplate = ensureNodeExistsAndIsEmpty("testTextAreaTemplate", "textarea");        
         window.templateOutput = ensureNodeExistsAndIsEmpty("templateOutput");
     }, 
 
@@ -35,6 +36,13 @@ describe('Native template engine', {
         ko.renderTemplate("testScriptTemplate", { name: 'bert' }, null, window.templateOutput);
         value_of(window.templateOutput).should_contain_html("name: <div data-bind=\"text: name\">bert</div>");
     }, 
+
+    'Named template can fetch template from <textarea> elements and data-bind on results': function () {
+        var prop = (typeof window.testTextAreaTemplate.innerText !== "undefined") ? "innerText" : "textContent";
+        window.testTextAreaTemplate[prop] = "name: <div data-bind='text: name'></div>";
+        ko.renderTemplate("testTextAreaTemplate", { name: 'bert' }, null, window.templateOutput);
+        value_of(window.templateOutput).should_contain_html("name: <div data-bind=\"text: name\">bert</div>");
+    },
     
     'Anonymous template can display static content': function () {
         new ko.templateSources.anonymousTemplate(window.templateOutput).text("this is some static content");

--- a/src/templating/templateSources.js
+++ b/src/templating/templateSources.js
@@ -32,12 +32,14 @@
     }
     
     ko.templateSources.domElement.prototype['text'] = function(/* valueToWrite */) {
+        var tagName = this.domElement.tagName.toLowerCase(),
+            elemProp = tagName == "script" ? "text" : tagName == "textarea" ? "value" : "innerHTML";
         if (arguments.length == 0) {
-            return this.domElement.tagName.toLowerCase() == "script" ? this.domElement.text : this.domElement.innerHTML;
+            return this.domElement[elemProp];
         } else {
             var valueToWrite = arguments[0];
-            if (this.domElement.tagName.toLowerCase() == "script")
-                this.domElement.text = valueToWrite;
+            if (elemProp != "innerHTML")
+                this.domElement[elemProp] = valueToWrite;
             else
                 ko.utils.setHtml(this.domElement, valueToWrite);
         }


### PR DESCRIPTION
Right now named templates won't work if stored in a textarea tag. I mentioned this in the forums along with the code change to support it:

http://groups.google.com/group/knockoutjs/browse_thread/thread/a9c66c75bf993dc6/e3d79c1e2acc640a
