### PR TITLE
HTML5 elems + containerless templates + jQuery spec fails on IE7/8

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -1628,11 +1628,11 @@ describe('Binding: Foreach', {
 
     'Should be able to output HTML5 elements within container-less templates (same as above)': function() {
         // Represents https://github.com/SteveSanderson/knockout/issues/194
-        ko.utils.setHtml(testNode, "<!-- ko foreach:someitems --><div><section data-bind='text: $data'></section></div><!-- /ko -->");
+        ko.utils.setHtml(testNode, "xxx<!-- ko foreach:someitems --><div><section data-bind='text: $data'></section></div><!-- /ko -->");
         var viewModel = {
             someitems: [ 'Alpha', 'Beta' ]
         };
         ko.applyBindings(viewModel, testNode);
-        value_of(testNode).should_contain_html('<!-- ko foreach:someitems --><div><section data-bind="text: $data">alpha</section></div><div><section data-bind="text: $data">beta</section></div><!-- /ko -->');
+        value_of(testNode).should_contain_html('xxx<!-- ko foreach:someitems --><div><section data-bind="text: $data">alpha</section></div><div><section data-bind="text: $data">beta</section></div><!-- /ko -->');
     }
 });


### PR DESCRIPTION
I was just about to put out the 2.1.0 Release Candidate when I discovered that we currently have a failing spec: `Should be able to output HTML5 elements within container-less templates (same as above)` originally added in commit 10c99b8c.

It fails if you're using IE7/8 (or IE9 simulating IE7/8) _and_ you have referenced jQuery and Modernizr. In other words, if `spec/runner.html` is modified on lines 8-11 so that the jQuery+Modernizr references are enabled.

Oddly, it works on IE6 though.

I can't investigate it this morning but will try to get to it soon. If anyone (Michael?) can guess immediately what is wrong or has opportunity to find a fix, please let me know!
