### PR TITLE
Guard against arbitrary objects being passed in on subscribe

### DIFF
--- a/spec/subscribableBehaviors.js
+++ b/spec/subscribableBehaviors.js
@@ -13,6 +13,19 @@ describe('Subscribable', {
         value_of(notifiedValue).should_be(123);
     },
 
+    'Should complain if subscriber is not a function': function(){
+        var instance = new ko.subscribable();
+        var bad_subscriber = {};
+        var threw = false;
+        try {
+            instance.subscribe(bad_subscriber);
+        }
+        catch (ex) {
+            threw = true;
+        }
+        value_of(threw).should_be(true);
+    },
+
     'Should be able to unsubscribe': function () {
         var instance = new ko.subscribable();
         var notifiedValue;

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -23,6 +23,9 @@ var defaultEvent = "change";
 
 ko.subscribable['fn'] = {
     subscribe: function (callback, callbackTarget, event) {
+        if (!(typeof callback === 'function')) {
+            throw new Error('Tried to register a subscriber that is not a function.');
+        }
         event = event || defaultEvent;
         var boundCallback = callbackTarget ? callback.bind(callbackTarget) : callback;
 


### PR DESCRIPTION
This improves feedback, because the error is thrown when the subscriber is registered as opposed to the previous behaviour where the error would not occur until the first notification.
