### PR TITLE
Should be able to read an observable without creating a subscription

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -110,6 +110,26 @@ describe('Dependent Observable', {
         value_of(depedentObservable()).should_be(51);
     },
 
+    'Should be able to use \'peek\' on an observable to avoid a dependency': function() {
+        var observable = ko.observable(1),
+            computed = ko.dependentObservable(function () { return observable.peek() + 1; });
+        value_of(computed()).should_be(2);
+
+        observable(50);
+        value_of(computed()).should_be(2);    // value wasn't changed
+    },
+
+    'Should be able to use \'ko.ignoreDependencies\' within a computed to avoid dependencies': function() {
+        var observable = ko.observable(1),
+            computed = ko.dependentObservable(function () {
+                return ko.ignoreDependencies(function() { return observable() + 1 } );
+            });
+        value_of(computed()).should_be(2);
+
+        observable(50);
+        value_of(computed()).should_be(2);    // value wasn't changed
+    },
+
     'Should unsubscribe from previous dependencies each time a dependency changes': function () {
         var observableA = new ko.observable("A");
         var observableB = new ko.observable("B");
@@ -181,6 +201,16 @@ describe('Dependent Observable', {
         value_of(dependent2()).should_be(13);
     },
 
+    'Should be able to use \'peek\' on a computed observable to avoid a dependency': function () {
+        var underlyingObservable = new ko.observable(1);
+        var computed1 = new ko.dependentObservable(function () { return underlyingObservable() + 1; });
+        var computed2 = new ko.dependentObservable(function () { return computed1.peek() + 1; });
+        value_of(computed2()).should_be(3);
+
+        underlyingObservable(11);
+        value_of(computed2()).should_be(3);    // value wasn't changed
+    },
+
     'Should accept "owner" parameter to define the object on which the evaluator function should be called': function () {
         var model = new (function () {
             this.greeting = "hello";
@@ -237,5 +267,5 @@ describe('Dependent Observable', {
                 // isn't prevented
                 observable(observable() + 1);
             });
-     }
+    }
 })

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -16,11 +16,22 @@ ko.dependencyDetection = (function () {
                 throw new Error("Only subscribable things can act as dependencies");
             if (_frames.length > 0) {
                 var topFrame = _frames[_frames.length - 1];
-                if (ko.utils.arrayIndexOf(topFrame.distinctDependencies, subscribable) >= 0)
+                if (!topFrame || ko.utils.arrayIndexOf(topFrame.distinctDependencies, subscribable) >= 0)
                     return;
                 topFrame.distinctDependencies.push(subscribable);
                 topFrame.callback(subscribable);
             }
+        },
+
+        ignore: function(callback, object, args) {
+            try {
+                _frames.push(null);
+                return callback.apply(object, args || []);
+            } finally {
+                _frames.pop();
+            }
         }
     };
 })();
+
+ko.exportSymbol('ignoreDependencies', ko.ignoreDependencies = ko.dependencyDetection.ignore);

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -24,10 +24,12 @@ ko.observable = function (initialValue) {
     }
     if (DEBUG) observable._latestValue = _latestValue;
     ko.subscribable.call(observable);
+    observable.peek = function() { return _latestValue };
     observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
     ko.utils.extend(observable, ko.observable['fn']);
 
+    ko.exportProperty(observable, 'peek', observable.peek);
     ko.exportProperty(observable, "valueHasMutated", observable.valueHasMutated);
     ko.exportProperty(observable, "valueWillMutate", observable.valueWillMutate);
 


### PR DESCRIPTION
There are times when it's useful to read an observable without creating a subscription. Here's a simple example:

``` javascript
var counter = ko.observable(0), somethingToWatch = ko.observable();
var somethingDoubled = ko.computed(function() {
    counter(counter()+1);
    return somethingToWatch() * 2;
});
```

The call to `counter()` creates a subscription, but since we don't use the value except to write to `counter`, we shouldn't have a subscription. In fact this code will cause an stack overflow because writing to `counter` will trigger re-running the function.

In #225, I suggested adding a `_latestValue` property to observables so the value could be accessed when inspecting the observable in a debugger. This could be extended by exporting the property, and then it'd be possible to read the value directly without triggering a subscription. Writing to the property would not be supported, of course.

Another solution would be to add a function to observables like `getWithoutDependency` that returns the value.

Outside of modifying Knockout, a way to solve the example above is to update `counter` asynchronously in a setTimeout call: `setTimeout(function() { counter(counter()+1); }, 0);`
