### PR TITLE
Extend memoizeDataBindingAttributeSyntaxRegex to accomodate spaces around the equal signs

### DIFF
--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -1,6 +1,6 @@
 
 ko.templateRewriting = (function () {
-    var memoizeDataBindingAttributeSyntaxRegex = /(<[a-z]+\d*(\s+(?!data-bind=)[a-z0-9\-]+(=(\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind=(["'])([\s\S]*?)\5/gi;
+    var memoizeDataBindingAttributeSyntaxRegex = /(<[a-z]+\d*(\s+(?!data-bind\s*=\s*)[a-z0-9\-]+(=(\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind\s*=\s*(["'])([\s\S]*?)\5/gi;
     var memoizeVirtualContainerBindingSyntaxRegex = /<!--\s*ko\b\s*([\s\S]*?)\s*-->/g;
 
     function validateDataBindValuesForRewriting(keyValueArray) {


### PR DESCRIPTION
A fix for #375

Please see my comment on that issue, questioning how to add a unit test for this.

Thanks :]
