### PR TITLE
HTML tags are written using capital letters

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -156,7 +156,7 @@ ko.bindingHandlers['value'] = {
         });
     },
     'update': function (element, valueAccessor) {
-        var valueIsSelectOption = ko.utils.tagNameLower(element) === "select";
+        var valueIsSelectOption = getElementType(element) === elementTypes_select;
         var newValue = ko.utils.unwrapObservable(valueAccessor());
         var elementValue = ko.selectExtensions.readValue(element);
         var valueHasChanged = (newValue != elementValue);
@@ -187,12 +187,12 @@ ko.bindingHandlers['value'] = {
 
 ko.bindingHandlers['options'] = {
     'update': function (element, valueAccessor, allBindingsAccessor) {
-        if (ko.utils.tagNameLower(element) !== "select")
+        if (getElementType(element) !== elementTypes_select)
             throw new Error("options binding applies only to SELECT elements");
 
         var selectWasPreviouslyEmpty = element.length == 0;
         var previousSelectedValues = ko.utils.arrayMap(ko.utils.arrayFilter(element.childNodes, function (node) {
-            return node.tagName && (ko.utils.tagNameLower(node) === "option") && node.selected;
+            return node.tagName && (getElementType(node) === elementTypes_option) && node.selected;
         }), function (node) {
             return ko.selectExtensions.readValue(node) || node.innerText || node.textContent;
         });
@@ -275,10 +275,10 @@ ko.bindingHandlers['selectedOptions'] = {
         var result = [];
         var nodes = selectNode.childNodes;
         for (var i = 0, j = nodes.length; i < j; i++) {
-            var node = nodes[i], tagName = ko.utils.tagNameLower(node);
-            if (tagName == "option" && node.selected)
+            var node = nodes[i], elemType = getElementType(node);
+            if (elemType == elementTypes_option && node.selected)
                 result.push(ko.selectExtensions.readValue(node));
-            else if (tagName == "optgroup") {
+            else if (elemType == elementTypes_optgroup) {
                 var selectedValuesFromOptGroup = ko.bindingHandlers['selectedOptions'].getSelectedValuesFromSelectNode(node);
                 Array.prototype.splice.apply(result, [result.length, 0].concat(selectedValuesFromOptGroup)); // Add new entries to existing 'result' instance
             }
@@ -298,7 +298,7 @@ ko.bindingHandlers['selectedOptions'] = {
         });    	
     },
     'update': function (element, valueAccessor) {
-        if (ko.utils.tagNameLower(element) != "select")
+        if (getElementType(element) != elementTypes_select)
             throw new Error("values binding applies only to SELECT elements");
 
         var newValue = ko.utils.unwrapObservable(valueAccessor());
@@ -306,7 +306,7 @@ ko.bindingHandlers['selectedOptions'] = {
             var nodes = element.childNodes;
             for (var i = 0, j = nodes.length; i < j; i++) {
                 var node = nodes[i];
-                if (ko.utils.tagNameLower(node) === "option")
+                if (getElementType(node) === elementTypes_option)
                     ko.utils.setOptionNodeSelectionState(node, ko.utils.arrayIndexOf(newValue, ko.selectExtensions.readValue(node)) >= 0);
             }
         }

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -6,12 +6,12 @@
     // that are arbitrary objects. This is very convenient when implementing things like cascading dropdowns.
     ko.selectExtensions = {
         readValue : function(element) {
-            switch (ko.utils.tagNameLower(element)) {
-                case 'option':
+            switch (getElementType(element)) {
+                case elementTypes_option:
                     if (element[hasDomDataExpandoProperty] === true)
                         return ko.utils.domData.get(element, ko.bindingHandlers.options.optionValueDomDataKey);
                     return element.getAttribute("value");
-                case 'select':
+                case elementTypes_select:
                     return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
                 default:
                     return element.value;
@@ -19,8 +19,8 @@
         },
         
         writeValue: function(element, value) {
-            switch (ko.utils.tagNameLower(element)) {
-                case 'option':
+            switch (getElementType(element)) {
+                case elementTypes_option:
                     switch(typeof value) {
                         case "string":
                             ko.utils.domData.set(element, ko.bindingHandlers.options.optionValueDomDataKey, undefined);
@@ -39,7 +39,7 @@
                             break;
                     }
                     break;
-                case 'select':
+                case elementTypes_select:
                     for (var i = element.options.length - 1; i >= 0; i--) {
                         if (ko.selectExtensions.readValue(element.options[i]) == value) {
                             element.selectedIndex = i;

--- a/src/templating/templateSources.js
+++ b/src/templating/templateSources.js
@@ -32,9 +32,9 @@
     }
     
     ko.templateSources.domElement.prototype['text'] = function(/* valueToWrite */) {
-        var tagNameLower = ko.utils.tagNameLower(this.domElement),
-            elemContentsProperty = tagNameLower === "script" ? "text"
-                                 : tagNameLower === "textarea" ? "value"
+        var elemType = getElementType(this.domElement),
+            elemContentsProperty = elemType === elementTypes_script ? "text"
+                                 : elemType === elementTypes_textarea ? "value"
                                  : "innerHTML";
 
         if (arguments.length == 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,12 +29,12 @@ ko.utils = new (function () {
         isIe7 = ieVersion === 7;
 
     function isClickOnCheckableElement(element, eventType) {
-        if ((ko.utils.tagNameLower(element) !== "input") || !element.type) return false;
+        if ((getElementType(element) !== elementTypes_input) || !element.type) return false;
         if (eventType.toLowerCase() != "click") return false;
         var inputType = element.type;
         return (inputType == "checkbox") || (inputType == "radio");
     }
-    
+
     return {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
         
@@ -204,13 +204,6 @@ ko.utils = new (function () {
             return ko.utils.domNodeIsContainedBy(node, document);
         },
 
-        tagNameLower: function(element) {
-            // For HTML elements, tagName will always be upper case; for XHTML elements, it'll be lower case.
-            // Possible future optimization: If we know it's an element from an XHTML document (not HTML),
-            // we don't need to do the .toLowerCase() as it will always be lower case anyway.
-            return element.tagName.toLowerCase();
-        },
-
         registerEventHandler: function (element, eventType, handler) {
             if (typeof jQuery != "undefined") {
                 if (isClickOnCheckableElement(element, eventType)) {
@@ -372,7 +365,7 @@ ko.utils = new (function () {
             var url = urlOrForm;
             
             // If we were given a form, use its 'action' URL and pick out any requested field values 	
-            if((typeof urlOrForm == 'object') && (ko.utils.tagNameLower(urlOrForm) === "form")) {
+            if((typeof urlOrForm == 'object') && (getElementType(urlOrForm) === elementTypes_form)) {
                 var originalForm = urlOrForm;
                 url = originalForm.action;
                 for (var i = includeFields.length - 1; i >= 0; i--) {
@@ -427,6 +420,27 @@ ko.exportSymbol('utils.toggleDomNodeCssClass', ko.utils.toggleDomNodeCssClass);
 ko.exportSymbol('utils.triggerEvent', ko.utils.triggerEvent);
 ko.exportSymbol('utils.unwrapObservable', ko.utils.unwrapObservable);
 
+var getElementType = function(element) {
+    return element.tagName
+}; 
+if (document.documentElement.tagName === 'HTML') {
+    var elementTypes_input = "INPUT",
+        elementTypes_form = "FORM",
+        elementTypes_select = "SELECT",
+        elementTypes_option = "OPTION",
+        elementTypes_optgroup = "OPTGROUP",
+        elementTypes_script = "SCRIPT",
+        elementTypes_textarea = "TEXTAREA";
+} else {
+    var elementTypes_input = "input",
+        elementTypes_form = "form",
+        elementTypes_select = "select",
+        elementTypes_option = "option",
+        elementTypes_optgroup = "optgroup",
+        elementTypes_script = "script",
+        elementTypes_textarea = "textarea";
+}
+    
 if (!Function.prototype['bind']) {
     // Function.prototype.bind is a standard part of ECMAScript 5th Edition (December 2009, http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf)
     // In case the browser doesn't implement it natively, provide a JavaScript implementation. This implementation is based on the one in prototype.js

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -155,7 +155,7 @@
             // Workaround for https://github.com/SteveSanderson/knockout/issues/155 
             // (IE <= 8 or IE 9 quirks mode parses your HTML weirdly, treating closing </li> tags as if they don't exist, thereby moving comment nodes
             // that are direct descendants of <ul> into the preceding <li>)
-            if (!htmlTagsWithOptionallyClosingChildren[ko.utils.tagNameLower(elementVerified)])
+            if (!htmlTagsWithOptionallyClosingChildren[elementVerified.tagName.toLowerCase()])
                 return;
             
             // Scan immediate children to see if they contain unbalanced comment tags. If they do, those comment tags


### PR DESCRIPTION
konrad-kruczynski:
KO searches for and writes HTML tags written using capital letters. That makes no problem with HTML, but will give a lot of them in XHTML. Shouldn't small letters be used instead?
