### PR TITLE
Added 'para' binding

### DIFF
--- a/src/binding/defaultBindings.js
+++ b/src/binding/defaultBindings.js
@@ -315,6 +315,33 @@ ko.bindingHandlers['text'] = {
 };
 ko.virtualElements.allowedBindings['text'] = true;
 
+ko.bindingHandlers['para'] = {
+    'init': function () {
+		return { 'controlsDescendantBindings': true };
+	},
+	'update': function (element, valueAccessor) {
+		ko.virtualElements.emptyNode(element);
+
+		var splitParas = ko.utils.unwrapObservable(valueAccessor()).split(/[\r\n]+/);
+
+		var arrayOfNodes = [];
+
+		for (var i = 0; i < splitParas.length; i++) {
+			var paraNode = document.createElement('p');
+			var thisPara = splitParas[i].trim();
+			//Prevent any empty paragraphs
+			if (thisPara === null || thisPara === undefined || thisPara == "") {
+				continue;
+			}
+			ko.utils.setTextContent(paraNode, splitParas[i]);
+			arrayOfNodes.push(paraNode);
+		}
+
+		ko.virtualElements.setDomNodeChildren(element, arrayOfNodes);
+	}
+};
+ko.virtualElements.allowedBindings['para'] = true;
+
 ko.bindingHandlers['html'] = {
     'init': function() {
         // Prevent binding on the dynamically-injected HTML (as developers are unlikely to expect that, and it has security implications)


### PR DESCRIPTION
Added binding that splits large blocks of text on newlines into paragraphs.

Designed to compliment the text binding, which works for short amounts of text.
