### PR TITLE
afterChange

### DIFF
--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -12,6 +12,7 @@ ko.observable = function (initialValue) {
                 observable.valueWillMutate();
                 _latestValue = arguments[0];
                 observable.valueHasMutated();
+                observable.afterValueHasMutated();
             }
             return this; // Permits chained assignments
         }
@@ -24,10 +25,12 @@ ko.observable = function (initialValue) {
     ko.subscribable.call(observable);
     observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
+    observable.afterValueHasMutated = function () { observable["notifySubscribers"](_latestValue, "afterChange"); }
     ko.utils.extend(observable, ko.observable['fn']);
 
     ko.exportProperty(observable, "valueHasMutated", observable.valueHasMutated);
     ko.exportProperty(observable, "valueWillMutate", observable.valueWillMutate);
+    ko.exportProperty(observable, "afterValueHasMutated", observable.afterValueHasMutated);
     
     return observable;
 }


### PR DESCRIPTION
Adding an afterChange event to observables.

Use Case:  In my project, I have a DIV that is sometimes visible, and sometimes not depending on an observable.  I want to set the max-height attribute of this DIV, but this can only be calculated when the DIV is visible.  If I use a normal subscription, there is no guarantee the DIV is visible when the subscription is fired.  By subscribing to afterChange, everything works as it should.
