### PR TITLE
Add ko.asyncComputed shorthand for a minimally-throttled computed

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -108,10 +108,10 @@ asyncTest("Should run evaluator only once when dependencies stop updating for th
 	}, 10);
 });
 
-asyncTest("Should be able to use ko.asyncComputed as a shortcut to create a minimally-throttled computed", function() {
+asyncTest("Should be able to use ko.computedAsync as a shortcut to create a minimally-throttled computed", function() {
 	var evaluationCount = 0,
 		someDependency = ko.observable("Initial value"),
-		asyncComputed = ko.asyncComputed(function() {
+		computedAsync = ko.computedAsync(function() {
 			evaluationCount++;
 			return someDependency();
 		});
@@ -125,11 +125,11 @@ asyncTest("Should be able to use ko.asyncComputed as a shortcut to create a mini
 	equal(evaluationCount, 1, "Should not re-evaluate synchronously when dependencies update");
 
 	// Check it does re-evaluate after a pause
-	equal(asyncComputed(), "Initial value");
+	equal(computedAsync(), "Initial value");
 	stop();
 	setTimeout(function() {
 		start();
 		equal(evaluationCount, 2); // Finally, it's evaluated
-		equal(asyncComputed(), "C");
+		equal(computedAsync(), "C");
 	}, 1);
 });

--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -107,3 +107,29 @@ asyncTest("Should run evaluator only once when dependencies stop updating for th
 		}, 110);
 	}, 10);
 });
+
+asyncTest("Should be able to use ko.asyncComputed as a shortcut to create a minimally-throttled computed", function() {
+	var evaluationCount = 0,
+		someDependency = ko.observable("Initial value"),
+		asyncComputed = ko.asyncComputed(function() {
+			evaluationCount++;
+			return someDependency();
+		});
+
+	// Mutate a few times synchronously
+	start();
+	equal(evaluationCount, 1); // Evaluates synchronously when first created, like all computeds
+	someDependency("A");
+	someDependency("B");
+	someDependency("C");
+	equal(evaluationCount, 1, "Should not re-evaluate synchronously when dependencies update");
+
+	// Check it does re-evaluate after a pause
+	equal(asyncComputed(), "Initial value");
+	stop();
+	setTimeout(function() {
+		start();
+		equal(evaluationCount, 2); // Finally, it's evaluated
+		equal(asyncComputed(), "C");
+	}, 1);
+});

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -50,8 +50,9 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
 
     var evaluationTimeoutInstance = null;
     function evaluatePossiblyAsync() {
-        var throttleEvaluationTimeout = dependentObservable['throttleEvaluation'];
-        if (throttleEvaluationTimeout && throttleEvaluationTimeout >= 0) {
+        var throttleEvaluationTimeout = dependentObservable['throttleEvaluation'],
+            shouldThrottle = typeof throttleEvaluationTimeout == 'number';
+        if (shouldThrottle) {
             clearTimeout(evaluationTimeoutInstance);
             evaluationTimeoutInstance = setTimeout(evaluateImmediate, throttleEvaluationTimeout);
         } else

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -41,4 +41,10 @@ function applyExtenders(requestedExtenders) {
     return target;
 }
 
+// Define ko.asyncComputed as a syntactical shortcut for a minimally-throttled computed
+ko.asyncComputed = function() {
+    return ko.computed.apply(this, arguments).extend({ 'throttle': 0 });
+};
+
 ko.exportSymbol('extenders', ko.extenders);
+ko.exportSymbol('asyncComputed', ko.asyncComputed);

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -41,10 +41,10 @@ function applyExtenders(requestedExtenders) {
     return target;
 }
 
-// Define ko.asyncComputed as a syntactical shortcut for a minimally-throttled computed
-ko.asyncComputed = function() {
+// Define ko.computedAsync as a syntactical shortcut for a minimally-throttled computed
+ko.computedAsync = function() {
     return ko.dependentObservable.apply(this, arguments).extend({ 'throttle': 0 });
 };
 
 ko.exportSymbol('extenders', ko.extenders);
-ko.exportSymbol('asyncComputed', ko.asyncComputed);
+ko.exportSymbol('computedAsync', ko.computedAsync);

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -43,7 +43,7 @@ function applyExtenders(requestedExtenders) {
 
 // Define ko.asyncComputed as a syntactical shortcut for a minimally-throttled computed
 ko.asyncComputed = function() {
-    return ko.computed.apply(this, arguments).extend({ 'throttle': 0 });
+    return ko.dependentObservable.apply(this, arguments).extend({ 'throttle': 0 });
 };
 
 ko.exportSymbol('extenders', ko.extenders);


### PR DESCRIPTION
I've been making lots of use of `.extend({ throttle: 1 })` recently to debounce recomputations during batch operations. Speaking to others at the "Throne of JS" conference last weekend, this seems to be a more common requirement than I realised before. One or two people knew how to use `throttle`, but most said they had never heard of it.

It would be nice to offer a really straightforward way of discovering this functionality we already have. By adding `ko.asyncComputed`, and by documenting it, hopefully people will be more confident in making use of this ability.