### PR TITLE
Problem setting domnode value in IE 9

### DIFF
--- a/src/utils.domData.js
+++ b/src/utils.domData.js
@@ -19,7 +19,7 @@ ko.utils.domData = new (function () {
         },
         getAll: function (node, createIfNotFound) {
             var dataStoreKey = node[dataStoreKeyExpandoPropertyName];
-            var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null");
+            var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null") && dataStore[dataStoreKey];
             if (!hasExistingDataStore) {
                 if (!createIfNotFound)
                     return undefined;


### PR DESCRIPTION
I have an application using knockout and jquery. Sometimes, when rerendering the view because an observable changed, I get an error like this:
SCRIPT5007: Unable to set value of the property '__ko_domNodeDisposal__1328878784312': object is null or undefined 
knockout-2.0.0.debug.js, line 474 character 13

I only get this in IE 9 (maybe also earlier) but not in Firefox or Chrome.

I can fix it if I change this line: 
var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null");
into:
var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null") && dataStore[dataStoreKey];

Everything seems to work then. But since the clear function seems to clear both the datastorekey and the value in the datastore at the same time, I can't figure out what is happening...
