### PR TITLE
Minify could be stronger on literals

### DIFF
--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -29,9 +29,8 @@ ko.templateRewriting = (function () {
         // For no obvious reason, Opera fails to evaluate rewrittenDataBindAttributeValue unless it's wrapped in an additional
         // anonymous function, even though Opera's built-in debugger can evaluate it anyway. No other browser requires this
         // extra indirection.
-        var applyBindingsToNextSiblingScript = "ko.templateRewriting.applyMemoizedBindingsToNextSibling(function() { \
-            return (function() { return { " + rewrittenDataBindAttributeValue + " } })() \
-        })";
+        var applyBindingsToNextSiblingScript =
+            "ko.__tr_ambtns(function(){return(function(){return{" + rewrittenDataBindAttributeValue + "} })()})";
         return templateEngine['createJavaScriptEvaluatorBlock'](applyBindingsToNextSiblingScript) + tagToRetain;
     }
 
@@ -60,5 +59,6 @@ ko.templateRewriting = (function () {
     }
 })();
 
-ko.exportSymbol('templateRewriting', ko.templateRewriting);
-ko.exportSymbol('templateRewriting.applyMemoizedBindingsToNextSibling', ko.templateRewriting.applyMemoizedBindingsToNextSibling); // Exported only because it has to be referenced by string lookup from within rewritten template
+
+// Exported only because it has to be referenced by string lookup from within rewritten template
+ko.exportSymbol('__tr_ambtns', ko.templateRewriting.applyMemoizedBindingsToNextSibling);


### PR DESCRIPTION
In 2.0.0, there were 13 trailing spaces at the end of the file.
This seems to not happen anymore in the latest 2.1. Just wanted to point that out so it doesn't show up in future version.

Also, this section of the code in literal:

``` javascript
"ko.templateRewriting.applyMemoizedBindingsToNextSibling(function() {             return (function() { return { "+a.g.ka(b)+
" } })()         })"
```

could be minified better and cash in 40 bytes :)

Low priority
