### PR TITLE
Make Windows build produce unix-style line endings

### DIFF
--- a/build/build-windows.bat
+++ b/build/build-windows.bat
@@ -23,17 +23,18 @@ tools\curl -d output_info=compiled_code -d output_format=text -d compilation_lev
 
 @rem Finalise each file by prefixing with version header and surrounding in function closure
 copy /y fragments\version-header.js %OutDebugFile%
-echo (function(window,document,navigator,undefined){ >> %OutDebugFile%
-type %OutDebugFile%.temp                             >> %OutDebugFile%
-echo })(window,document,navigator);                  >> %OutDebugFile%
+echo (function(window,document,navigator,undefined){>> %OutDebugFile%
+type %OutDebugFile%.temp                            >> %OutDebugFile%
+echo })(window,document,navigator);>> %OutDebugFile%
 del %OutDebugFile%.temp
 
 copy /y fragments\version-header.js %OutMinFile%
-echo (function(window,document,navigator,undefined){ >> %OutMinFile%
-type %OutMinFile%.temp                               >> %OutMinFile%
-echo })(window,document,navigator);                  >> %OutMinFile%
+echo (function(window,document,navigator,undefined){>> %OutMinFile%
+type %OutMinFile%.temp                              >> %OutMinFile%
+echo })(window,document,navigator);>> %OutMinFile%
 del %OutMinFile%.temp
 
 @rem Inject the version number string
 set /p Version= <fragments\version.txt
 cscript tools\searchReplace.js "##VERSION##" %VERSION% %OutDebugFile% %OutMinFile%
+cscript tools\searchReplace.js "\r\n" "\n" %OutDebugFile%  %OutMinFile%

--- a/build/tools/searchReplace.js
+++ b/build/tools/searchReplace.js
@@ -12,12 +12,17 @@ function readText(filename) {
 function writeText(filename, text) {
     var fso = WSH.CreateObject("Scripting.FileSystemObject");
     var file = fso.OpenTextFile(filename, 2 /* readwrite */, true);
-    file.WriteLine(text);
+    file.Write(text);
     file.Close();
 }
 
 var find = WScript.Arguments.Item(0),
     replace = WScript.Arguments.Item(1);
+
+// Special handling for newline chars, as I haven't found a reasonable way to pass them from DOS
+if (replace === "\\n")
+    replace = "\n";
+
 for (var i = 2; i < WScript.Arguments.Length; i++) {
     var filename = WScript.Arguments.Item(i);
     WSH.Echo("Replacing content in " + filename + "...");


### PR DESCRIPTION
I'm doing some development on OS X now, so getting the two platforms to produce identical builds avoids confusing the Git logs.
