### PR TITLE
Added a build for a NodeJs module. Also, added window and navigator to function wrapper.

### DIFF
--- a/build/build-linux
+++ b/build/build-linux
@@ -13,11 +13,12 @@ cat $SourceFiles                    >> $OutDebugFile.temp
 cat fragments/amd-post.js           >> $OutDebugFile.temp
 
 # Now call Google Closure Compiler to produce a minified version
-curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@$OutDebugFile.temp "http://closure-compiler.appspot.com/compile" > $OutMinFile.temp
+curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode "js_code=/**@const*/var DEBUG=false;" --data-urlencode js_code@$OutDebugFile.temp "http://closure-compiler.appspot.com/compile" > $OutMinFile.temp
 
 # Finalise each file by prefixing with version header and surrounding in function closure
 cp fragments/version-header.js $OutDebugFile
 echo "(function(window,document,navigator,undefined){" >> $OutDebugFile
+echo "var DEBUG=true;"                                 >> $OutDebugFile
 cat $OutDebugFile.temp                                 >> $OutDebugFile
 echo "})(window,document,navigator);"                  >> $OutDebugFile
 rm $OutDebugFile.temp

--- a/build/build-windows.bat
+++ b/build/build-windows.bat
@@ -19,11 +19,12 @@ type %AllFiles%                   >> %OutDebugFile%.temp
 type fragments\amd-post.js        >> %OutDebugFile%.temp
 
 @rem Now call Google Closure Compiler to produce a minified version
-tools\curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode js_code@%OutDebugFile%.temp "http://closure-compiler.appspot.com/compile" > %OutMinFile%.temp
+tools\curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode "js_code=/**@const*/var DEBUG=false;" --data-urlencode js_code@%OutDebugFile%.temp "http://closure-compiler.appspot.com/compile" > %OutMinFile%.temp
 
 @rem Finalise each file by prefixing with version header and surrounding in function closure
 copy /y fragments\version-header.js %OutDebugFile%
 echo (function(window,document,navigator,undefined){ >> %OutDebugFile%
+echo var DEBUG=true;                                 >> %OutDebugFile%
 type %OutDebugFile%.temp                             >> %OutDebugFile%
 echo })(window,document,navigator);                  >> %OutDebugFile%
 del %OutDebugFile%.temp

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -89,6 +89,7 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
 
             dependentObservable["notifySubscribers"](_latestValue, "beforeChange");
             _latestValue = newValue;
+            if (DEBUG) dependentObservable._latestValue = _latestValue;
         } finally {
             ko.dependencyDetection.end();
         }

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -11,6 +11,7 @@ ko.observable = function (initialValue) {
             if ((!observable['equalityComparer']) || !observable['equalityComparer'](_latestValue, arguments[0])) {
                 observable.valueWillMutate();
                 _latestValue = arguments[0];
+                if (DEBUG) observable._latestValue = _latestValue;
                 observable.valueHasMutated();
             }
             return this; // Permits chained assignments
@@ -21,6 +22,7 @@ ko.observable = function (initialValue) {
             return _latestValue;
         }
     }
+    if (DEBUG) observable._latestValue = _latestValue;
     ko.subscribable.call(observable);
     observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }


### PR DESCRIPTION
I added a build for a NodeJs module. This is to facilitate browser-less unit testing through NodeJs. It simply creates a dummy dom structure and initializes knockout so tests can run. The dom structure is very empty, but the point is not to test the dom in browser-less unit testing.

In order to facilitate this I also added document and navigator to the function wrapper that is applied during the build. Similar to how document and undefined were being wrapped in.

Also contains NeonStalwarts pull request rebase onto master. See Pull request #206
