### PR TITLE
Update to end comment regex to support the form <!-- /ko some more text -->

### DIFF
--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -13,7 +13,7 @@
     var commentNodesHaveTextProperty = document.createComment("test").text === "<!--test-->";
 
     var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko\s+(.*\:.*)\s*-->$/ : /^\s*ko\s+(.*\:.*)\s*$/;
-    var endCommentRegex =   commentNodesHaveTextProperty ? /^<!--\s*\/ko\s*-->$/ : /^\s*\/ko\s*$/;
+    var endCommentRegex =   commentNodesHaveTextProperty ? /^<!--\s*\/ko(?:\s+.*)?\s*-->$/ : /^\s*\/ko(?:\s+.*)?\s*$/;
     var htmlTagsWithOptionallyClosingChildren = { 'ul': true, 'ol': true };
 
     function isStartComment(node) {


### PR DESCRIPTION
In a larger project one might often end up with a lot of markup in between a start and end comment, or lots of nested comment tags.  This change relaxes constraints on parsing of the end tag, so you can include some comment text to indicate what the tag closes:

``` html
<!-- ko foreach: Foo -->
... lots of lines here ...
<!-- /ko foreach: Foo -->
```
