### PR TITLE
Added a stringContains method to utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -182,6 +182,11 @@ ko.utils = new (function () {
                 return false;
             return string.substring(0, startsWith.length) === startsWith;
         },
+        
+        stringContains: function (string, contains) {
+            string = string || "";
+            return string.indexOf(contains) != -1;
+        },
 
         buildEvalWithinScopeFunction: function (expression, scopeLevels) {
             // Build the source for a function that evaluates "expression"


### PR DESCRIPTION
Found myself looking for such a method when trying to filter an observableArray. As we have the stringStartsWith method I think this could be a nice addition. Not sure if this should be case-insensitive and in case how this should be implemented.
