### PR TITLE
fix selectedOption behaviour with optgroup

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -575,6 +575,21 @@ describe('Binding: Selected Options', {
         ko.utils.triggerEvent(testNode.childNodes[0], "change");
 
         value_of(selection()).should_be(['a', 'c']);
+    },
+
+    'Should set selection in the SELECT node inside an optgroup to match the model': function () {
+        var selection = new ko.observableArray(['a']);
+        testNode.innerHTML = "<select multiple='multiple' data-bind='selectedOptions:mySelection'><optgroup label='group'><option value='a'>a-text</option><option value='b'>b-text</option><option value='c'>c-text</option></optgroup><optgroup label='group2'><option value='d'>d-text</option></optgroup></select>";
+        ko.applyBindings({ mySelection: selection }, testNode);
+
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[0])).should_be(['a']);
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[1])).should_be([]);
+        selection.push('c');
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[0])).should_be(['a', 'c']);
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[1])).should_be([]);
+        selection.push('d');
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[0])).should_be(['a', 'c']);
+        value_of(getSelectedValuesFromSelectNode(testNode.childNodes[0].childNodes[1])).should_be(['d']);
     }
 });
 

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -291,6 +291,17 @@ ko.bindingHandlers['selectedOptions'] = {
         }
         return result;
     },
+    setSelectedValuesInSelectNode : function (selectNode, newValue) {
+        var nodes = selectNode.childNodes;
+        for (var i = 0, j = nodes.length; i < j; i++) {
+            var node = nodes[i], tagName = ko.utils.tagNameLower(node);
+            if (tagName == "option")
+                ko.utils.setOptionNodeSelectionState(node, ko.utils.arrayIndexOf(newValue, ko.selectExtensions.readValue(node)) >= 0);
+            else if (tagName == "optgroup") {
+                ko.bindingHandlers['selectedOptions'].setSelectedValuesInSelectNode(node, newValue);
+            }
+        }
+    },
     'init': function (element, valueAccessor, allBindingsAccessor) {
         ko.utils.registerEventHandler(element, "change", function () {
             var value = valueAccessor();
@@ -304,12 +315,7 @@ ko.bindingHandlers['selectedOptions'] = {
 
         var newValue = ko.utils.unwrapObservable(valueAccessor());
         if (newValue && typeof newValue.length == "number") {
-            var nodes = element.childNodes;
-            for (var i = 0, j = nodes.length; i < j; i++) {
-                var node = nodes[i];
-                if (ko.utils.tagNameLower(node) === "option")
-                    ko.utils.setOptionNodeSelectionState(node, ko.utils.arrayIndexOf(newValue, ko.selectExtensions.readValue(node)) >= 0);
-            }
+            ko.bindingHandlers['selectedOptions'].setSelectedValuesInSelectNode(element, newValue);
         }
     }
 };


### PR DESCRIPTION
selectedOptions can already read its value from options inside optgroup but it should also be able to synchronize the other way around and update options inside optgroup when the model value is mutated
