### PR TITLE
Support svg elements in css: bindings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -280,17 +280,24 @@ ko.utils = new (function () {
         },
 
         toggleDomNodeCssClass: function (node, className, shouldHaveClass) {
-            var currentClassNames = (node.className || "").split(/\s+/);
+            var classList = node.className['baseVal'] || node.className || "";
+            var currentClassNames = classList.split(/\s+/);
             var hasClass = ko.utils.arrayIndexOf(currentClassNames, className) >= 0;
 
+            var newClassName = null;
             if (shouldHaveClass && !hasClass) {
-                node.className += (currentClassNames[0] ? " " : "") + className;
+                newClassName = classList + (currentClassNames[0] ? " " : "") + className;
             } else if (hasClass && !shouldHaveClass) {
-                var newClassName = "";
+                newClassName = "";
                 for (var i = 0; i < currentClassNames.length; i++)
                     if (currentClassNames[i] != className)
                         newClassName += currentClassNames[i] + " ";
                 node.className = ko.utils.stringTrim(newClassName);
+            }
+            if (newClassName) {
+                node.className['baseVal'] ?
+                    node.className['baseVal'] = newClassName :
+                    node.className = newClassName;
             }
         },
 


### PR DESCRIPTION
Bug in css: bindings accessing className on svg elements:

elem.className isn't always a string: Missing .split() error for svgs

I'm creating an application that contains svg content. Nodes in that part need to change classes depending on my model.

data-bind="css: { someclass: condition }" fails with

Uncaught TypeError: Object # has no method 'split'

The error is in toggleDomNodeCssClass - that method assumes that className is a string, while it's a SVGAnimatedString in my case. Other libraries handle this fine - I'll try and see if I can fix that up in a couple of lines in a fork.

Relevant jsFiddle link: http://jsfiddle.net/ZamFT/

This change against master checks if element.className has a property baseVal and reads/updates that instead. For normal elements the behavior should be unchanged. For svg content (see bug for jsFiddle link) this allows css: { .. } bindings.

I tried to make this as little intrusive as possible. The only problem I encountered was convincing the closure compiler to keep my 'baseVal' property intact. I solved that by accessing element.className['baseVal'] instead of .baseVal.

Both debug and production version build and work on my machine. Credits for the solution go in parts to the d3.js project - I knew that they handle setting classes on svg elements and checked their implementation.

(Edit: I failed using Github issues. I opened a bug first, fixed it on my branch, submitted a merge request referencing the original bug - not knowing that Github would create a new issue for the merge request anyway. Copied the original report and description to this merge request now, will remove the obsolete issue)
