### PR TITLE
Added new options parameter 'optionsDisabled'

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -455,6 +455,30 @@ describe('Binding: Options', {
         value_of(displayedText).should_be(["bob (manager)", "frank (coder & tester)"]);
     },
 
+    'Should accept optionsDisabled param to set the disabled subproperty of the model values': function () {
+        var modelValues = new ko.observableArray([
+            { name: 'bob', id: ko.observable(6), disabled: ko.observable(true) },
+            { name: ko.observable('frank'), id: 13, disabled: true },
+            { name: ko.observable('jill'), id: 24, disabled: false }
+        ]);
+        testNode.innerHTML = "<select data-bind='options:myValues, optionsText: \"name\", optionsValue: \"id\", optionsDisabled: \"disabled\"'><option>should be deleted</option></select>";
+        ko.applyBindings({ myValues: modelValues }, testNode);
+        var disabledValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes,
+            function (node) {
+                var _disabled = node.getAttribute('disabled');
+                if (_disabled === 'disabled')
+                    return node.value;
+            });
+        var enabledValues = ko.utils.arrayMap(testNode.childNodes[0].childNodes,
+            function (node) {
+                var _disabled = node.getAttribute('disabled');
+                if (_disabled === undefined || _disabled === null)
+                    return node.value;
+            });
+        value_of(disabledValues).should_be([6, 13, undefined]);
+        value_of(enabledValues).should_be([undefined, undefined, 24]);
+    },
+
     'Should update the SELECT node\'s options if the model changes': function () {
         var observable = new ko.observableArray(["A", "B", "C"]);
         testNode.innerHTML = "<select data-bind='options:myValues'><option>should be deleted</option></select>";

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -231,7 +231,14 @@ ko.bindingHandlers['options'] = {
                 var optionValue = typeof allBindings['optionsValue'] == "string" ? value[i][allBindings['optionsValue']] : value[i];
                 optionValue = ko.utils.unwrapObservable(optionValue);
                 ko.selectExtensions.writeValue(option, optionValue);
-                
+
+                if (allBindings['optionsDisabled']) {
+                    var disabledValue = typeof allBindings['optionsDisabled'] == "string" ? value[i][allBindings['optionsDisabled']] : allBindings['optionsDisabled'];
+                    disabledValue = ko.utils.unwrapObservable(disabledValue);
+                    if (disabledValue)
+                        option.setAttribute('disabled', 'disabled');
+                }
+
                 // Apply some text to the option element
                 var optionsTextValue = allBindings['optionsText'];
                 var optionText;


### PR DESCRIPTION
Allows option binding to include unselectable options (disabled)

Unfortunately this is not supported by IE 8 and below.
- UPDATE - 
  This is supported by IE 8
