### PR TITLE
if $data is unchanged in child context, so should $parent

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -211,11 +211,16 @@ describe('Binding attribute syntax', {
                 return { controlsDescendantBindings : true };
             }
         };
-        testNode.innerHTML = "<div data-bind='with: true'><div data-bind='addCustomProperty: true'><div data-bind='text: $customProp'></div></div></div>";
-        ko.applyBindings(null, testNode);
+        testNode.innerHTML = "<div data-bind='with: sub'><div data-bind='addCustomProperty: true'><div data-bind='text: $customProp'></div></div></div>";
+        var vm = { sub: {} };
+        ko.applyBindings(vm, testNode);
         value_of(testNode).should_contain_text("my value");
         value_of(ko.contextFor(testNode.childNodes[0].childNodes[0].childNodes[0]).$customProp).should_be("my value");
         value_of(ko.contextFor(testNode.childNodes[0].childNodes[0]).$customProp).should_be(undefined); // Should not affect original binding context
+
+        // vale of $data and $parent should be unchanged in extended context
+        value_of(ko.contextFor(testNode.childNodes[0].childNodes[0].childNodes[0]).$data).should_be(vm.sub);
+        value_of(ko.contextFor(testNode.childNodes[0].childNodes[0].childNodes[0]).$parent).should_be(vm);
     },
 
     'Binding contexts should inherit any custom properties from ancestor binding contexts': function() {

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -18,7 +18,7 @@
         return new ko.bindingContext(dataItem, this);
     };
     ko.bindingContext.prototype['extend'] = function(properties) {
-        var clone = new ko.bindingContext(this['$data'], this);
+        var clone = ko.utils.extend(new ko.bindingContext(), this);
         return ko.utils.extend(clone, properties);
     };
 


### PR DESCRIPTION
With #290, we introduced the idea that a child binding context could have the same `$data` value as its parent using the `bindingContext.extend` method. I had originally proposed that the new context not be a child context, but with the addition of `$parentContext`, I can see that it's useful to have access to the previous context object. On the other hand, it's confusing to have useless `$parent` and `$parent[0]` pointers, which will just be the same as `$data`.
