### PR TITLE
allow long subscriber chains

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -13,7 +13,7 @@ describe('Dependent Observable', {
     'Should advertise that instances are computed': function () {
         var instance = new ko.dependentObservable(function () { });
         value_of(ko.isComputed(instance)).should_be(true);
-    },    
+    },
 
     'Should advertise that instances cannot have values written to them': function () {
         var instance = new ko.dependentObservable(function () { });
@@ -42,7 +42,7 @@ describe('Dependent Observable', {
         value_of(instance()).should_be(123);
         value_of(threw).should_be(true);
     },
-    
+
     'Should invoke the "write" callback, where present, if you attempt to write a value to it': function() {
         var invokedWriteWithValue, invokedWriteWithThis;
         var instance = new ko.dependentObservable({ 
@@ -85,12 +85,12 @@ describe('Dependent Observable', {
         value_of(actualReadThis).should_be(expectedThis);
         value_of(actualWriteThis).should_be(expectedThis);
     },
-    
+
     'Should be able to pass evaluator function using "options" parameter called "read"': function() {
         var instance = new ko.dependentObservable({
             read: function () { return 123; }
         });
-        value_of(instance()).should_be(123);    		
+        value_of(instance()).should_be(123);
     },
 
     'Should cache result of evaluator function and not call it again until dependencies change': function () {
@@ -208,7 +208,7 @@ describe('Dependent Observable', {
         value_of(timesEvaluated).should_be(1);
         value_of(dependent.getDependenciesCount()).should_be(0);
     },
-    
+
     'Should advertise that instances *can* have values written to them if you supply a "write" callback': function() {
         var instance = new ko.dependentObservable({ 
             read: function() {},
@@ -216,7 +216,7 @@ describe('Dependent Observable', {
         });
         value_of(ko.isWriteableObservable(instance)).should_be(true);    	
     },
-    
+
     'Should allow deferring of evaluation (and hence dependency detection)': function () {
         var timesEvaluated = 0;
         var instance = new ko.dependentObservable({ 
@@ -226,5 +226,19 @@ describe('Dependent Observable', {
         value_of(timesEvaluated).should_be(0);
         value_of(instance()).should_be(123);
         value_of(timesEvaluated).should_be(1);
-     }    
+    },
+
+    'Should allow long chains without overflowing the stack': function() {
+        var depth = 10000;
+        var first = ko.observable(0);
+        var last = first;
+        for (var i = 0; i < depth; i++) {
+           (function() {
+               var l = last;
+               last = ko.computed(function() { return l() + 1; })
+           })();
+        }
+        first(1);
+        value_of(last()).should_be(depth+1);
+     }
 })

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -54,10 +54,10 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             clearTimeout(evaluationTimeoutInstance);
             evaluationTimeoutInstance = setTimeout(evaluateImmediate, throttleEvaluationTimeout);
         } else
-            evaluateImmediate();
+            return evaluateImmediate(true);
     }
 
-    function evaluateImmediate() {
+    function evaluateImmediate(notifyOutOfLine) {
         // Don't dispose on first evaluation, because the "disposeWhen" callback might
         // e.g., dispose when the associated DOM element isn't in the doc, and it's not
         // going to be in the doc until *after* the first evaluation
@@ -94,8 +94,12 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             ko.dependencyDetection.end();
         }
 
-        dependentObservable["notifySubscribers"](_latestValue);
         _hasBeenEvaluated = true;
+        if (notifyOutOfLine) {
+            return [[dependentObservable, _latestValue]];
+        } else {
+            dependentObservable["notifySubscribers"](_latestValue);
+        }
     }
 
     function dependentObservable() {

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -42,10 +42,9 @@ ko.subscribable['fn'] = {
             event = event || defaultEvent;
             if (!subscribable._subscriptions[event]) return;
             var subscriptions = subscribable._subscriptions[event].slice(0);
-            subscriptions.reverse();
-            ko.utils.arrayForEach(subscriptions, function(subscription) {
-                stack.push([subscription, value]);
-            });
+            while (subscriptions.length > 0) {
+                stack.push([subscriptions.pop(), value]);
+            }
         }
         pushSubscriptions(this, valueToNotify, event);
         while (stack.length > 0) {

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -37,14 +37,28 @@ ko.subscribable['fn'] = {
     },
 
     "notifySubscribers": function (valueToNotify, event) {
-        event = event || defaultEvent;
-        if (this._subscriptions[event]) {
-            ko.utils.arrayForEach(this._subscriptions[event].slice(0), function (subscription) {
-                // In case a subscription was disposed during the arrayForEach cycle, check
-                // for isDisposed on each subscription before invoking its callback
-                if (subscription && (subscription.isDisposed !== true))
-                    subscription.callback(valueToNotify);
+        var stack = [];
+        function pushSubscriptions(subscribable, value, event) {
+            event = event || defaultEvent;
+            if (!subscribable._subscriptions[event]) return;
+            var subscriptions = subscribable._subscriptions[event].slice(0);
+            subscriptions.reverse();
+            ko.utils.arrayForEach(subscriptions, function(subscription) {
+                stack.push([subscription, value]);
             });
+        }
+        pushSubscriptions(this, valueToNotify, event);
+        while (stack.length > 0) {
+            var stackEntry = stack.pop();
+            var subscription = stackEntry[0],
+                value = stackEntry[1];
+            // In case a subscription was disposed while delivering other callbacks,
+            // check for isDisposed on each subscription before invoking its callback.
+            if (subscription && (subscription.isDisposed !== true)) {
+                var ret = subscription.callback(value);
+                if (ret)
+                    ko.utils.arrayForEach(ret, function(arr) { pushSubscriptions(arr[0], arr[1], arr[2]); });
+            }
         }
     },
 
@@ -56,7 +70,7 @@ ko.subscribable['fn'] = {
         }
         return total;
     },
-    
+
     extend: applyExtenders
 };
 


### PR DESCRIPTION
This allows subscriber chains to be very long
without stack overflow.  This is only done for
the default event; could probably be done for
"beforeChange" also, but would be a more
intrusive code change.

This change passes all tests in my browser
(Chrome).

See: https://github.com/SteveSanderson/knockout/issues/358