### PR TITLE
Text-based template support breaks when an AMD loader is present

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -11,6 +11,10 @@
         } else {
             this['$parents'] = [];
             this['$root'] = dataItem;
+            // Export 'ko' in the binding context so it will be available in bindings and templates
+            // even if 'ko' isn't exported as a global, such as when using an AMD loader.
+            // See https://github.com/SteveSanderson/knockout/issues/490
+            this['ko'] = ko;
         }
         this['$data'] = dataItem;
     }


### PR DESCRIPTION
It seems the text-based template support breaks when an amd loader is present. Knockout doesn't create window.ko when an AMD loader is present, but the template compiler requires window.ko to be there.

jQuery template: http://jsfiddle.net/5VxcE/2/
underscore: http://jsfiddle.net/5VxcE/4/
native knockout (works): http://jsfiddle.net/5VxcE/5/
