### PR TITLE
Allow newlines in virtual elements

### DIFF
--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -12,7 +12,7 @@
     // So, use node.text where available, and node.nodeValue elsewhere
     var commentNodesHaveTextProperty = document.createComment("test").text === "<!--test-->";
 
-    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko\s+(.*\:.*)\s*-->$/ : /^\s*ko\s+(.*\:.*)\s*$/;
+    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko\s+((?:.|\n)*\:(?:.|\n)*)-->$/ : /^\s*ko\s+((?:.|\n)*\:(?:.|\n)*)$/;
     var endCommentRegex =   commentNodesHaveTextProperty ? /^<!--\s*\/ko\s*-->$/ : /^\s*\/ko\s*$/;
     var htmlTagsWithOptionallyClosingChildren = { 'ul': true, 'ol': true };
 


### PR DESCRIPTION
Currently newlines are allowed only at the very end of the comment (due to `\s*-->$` and `\s*$` in `startCommentRegex`). However, inline newlines can greatly increase readability in some cases, such as for template bindings with long arguments.

The proposed change replaces each `.` with `(?:.|\n)`, but obviously any other "any character" clause would also work. The trailing `\s*`, which previously could have matched a newline followed by any other whitespace, is removed as it no longer serves any purpose.

Allowing newlines in virtual elements is also in agreement with ordinary data-bindings, where newlines in the attribute values to `data-bind` are allowed.
