### PR TITLE
Extended equalityComparer support to dependentObservables

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -74,7 +74,9 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             dispose();
             return;
         }
-
+        
+        var valueHasChanged = true;
+        
         _isBeingEvaluated = true;
         try {
             // Initially, we assume that none of the subscriptions are still being used (i.e., all are candidates for disposal).
@@ -97,15 +99,24 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
                     _subscriptionsToDependencies.splice(i, 1)[0].dispose();
             }
             _hasBeenEvaluated = true;
-
-            dependentObservable["notifySubscribers"](_latestValue, "beforeChange");
+            
+            // Do not notify subscribers if the value hasn't changed
+            if((dependentObservable['equalityComparer']) && dependentObservable['equalityComparer'](_latestValue, newValue)) {
+                valueHasChanged = false;
+            }
+            
+            if(valueHasChanged) {
+                dependentObservable["notifySubscribers"](_latestValue, "beforeChange");
+            }
             _latestValue = newValue;
             if (DEBUG) dependentObservable._latestValue = _latestValue;
         } finally {
             ko.dependencyDetection.end();
         }
-
-        dependentObservable["notifySubscribers"](_latestValue);
+        
+        if(valueHasChanged) {
+            dependentObservable["notifySubscribers"](_latestValue);
+        }
         _isBeingEvaluated = false;
 
     }
@@ -158,7 +169,12 @@ ko.isComputed = function(instance) {
 var protoProp = ko.observable.protoProperty; // == "__ko_proto__"
 ko.dependentObservable[protoProp] = ko.observable;
 
-ko.dependentObservable['fn'] = {};
+ko.dependentObservable['fn'] = {
+    "equalityComparer": function valuesArePrimitiveAndEqual(a, b) {
+        var oldValueIsPrimitive = (a === null) || (typeof(a) in primitiveTypes);
+        return oldValueIsPrimitive ? (a === b) : false;
+    }
+};
 ko.dependentObservable['fn'][protoProp] = ko.dependentObservable;
 
 ko.exportSymbol('dependentObservable', ko.dependentObservable);


### PR DESCRIPTION
With this patch, dependentObservables only notify subscribers if their computed value has changed.  Changes are detected with equalityComparer, just like with observables.

This was such a small change, I'm wondering if you have a good reason why dependentObservables must always notify subscribers.  Thoughts?
