### PR TITLE
Regression with jquery.tmpl

### DIFF
--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -30,7 +30,7 @@ ko.templateRewriting = (function () {
         // anonymous function, even though Opera's built-in debugger can evaluate it anyway. No other browser requires this
         // extra indirection.
         var applyBindingsToNextSiblingScript =
-            "ko.__tr_ambtns(function(){return(function(){return{" + rewrittenDataBindAttributeValue + "} })()})";
+            "ko.__tr_ambtns(function(){return(function(){return{ " + rewrittenDataBindAttributeValue + " } })()})";
         return templateEngine['createJavaScriptEvaluatorBlock'](applyBindingsToNextSiblingScript) + tagToRetain;
     }
 


### PR DESCRIPTION
I have a template that causes jquery.tmpl to fail, complaining about "invalid token )". The template that is being parsed by jquery.tmpl looks like this:

The problem occurs because this templateText is passed on to jquery.tmpl to evaluate, and it is invalid javascript:

``` javascript
var $ = jQuery,
  call, __ = [],
  $data = $item.data;
with($data) {
  __.push('');
  with($item.koBindingContext) {
    __.push(' <div class="ui-widget ui-corner-all">   ');
    if ((typeof (headerTemplate) !== 'undefined' && (headerTemplate) != null) && (headerTemplate).call($item)) {
      __.push('     ');
      __.push(((function () {
        return ko.__tr_ambtns(function () {
          return (function () {
            return {
              'template': {
                name: headerTemplate(),
                data: header || '');
              __.push(' })()}) })()) }}<div class="ui-widget-header ui-helper-clearfix" />   ');
            }
            __.push('   ');
            __.push(((function () {
              return ko.__tr_ambtns(function () {
                return (function () {
                  return {
                    'template': {
                      name: tableTemplate() || '');
                    __.push(' })()}) })()) }}<div class="ui-widget-content"         />   ');
                    if ((typeof (footerTemplate) !== 'undefined' && (footerTemplate) != null) && (footerTemplate).call($item)) {
                      __.push('     ');
                      __.push(((function () {
                        return ko.__tr_ambtns(function () {
                          return (function () {
                            return {
                              'template': {
                                name: footerTemplate(),
                                data: footer || '');
                              __.push(' })()}) })()) }}<div class="ui-widget-header ui-helper-clearfix" />   ');
                            }
                            __.push(' </div> ');
                          }
                          __.push('');
                          }
                          return __;
```
