### PR TITLE
Replace stringTrimRegexp with a shorter and faster variant

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,4 @@
 ko.utils = (function () {
-    var stringTrimRegex = /^[\s\xa0]+|[\s\xa0]+$/g;
-
     var objectForEach = function(obj, action) {
         for (var prop in obj) {
             if (obj.hasOwnProperty(prop)) {
@@ -192,7 +190,10 @@ ko.utils = (function () {
         },
 
         stringTrim: function (string) {
-            return (string || "").replace(stringTrimRegex, "");
+            return string === null || string === undefined ? '' :
+                string.trim ?
+                    string.trim() :
+                    string.toString().replace(/^[\s\xa0]+|[\s\xa0]+$/g, '');
         },
 
         stringTokenize: function (string, delimiter) {


### PR DESCRIPTION
1) Don't use unnecessary captures.
2) Use character classes instead of alternations.
3) Replace \u00a0 with \xa0 (saves 4 bytes).

According to http://jsperf.com/char-class-vs-alt this is 55% faster in IE7, 61% faster in Chrome 19, and a whopping 1840% faster in Firefox 11.
