### PR TITLE
Bug in IE9 Compatmode

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -363,8 +363,11 @@ ko.bindingHandlers['uniqueName'] = {
             // Workaround IE 6/7 issue
             // - https://github.com/SteveSanderson/knockout/issues/197
             // - http://www.matts411.com/post/setting_the_name_attribute_in_ie_dom/
-            if (ko.utils.isIe6 || ko.utils.isIe7)
-                element.mergeAttributes(document.createElement("<input name='" + element.name + "'/>"), false);
+            if (ko.utils.isIe6 || ko.utils.isIe7){
+                var newEl = document.createElement("input");
+                newEl.setAttribute("name", element.name);
+                element.mergeAttributes(newEl, false);
+            }
         }
     }
 };


### PR DESCRIPTION
Found and fixed a bug where IE9 in compatibility mode breaks on document.createElement, where first argument is a element string with brackets. 

See http://msdn.microsoft.com/en-us/library/ie/ff986077(v=vs.85).aspx
