### PR TITLE
foreach doesn't update correctly in 2.1 if first item in rewritten template has a binding

### DIFF
--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -151,10 +151,10 @@
             }
         }
         if (!invokedBeforeRemoveCallback && nodesToDelete.length) {
-            var commonParent = nodesToDelete[0].element.parentNode;
-            if (commonParent) {
-                for (var i = 0; i < nodesToDelete.length; i++)
-                    commonParent.removeChild(nodesToDelete[i].element);
+            for (var i = 0; i < nodesToDelete.length; i++) {
+                var element = nodesToDelete[i].element;
+                if (element.parentNode)
+                    element.parentNode.removeChild(element);
             }
         }
 


### PR DESCRIPTION
Example to demonstrate: http://jsfiddle.net/madcapnmckay/radm8/ 

Also see http://groups.google.com/group/knockoutjs/msg/7ece39cc1bd0a351 and my comments on #144
