### PR TITLE
[#650] Export ko.bindingContext() constructor

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -197,6 +197,7 @@
         return context ? context['$data'] : undefined;
     };
 
+    ko.exportSymbol('bindingContext', ko.bindingContext);
     ko.exportSymbol('bindingHandlers', ko.bindingHandlers);
     ko.exportSymbol('applyBindings', ko.applyBindings);
     ko.exportSymbol('applyBindingsToDescendants', ko.applyBindingsToDescendants);


### PR DESCRIPTION
Fixes issue #650.

Exports the ko.bindingContext() constructor so there is a way to create bindingContexts from scratch.
