### PR TITLE
Enable preprocessing nodes during binding

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -417,5 +417,49 @@ describe('Binding attribute syntax', {
 
         ko.applyBindings({ myObservable: observable }, testNode);
         value_of(hasUpdatedSecondBinding).should_be(true);
+    },
+
+    'Should call bindingProvider preprocess node function if present': function() {
+        var currentBindingProvider = ko.bindingProvider.instance,
+            preprocessingBindingProvider = new ko.bindingProvider(),
+            preprocessedNode;
+
+        preprocessingBindingProvider.preprocessNode = function(node) {
+            preprocessedNode = node;
+        };
+
+        ko.bindingProvider.instance = preprocessingBindingProvider;
+
+        testNode.innerHTML = "<div id='testNode'></div>";
+        ko.applyBindings({ }, testNode);
+
+        ko.bindingProvider.instance = currentBindingProvider
+
+        value_of(preprocessedNode.id).should_be('testNode');
+    },
+
+    'Should use returned node from bindingProvider\'s preprocessNode': function() {
+        var currentBindingProvider = ko.bindingProvider.instance,
+            preprocessingBindingProvider = new ko.bindingProvider(),
+            testInitCalled = false;
+
+        preprocessingBindingProvider.preprocessNode = function(node) {
+            return document.createElement('div');;
+        };
+
+        ko.bindingHandlers.test = {
+            init: function() {
+                testInitCalled = true;
+            }
+        }
+
+        ko.bindingProvider.instance = preprocessingBindingProvider;
+
+        testNode.innerHTML = "<div id='testNode' data-bind='test: true'></div>";
+        ko.applyBindings({ }, testNode);
+
+        ko.bindingProvider.instance = currentBindingProvider
+
+        value_of(testInitCalled).should_be(false);
     }
 });

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -86,6 +86,12 @@
             return parsedBindings;
         }
 
+        var preprocessNode = ko.bindingProvider['instance']['preprocessNode'];
+
+        if (preprocessNode) {
+            node = preprocessNode(node) || node;
+        }
+        
         var bindingHandlerThatControlsDescendantBindings;
         ko.dependentObservable(
             function () {


### PR DESCRIPTION
I have found the need to, from a binding provider, preprocess the nodes that are being bound in a way that cannot currently be done (AFAICT).

To support something akin to the functionality of allowing custom HTML tags as [AngularJS](http://angularjs.org/) does, from a custom binding provider I am using the name of the tag to determine what binding provider to use. This all works fine in most browsers, except in IE < 9, where setting text content and child nodes will not work, requiring the [HTML5 Shiv](https://github.com/aFarkas/html5shiv) to enable this functionality (i.e. I need to create a new element and replace the existing one).

To support this functionality I have made a small addition to the `applyBindingsToNodeInternal` that allows the current `bindingProvider` to preprocess, and potentially replace, the current node:       

``` javascript
var preprocessNode = ko.bindingProvider['instance']['preprocessNode'];

if (preprocessNode) {
    node = preprocessNode(node) || node;
}
```

As it currently stands I have not done extensive testing of how this may affect other parts of knockout, but at the least all current tests pass. I've added a couple of simple tests, but they could probably be expanded on with more scenarios.
