### PR TITLE
Select List Without Options Doesn't Update Observable

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -379,6 +379,18 @@ describe('Binding: Value', {
         value_of(observable()).should_be(20);
     },
 
+    'For select boxes with values attributes, should always use value (and not text)': function() {
+        var observable = new ko.observable('A');
+        testNode.innerHTML = "<select data-bind='value:myObservable'><option value=''>A</option><option value='A'>B</option></select>";
+        ko.applyBindings({ myObservable: observable }, testNode);
+        var dropdown = testNode.childNodes[0];
+        value_of(dropdown.selectedIndex).should_be(1);
+
+        dropdown.selectedIndex = 0;
+        ko.utils.triggerEvent(dropdown, "change");
+        value_of(observable()).should_be("");
+    },
+
     'For select boxes with text values but no value property, should use text value': function() {
         var observable = new ko.observable('B');
         testNode.innerHTML = "<select data-bind='value:myObservable'><option>A</option><option>B</option><option>C</option></select>";

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -10,7 +10,9 @@
                 case 'option':
                     if (element[hasDomDataExpandoProperty] === true)
                         return ko.utils.domData.get(element, ko.bindingHandlers.options.optionValueDomDataKey);
-                    return element.value || element.text;
+                    return ko.utils.ieVersion <= 7
+                        ? (element.getAttributeNode('value').specified ? element.value : element.text)
+                        : element.value;
                 case 'select':
                     return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
                 default:


### PR DESCRIPTION
http://stackoverflow.com/questions/10402042/knockout-js-not-working-when-select-list-doesnt-have-options

I think I found a bug in knockout.js in conjuction with the asp.net mvc dropdownlist. When supplying just a list of strings MVC doesn't render the option values on the select element. Knockout.js won't update the value because of this. If I use the second html snippet below by explicitly telling it properties it works. Shouldn't knockout.js read the inner html if the options value isn't available?
