### PR TITLE
Broken build instructions for Mac?

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can [download released versions of Knockout](https://github.com/SteveSanders
 
 Or, if you prefer to build the source yourself, clone the repo from Github, and then:
 
-* To build on Linux or Mac, run `build/build-linux`
+* To build on Linux or Mac, run `cd build` then `./build-linux`
 * To build on Windows, run `build\build-windows.bat`
 
 ##License


### PR DESCRIPTION
I cloned a fork to investigate on #592 and followed the instructions on the readme:

> To build on Linux or Mac, run `build/build-linux`

but doing so gave me:

```
build/build-linux: line 8: tools/check-trailing-space-linux: No such file or directory
```

if then I do `cd build` then the build seems to succeed.

Should we update the doc to say run `cd build && ./build-linux`?
