### PR TITLE
Running knockout with multiple versions of jQuery 

### DIFF
--- a/build/build-linux
+++ b/build/build-linux
@@ -15,25 +15,25 @@ SourceFiles=`grep js < fragments/source-references.js | # Find JS references
              sed "s/[ \',]//g" |                        # Strip off JSON fluff (whitespace, commas, quotes)
              sed -e 's/.*/..\/&/' |                     # Fix the paths by prefixing with ../
              tr '\n' ' '`                               # Combine into single line
-cat fragments/amd-pre.js            > $OutDebugFile.temp
+cat fragments/extern-pre.js         > $OutDebugFile.temp
+cat fragments/amd-pre.js            >> $OutDebugFile.temp
 cat $SourceFiles                    >> $OutDebugFile.temp
 cat fragments/amd-post.js           >> $OutDebugFile.temp
+cat fragments/extern-post.js        >> $OutDebugFile.temp
 
 # Now call Google Closure Compiler to produce a minified version
-curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode "js_code=/**@const*/var DEBUG=false;" --data-urlencode js_code@$OutDebugFile.temp "http://closure-compiler.appspot.com/compile" > $OutMinFile.temp
+curl -d output_info=compiled_code -d output_format=text -d compilation_level=ADVANCED_OPTIMIZATIONS --data-urlencode output_wrapper="(function() {%output%})();" --data-urlencode "js_code=/**@const*/var DEBUG=false;" --data-urlencode js_code@$OutDebugFile.temp "http://closure-compiler.appspot.com/compile" > $OutMinFile.temp
 
 # Finalise each file by prefixing with version header and surrounding in function closure
 cp fragments/version-header.js $OutDebugFile
-echo "(function(window,document,navigator,undefined){" >> $OutDebugFile
-echo "var DEBUG=true;"                                 >> $OutDebugFile
-cat $OutDebugFile.temp                                 >> $OutDebugFile
-echo "})(window,document,navigator);"                  >> $OutDebugFile
+echo "(function(){"                 >> $OutDebugFile
+echo "var DEBUG=true;"              >> $OutDebugFile
+cat $OutDebugFile.temp              >> $OutDebugFile
+echo "})();"                        >> $OutDebugFile
 rm $OutDebugFile.temp
 
 cp fragments/version-header.js $OutMinFile
-echo "(function(window,document,navigator,undefined){" >> $OutMinFile
-cat $OutMinFile.temp                                   >> $OutMinFile
-echo "})(window,document,navigator);"                  >> $OutMinFile
+cat $OutMinFile.temp                >> $OutMinFile
 rm $OutMinFile.temp
 
 # Inject the version number string

--- a/build/fragments/extern-post.js
+++ b/build/fragments/extern-post.js
@@ -1,0 +1,1 @@
+})(window,document,navigator,window["jQuery"]);

--- a/build/fragments/extern-pre.js
+++ b/build/fragments/extern-pre.js
@@ -1,0 +1,1 @@
+(function(window,document,navigator,jQuery,undefined){


### PR DESCRIPTION
I have had a requirement to include knockout in a page that is running multiple versions of jQuery. This is supported in jQuery by first loading up version A, loading up any dependencies then calling jQuery.noConflict(true). This removes jQuery from the global scope so that you can then load up version B. In order for this to work anything that depends on jQuery must store a reference to jQuery in its local scope and not reference it from global scope. This minor change adds a line to knockout to store jQuery locally in the Knockout namespace.
