### PR TITLE
added afterRender functionality to if, ifnot and with bindings

### DIFF
--- a/spec/defaultBindingsBehaviors.js
+++ b/spec/defaultBindingsBehaviors.js
@@ -1245,6 +1245,27 @@ describe('Binding: If', {
         // Make inner appear
         condition2(true);
         value_of(testNode).should_contain_html("hello <!-- ko if: condition1 -->first is true<!-- ko if: condition2 -->both are true<!-- /ko --><!-- /ko -->");
+    },
+
+    'Should be able to supply afterRender callback': function() {
+        var afterRenderCalled = false;
+        var passedElement;
+        var passedData;
+        var viewModel = {
+            active: true,
+            myAfterRender: function(renderedElements, data) {
+                afterRenderCalled = true;
+                passedElement = renderedElements[0];
+                passedData = data;
+            }
+        };
+
+        testNode.innerHTML = "<div data-bind='if: active, afterRender: myAfterRender'>Hello there</div>";
+        ko.applyBindings(viewModel, testNode);
+
+        value_of(afterRenderCalled).should_be(true);
+        value_of(passedElement.data).should_be("Hello there");
+        value_of(passedData).should_be(viewModel);
     }
 });
 
@@ -1293,6 +1314,27 @@ describe('Binding: Ifnot', {
         ko.applyBindings({ }, testNode);
         value_of(testNode.childNodes[0]).should_contain_text("Parents: 0");
         value_of(ko.contextFor(testNode.childNodes[0].childNodes[1]).$parents.length).should_be(0);
+    },
+
+    'Should be able to supply afterRender callback': function() {
+        var afterRenderCalled = false;
+        var passedElement;
+        var passedData;
+        var viewModel = {
+            active: false,
+            myAfterRender: function(renderedElements, data) {
+                afterRenderCalled = true;
+                passedElement = renderedElements[0];
+                passedData = data;
+            }
+        };
+
+        testNode.innerHTML = "<div data-bind='ifnot: active, afterRender: myAfterRender'>Hello there</div>";
+        ko.applyBindings(viewModel, testNode);
+
+        value_of(afterRenderCalled).should_be(true);
+        value_of(passedElement.data).should_be("Hello there");
+        value_of(passedData).should_be(viewModel);
     }
 });
 
@@ -1449,6 +1491,27 @@ describe('Binding: With', {
         // Make top disappear
         viewModel.topitem(null);
         value_of(testNode).should_contain_html("hello <!-- ko with: topitem --><!-- /ko -->");
+    },
+
+    'Should be able to supply afterRender callback': function() {
+        var afterRenderCalled = false;
+        var passedElement;
+        var passedData;
+        var viewModel = {
+            active: true,
+            myAfterRender: function(renderedElements, data) {
+                afterRenderCalled = true;
+                passedElement = renderedElements[0];
+                passedData = data;
+            }
+        };
+
+        testNode.innerHTML = "<div data-bind='with: active, afterRender: myAfterRender'>Hello there</div>";
+        ko.applyBindings(viewModel, testNode);
+
+        value_of(afterRenderCalled).should_be(true);
+        value_of(passedElement.data).should_be("Hello there");
+        value_of(passedData).should_be(true);
     }
 });
 

--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -475,14 +475,14 @@ ko.bindingHandlers['hasfocus'] = {
 
 // "with: someExpression" is equivalent to "template: { if: someExpression, data: someExpression }"
 ko.bindingHandlers['with'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() { var value = valueAccessor(); return { 'if': value, 'data': value, 'templateEngine': ko.nativeTemplateEngine.instance } };
+    makeTemplateValueAccessor: function(valueAccessor, allBindingsAccessor) {
+        return function() { var value = valueAccessor(); return { 'if': value, 'data': value, 'templateEngine': ko.nativeTemplateEngine.instance, 'afterRender': allBindingsAccessor()['afterRender']  } };
     },
     'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor));
+        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor));
     },
     'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
+        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['with'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor), allBindingsAccessor, viewModel, bindingContext);
     }
 };
 ko.jsonExpressionRewriting.bindingRewriteValidators['with'] = false; // Can't rewrite control flow bindings
@@ -490,14 +490,14 @@ ko.virtualElements.allowedBindings['with'] = true;
 
 // "if: someExpression" is equivalent to "template: { if: someExpression }"
 ko.bindingHandlers['if'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() { return { 'if': valueAccessor(), 'templateEngine': ko.nativeTemplateEngine.instance } };
+    makeTemplateValueAccessor: function(valueAccessor, allBindingsAccessor) {
+        return function() { return { 'if': valueAccessor(), 'templateEngine': ko.nativeTemplateEngine.instance, 'afterRender': allBindingsAccessor()['afterRender'] } };
     },
     'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor));
+        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor));
     },
     'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
+        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['if'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor), allBindingsAccessor, viewModel, bindingContext);
     }
 };
 ko.jsonExpressionRewriting.bindingRewriteValidators['if'] = false; // Can't rewrite control flow bindings
@@ -505,14 +505,14 @@ ko.virtualElements.allowedBindings['if'] = true;
 
 // "ifnot: someExpression" is equivalent to "template: { ifnot: someExpression }"
 ko.bindingHandlers['ifnot'] = {
-    makeTemplateValueAccessor: function(valueAccessor) {
-        return function() { return { 'ifnot': valueAccessor(), 'templateEngine': ko.nativeTemplateEngine.instance } };
+    makeTemplateValueAccessor: function(valueAccessor, allBindingsAccessor) {
+        return function() { return { 'ifnot': valueAccessor(), 'templateEngine': ko.nativeTemplateEngine.instance, 'afterRender': allBindingsAccessor()['afterRender']  } };
     },
     'init': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor));
+        return ko.bindingHandlers['template']['init'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor));
     },
     'update': function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor), allBindingsAccessor, viewModel, bindingContext);
+        return ko.bindingHandlers['template']['update'](element, ko.bindingHandlers['ifnot'].makeTemplateValueAccessor(valueAccessor, allBindingsAccessor), allBindingsAccessor, viewModel, bindingContext);
     }
 };
 ko.jsonExpressionRewriting.bindingRewriteValidators['ifnot'] = false; // Can't rewrite control flow bindings


### PR DESCRIPTION
The changes in here add `afterRender`-callback hooks to `if`, `ifnot` and `with` bindings. Currently, only `template` and `forEach` offer this functionality. The usage would be for example:

```
"<div data-bind='if: someObservable, afterRender: myAfterRender'>Hello there</div>"
```

Unit-tests for the new functionality are included. The syntax is now in line with Michael Best's suggestion in #421.

fixes #421
