### PR TITLE
Containerless control comments with line-breaks are not recognized.

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -287,9 +287,9 @@ describe('Binding attribute syntax', {
                              "        }\n" +
                              "   \t --><span data-bind='text: personName'></span><!-- \n" +
                              "     /ko \n" +
-                             "--> Goodbye";
+                             "-->, Goodbye";
         ko.applyBindings(null, testNode);
-        value_of(testNode).should_contain_text('Hello Bert Goodbye');
+        value_of(testNode).should_contain_text('Hello Bert, Goodbye');
     },
 
     'Should be able to access virtual children in custom containerless binding': function() {

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -751,6 +751,19 @@ describe('Templating', {
         });
     },
 
+    'Data binding syntax should permit nested templates using virtual containers (with arbitrary internal whitespace and newlines)': function() {
+        ko.setTemplateEngine(new dummyTemplateEngine({
+            outerTemplate: "Outer <!-- ko template: \n" +
+                "{ name: \"innerTemplate\" } \n" +
+                "--><!-- /ko -->",
+            innerTemplate: "Inner via inline binding: <span data-bind='text: \"someText\"'></span>"
+        }));
+        var model = { };
+        testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\" }'></div>";
+        ko.applyBindings(model, testNode);
+        value_of(testNode.childNodes[0]).should_contain_html("outer <!-- ko -->inner via inline binding: <span>sometext</span><!-- /ko -->");
+    },
+
     'Should be able to render anonymous templates using virtual containers': function() {
         ko.setTemplateEngine(new dummyTemplateEngine());
         testNode.innerHTML = "Start <!-- ko template: { data: someData } -->Childprop: [js: childProp]<!-- /ko --> End";

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -12,7 +12,7 @@
     // So, use node.text where available, and node.nodeValue elsewhere
     var commentNodesHaveTextProperty = document.createComment("test").text === "<!--test-->";
 
-    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko\s+(.+\s*\:[\s\S]*)\s*-->$/ : /^\s*ko\s+(.+\s*\:[\s\S]*)\s*$/;
+    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko(?:\s+(.+\s*\:[\s\S]*))?\s*-->$/ : /^\s*ko(?:\s+(.+\s*\:[\s\S]*))?\s*$/;
     var endCommentRegex =   commentNodesHaveTextProperty ? /^<!--\s*\/ko\s*-->$/ : /^\s*\/ko\s*$/;
     var htmlTagsWithOptionallyClosingChildren = { 'ul': true, 'ol': true };
 


### PR DESCRIPTION
Because the start comment test RegExp uses `.*`, it will not match over a line-break.

Rather than `.*`, can `[\s\S]*` or similar be used in its place so that multi-line comments still invoke container control flow?

This would greatly improve readability when mapping child template data for reusable templates, e.g.:

``` html
<!-- ko template : {
    name: 'reusable-template',
    data: {
        templateVar1: scopeVar,
        templateVar2: etc
    }
} --> <!-- /ko -->
```

rather than

``` html
<!-- ko template : { name: 'reusable-template', data: { templateVar1: scopeVar, templateVar2: etc } } --> <!-- /ko -->
```
