### PR TITLE
'Options' binding doesn't respect _destroy setting

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -520,6 +520,28 @@ describe('Binding: Options', {
         value_of(displayedText).should_be(["bob (manager)", "frank (coder & tester)"]);
     },
 
+    'Should exclude any items marked as destroyed': function() {
+        var modelValues = new ko.observableArray([
+            { name: 'bob', _destroy: true },
+            { name: 'frank' }
+        ]);
+        testNode.innerHTML = "<select data-bind='options: myValues, optionsValue: \"name\"'></select>";
+        ko.applyBindings({ myValues: modelValues }, testNode);
+        var values = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.value; });
+        value_of(values).should_be(["frank"]);
+    },
+
+    'Should include items marked as destroyed if optionsIncludeDestroyed is set': function() {
+        var modelValues = new ko.observableArray([
+            { name: 'bob', _destroy: true },
+            { name: 'frank' }
+        ]);
+        testNode.innerHTML = "<select data-bind='options: myValues, optionsValue: \"name\", optionsIncludeDestroyed: true'></select>";
+        ko.applyBindings({ myValues: modelValues }, testNode);
+        var values = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.value; });
+        value_of(values).should_be(["bob", "frank"]);
+    },
+
     'Should update the SELECT node\'s options if the model changes': function () {
         var observable = new ko.observableArray(["A", "B", "C"]);
         testNode.innerHTML = "<select data-bind='options:myValues'><option>should be deleted</option></select>";

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -215,7 +215,9 @@ ko.bindingHandlers['options'] = {
         }
 
         if (value) {
-            var allBindings = allBindingsAccessor();
+            var allBindings = allBindingsAccessor(),
+                includeDestroyed = allBindings['optionsIncludeDestroyed'];
+
             if (typeof value.length != "number")
                 value = [value];
             if (allBindings['optionsCaption']) {
@@ -224,7 +226,13 @@ ko.bindingHandlers['options'] = {
                 ko.selectExtensions.writeValue(option, undefined);
                 element.appendChild(option);
             }
+
             for (var i = 0, j = value.length; i < j; i++) {
+                // Skip destroyed items
+                var arrayEntry = value[i];
+                if (arrayEntry && arrayEntry['_destroy'] && !includeDestroyed)
+                    continue;
+
                 var option = document.createElement("option");
 
                 function applyToObject(object, predicate, defaultValue) {
@@ -238,11 +246,11 @@ ko.bindingHandlers['options'] = {
                 }
 
                 // Apply a value to the option element
-                var optionValue = applyToObject(value[i], allBindings['optionsValue'], value[i]);
+                var optionValue = applyToObject(arrayEntry, allBindings['optionsValue'], arrayEntry);
                 ko.selectExtensions.writeValue(option, ko.utils.unwrapObservable(optionValue));
 
                 // Apply some text to the option element
-                var optionText = applyToObject(value[i], allBindings['optionsText'], optionValue);
+                var optionText = applyToObject(arrayEntry, allBindings['optionsText'], optionValue);
                 ko.utils.setTextContent(option, optionText);
 
                 element.appendChild(option);


### PR DESCRIPTION
If an item has _destroy set then it will be ignored when rendering templates, however it will be included in a select list when using the options binding. For consistency I think _destroy should act like deleting the item in all cases.
