### PR TITLE
"foreach" and "with" can give a name to $data with "as: someName"

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -1289,6 +1289,12 @@ describe('Binding: With', {
         // Make top disappear
         viewModel.topitem(null);
         value_of(testNode).should_contain_html("hello <!-- ko with: topitem --><!-- /ko -->");
+    },
+
+    'Should be able to bind $data to an alias and use it within \"with\"': function() {
+        testNode.innerHTML = "<div data-bind='with: topitem, as: item'><span data-bind='text: item.name'></span></div>";
+        ko.applyBindings({ topitem: { name: 'alpha' } }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('<span data-bind="text: item.name">alpha</span>');
     }
 });
 
@@ -1634,5 +1640,40 @@ describe('Binding: Foreach', {
         };
         ko.applyBindings(viewModel, testNode);
         value_of(testNode).should_contain_html('xxx<!-- ko foreach:someitems --><div><section data-bind="text: $data">alpha</section></div><div><section data-bind="text: $data">beta</section></div><!-- /ko -->');
+    },
+
+    'Should be able to bind $data to an alias and use it within a loop': function() {
+        testNode.innerHTML = "<div data-bind='foreach: someItems, as: item'><span data-bind='text: item'></span></div>";
+        var someItems = ['alpha', 'beta'];
+        ko.applyBindings({ someItems: someItems }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('<span data-bind="text: item">alpha</span><span data-bind="text: item">beta</span>');
+    },
+
+    'Should be able to bind $data to an alias and use it within an object literal foreach (alias must be quoted)': function() {
+        testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><span data-bind='text: item'></span></div>";
+        var someItems = ['alpha', 'beta'];
+        ko.applyBindings({ someItems: someItems }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('<span data-bind="text: item">alpha</span><span data-bind="text: item">beta</span>');
+    },
+
+    'Should be able to bind $data to an alias and use it within a nested loop': function() {
+        testNode.innerHTML = "<div data-bind='foreach: someItems, as: item'><span data-bind='foreach: sub'><span data-bind='text: item.name+$data'></span></span></div>";
+        var someItems = [{ name: 'alpha', sub: ['a', 'b'] }, { name: 'beta', sub: ['c'] }];
+        ko.applyBindings({ someItems: someItems }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('<span data-bind="foreach: sub"><span data-bind="text: item.name+$data">alphaa</span><span data-bind="text: item.name+$data">alphab</span></span><span data-bind="foreach: sub"><span data-bind="text: item.name+$data">betac</span></span>');
+    },
+
+    'Should be able to use a $data alias from inside an \'if\' in a loop': function() {
+        testNode.innerHTML = "<div data-bind='foreach: someItems, as: item'><span data-bind='if: item.length'><span data-bind='text: item'></span></span></div>";
+        var someItems = ['alpha', 'beta'];
+        ko.applyBindings({ someItems: someItems }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('<span data-bind="if: item.length"><span data-bind="text: item">alpha</span></span><span data-bind="if: item.length"><span data-bind="text: item">beta</span></span>');
+    },
+
+    'Should be able to use a $data alias from inside a containerless \'if\' in a loop': function() {
+        testNode.innerHTML = "<div data-bind='foreach: someItems, as: item'>x<!-- ko if: item.length --><span data-bind='text: item'></span>x<!-- /ko --></div>";
+        var someItems = ['alpha', 'beta'];
+        ko.applyBindings({ someItems: someItems }, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html('x<!-- ko if: item.length --><span data-bind="text: item">alpha</span>x<!-- /ko -->x<!-- ko if: item.length --><span data-bind="text: item">beta</span>x<!-- /ko -->');
     }
 });

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -14,8 +14,10 @@
         }
         this['$data'] = dataItem;
     }
-    ko.bindingContext.prototype['createChildContext'] = function (dataItem) {
-        return new ko.bindingContext(dataItem, this);
+    ko.bindingContext.prototype['createChildContext'] = function (dataItem, bindingAlias) {
+        var child = new ko.bindingContext(dataItem, this);
+        if (bindingAlias) child[bindingAlias] = dataItem; // also bind $data as bindingAlias.
+        return child;
     };
     ko.bindingContext.prototype['extend'] = function(properties) {
         var clone = ko.utils.extend(new ko.bindingContext(), this);

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -532,7 +532,8 @@ ko.bindingHandlers['foreach'] = {
                 'afterAdd': bindingValue['afterAdd'],
                 'beforeRemove': bindingValue['beforeRemove'],
                 'afterRender': bindingValue['afterRender'],
-                'templateEngine': ko.nativeTemplateEngine.instance
+                'templateEngine': ko.nativeTemplateEngine.instance,
+                'as': bindingValue['as']
             };
         };
     },

--- a/src/binding/jsonExpressionRewriting.js
+++ b/src/binding/jsonExpressionRewriting.js
@@ -136,6 +136,9 @@ ko.jsonExpressionRewriting = (function () {
                     var quotedKey = ensureQuoted(keyValueEntry['key']), val = keyValueEntry['value'];
                     resultStrings.push(quotedKey);
                     resultStrings.push(":");
+                    // Special case for 'as': automatically quote the new binding name.
+                    if (quotedKey === "'as'")
+                        val = ensureQuoted(val);
                     resultStrings.push(val);
 
                     if (isWriteableValue(ko.utils.stringTrim(val))) {

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -117,7 +117,7 @@
         }
     };
 
-    ko.renderTemplateForEach = function (template, arrayOrObservableArray, options, targetNode, parentBindingContext) {
+    ko.renderTemplateForEach = function (template, arrayOrObservableArray, options, targetNode, parentBindingContext, bindingAlias) {
         // Since setDomNodeChildrenFromArrayMapping always calls executeTemplateForArrayItem and then
         // activateBindingsCallback for added items, we can store the binding context in the former to use in the latter.
         var arrayItemContext;
@@ -126,7 +126,7 @@
         var executeTemplateForArrayItem = function (arrayValue, index) {
             // Support selecting template as a function of the data being rendered
             var templateName = typeof(template) == 'function' ? template(arrayValue) : template;
-            arrayItemContext = parentBindingContext['createChildContext'](ko.utils.unwrapObservable(arrayValue));
+            arrayItemContext = parentBindingContext['createChildContext'](ko.utils.unwrapObservable(arrayValue), bindingAlias);
             arrayItemContext['$index'] = index;
             return executeTemplate(null, "ignoreTargetNode", templateName, arrayItemContext, options);
         }
@@ -178,6 +178,9 @@
             var templateName;
             var shouldDisplay = true;
 
+            // Support 'as' data binding, and allBindings shortcut for common usage.
+            var bindingAlias = bindingValue['as'] || allBindingsAccessor()['as'];
+
             if (typeof bindingValue == "string") {
                 templateName = bindingValue;
             } else {
@@ -195,12 +198,12 @@
             if ((typeof bindingValue === 'object') && ('foreach' in bindingValue)) { // Note: can't use 'in' operator on strings
                 // Render once for each data point (treating data set as empty if shouldDisplay==false)
                 var dataArray = (shouldDisplay && bindingValue['foreach']) || [];
-                templateSubscription = ko.renderTemplateForEach(templateName || element, dataArray, /* options: */ bindingValue, element, bindingContext);
+                templateSubscription = ko.renderTemplateForEach(templateName || element, dataArray, /* options: */ bindingValue, element, bindingContext, bindingAlias);
             } else {
                 if (shouldDisplay) {
                     // Render once for this single data point (or use the viewModel if no data was provided)
                     var innerBindingContext = (typeof bindingValue == 'object') && ('data' in bindingValue)
-                        ? bindingContext['createChildContext'](ko.utils.unwrapObservable(bindingValue['data'])) // Given an explitit 'data' value, we create a child binding context for it
+                        ? bindingContext['createChildContext'](ko.utils.unwrapObservable(bindingValue['data']), bindingAlias) // Given an explitit 'data' value, we create a child binding context for it
                         : bindingContext;                                                                       // Given no explicit 'data' value, we retain the same binding context
                     templateSubscription = ko.renderTemplate(templateName || element, innerBindingContext, /* options: */ bindingValue, element);
                 } else


### PR DESCRIPTION
The main rationale for this approach is to increase the maintainability of heavily nested bindings that refer to parents, although I'd argue that explicitly named references are much easier to follow than $parent chains.

To borrow one of your examples:

``` html
<ul data-bind="foreach: managers, as: mgr">
    <li>
        <strong data-bind="text: name"></strong>
        <ul data-bind="foreach: directReports">
            <li>
                <strong data-bind="text: name"></strong>
                (managed by <span data-bind="text: mgr.name"></span>)
            </li>
        </ul>
    </li>
</ul>
```

The automatic quoting I've added for "as:" might cause some controversy, and it is completely special-cased in the code - any thoughts on a better way to do this would be appreciated! (It also doesn't work inside an object literal foreach.)

The use-case for "with" is similar to "for"; somewhere in a context nested (deeply) in the "with" context, you want to access properties on the "with:" value.
