### PR TITLE
throttled subscribables can receive more than one argument

### DIFF
--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -13,8 +13,9 @@ ko.extenders = {
             'read': target,
             'write': function(value) {
                 clearTimeout(writeTimeoutInstance);
+                var args = [].splice.call(arguments, 0);
                 writeTimeoutInstance = setTimeout(function() {
-                    target(value);
+                    target.apply(target, args);
                 }, timeout);
             }
         });


### PR DESCRIPTION
It seems that regular subscribables can receive more than one argument, but not throttled subscribables. This patch changes throttled subscribables to be able to receive more than one argument. We find this useful at work, and rely on Knockout heavliy.
