### PR TITLE
Unify afterRender callbacks

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -1154,6 +1154,27 @@ describe('Binding: Ifnot', {
         ko.applyBindings({ }, testNode);
         value_of(testNode.childNodes[0]).should_contain_text("Parents: 0");
         value_of(ko.contextFor(testNode.childNodes[0].childNodes[1]).$parents.length).should_be(0);
+    },
+
+    'Should be able to supply afterRender callback': function() {
+        var afterRenderCalled = false;
+        var passedElement;
+        var passedData;
+        var viewModel = {
+            active: false,
+            myAfterRender: function(renderedElements, data) {
+                afterRenderCalled = true;
+                passedElement = renderedElements[0];
+                passedData = data;
+            }
+        };
+
+        testNode.innerHTML = "<div data-bind='ifnot: { data: active, afterRender: myAfterRender }'>Hello there</div>";
+        ko.applyBindings(viewModel, testNode);
+
+        value_of(afterRenderCalled).should_be(true);
+        value_of(passedElement.data).should_be("Hello there");
+        value_of(passedData).should_be(viewModel);
     }
 });
 
@@ -1310,6 +1331,27 @@ describe('Binding: With', {
         // Make top disappear
         viewModel.topitem(null);
         value_of(testNode).should_contain_html("hello <!-- ko with: topitem --><!-- /ko -->");
+    },
+
+    'Should be able to supply afterRender callback': function() {
+        var afterRenderCalled = false;
+        var passedElement;
+        var passedData;
+        var viewModel = {
+            active: true,
+            myAfterRender: function(renderedElements, data) {
+                afterRenderCalled = true;
+                passedElement = renderedElements[0];
+                passedData = data;
+            }
+        };
+
+        testNode.innerHTML = "<div data-bind='with: { data: active, afterRender: myAfterRender }'>Hello there</div>";
+        ko.applyBindings(viewModel, testNode);
+
+        value_of(afterRenderCalled).should_be(true);
+        value_of(passedElement.data).should_be("Hello there");
+        value_of(passedData).should_be(true);
     }
 });
 

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -469,59 +469,58 @@ ko.bindingHandlers['hasfocus'] = {
     }
 };
 
+
+/*
+ * Creates bindings that are specialized versions of the 'template'-binding. The
+ * standard creation can be further customized by passing a 'modifyResultFn', which
+ * will be called during the execution of 'makeTemplateValueAccessor'.
+ */
+function specializeTemplateBinding(name, modifyResultFn) {
+    return {
+        makeTemplateValueAccessor: function(valueAccessor) {
+            // This function assigns the binding's value to the result object's
+            // 'name'-property. If present, the afterRender-property is copied, too.
+            return function() {
+                var bindingValue = valueAccessor();
+                var result = { 'templateEngine': ko.nativeTemplateEngine.instance };
+                // determine whether the 'full' binding syntax with an object literal
+                // was used by checking the presence of a 'data' property
+                if (bindingValue == null || !bindingValue.hasOwnProperty('data')) {
+                    // the standard shorthand binding syntax was used
+                    result[name] = bindingValue;
+                } else {
+                    // full, object-literal syntax was used
+                    result[name] = bindingValue.data;
+                    result.afterRender = bindingValue.afterRender;
+                }
+                return modifyResultFn ? modifyResultFn(result, valueAccessor) : result;
+            };
+        },
+        'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers[name].makeTemplateValueAccessor(valueAccessor));
+        },
+        'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers[name].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
+        }
+    };
+}
+
 // "with: someExpression" is equivalent to "template: { if: someExpression, data: someExpression }"
-ko.bindingHandlers['with'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() { var value = valueAccessor(); return { 'if': value, 'data': value, 'templateEngine': ko.nativeTemplateEngine.instance } };
-    },
-    'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor));
-    },
-    'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
-    }
-};
+ko.bindingHandlers['with'] = specializeTemplateBinding('with', function(result, valueAccessor) {
+    result.data = result['if'] = result['with'];
+    delete result['with'];
+    return result;
+});
 ko.jsonExpressionRewriting.bindingRewriteValidators['with'] = false; // Can't rewrite control flow bindings
 ko.virtualElements.allowedBindings['with'] = true;
 
 // "if: someExpression" is equivalent to "template: { if: someExpression }"
-ko.bindingHandlers['if'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() {
-            var bindingValue = valueAccessor();
-            if (bindingValue == null || typeof bindingValue.data === "undefined") {
-                return { 'if': bindingValue, 'templateEngine': ko.nativeTemplateEngine.instance };
-            } else {
-                return {
-                    'if': bindingValue['data'],
-                    'afterRender': bindingValue['afterRender'],
-                    'templateEngine': ko.nativeTemplateEngine.instance
-                };
-            }
-        };
-    },
-    'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor));
-    },
-    'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
-    }
-};
+ko.bindingHandlers['if'] = specializeTemplateBinding('if');
 ko.jsonExpressionRewriting.bindingRewriteValidators['if'] = false; // Can't rewrite control flow bindings
 ko.virtualElements.allowedBindings['if'] = true;
 
 // "ifnot: someExpression" is equivalent to "template: { ifnot: someExpression }"
-ko.bindingHandlers['ifnot'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() { return { 'ifnot': valueAccessor(), 'templateEngine': ko.nativeTemplateEngine.instance } };
-    },
-    'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor));
-    },
-    'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
-    }
-};
+ko.bindingHandlers['ifnot'] = specializeTemplateBinding('ifnot');;
 ko.jsonExpressionRewriting.bindingRewriteValidators['ifnot'] = false; // Can't rewrite control flow bindings
 ko.virtualElements.allowedBindings['ifnot'] = true;
 


### PR DESCRIPTION
The changes in here would add `afterRender`-callback hooks also to `if`, `ifnot` and `with` bindings. Currently, only `template` and `forEach` offer this functionality. The usage would be for example:

```
"<div data-bind='if: { data: someObservable, afterRender: myAfterRender }'>Hello there</div>"
```

Unit-tests for the new functionality are included. If the changes are okay for everybody, I can extend the documentation to reflect them (but I wanted to wait with that until the functionality itself is approved).

fixes #421
