### PR TITLE
setDomNodeChildrenFromArrayMapping should remove nodes before add/reorder

### DIFF
--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -155,6 +155,9 @@
         // Call beforeMove first before any changes have been made to the DOM
         callCallback(options['beforeMove'], itemsForMoveCallbacks);
 
+        // Next remove nodes for deleted items (or just clean if there's a beforeRemove callback)
+        ko.utils.arrayForEach(nodesToDelete, options['beforeRemove'] ? ko.cleanNode : ko.removeNode);
+
         // Next add/reorder the remaining items (will include deleted items if there's a beforeRemove callback)
         for (var i = 0, nextNode = ko.virtualElements.firstChild(domNode), lastNode, node; mapData = itemsToProcess[i]; i++) {
             // Get nodes for newly added items
@@ -174,8 +177,11 @@
             }
         }
 
-        // Next remove nodes for deleted items; or call beforeRemove, which will remove them
-        ko.utils.arrayForEach(nodesToDelete, options['beforeRemove'] ? ko.cleanNode : ko.removeNode);
+        // If there's a beforeRemove callback, call it after reordering.
+        // Note that we assume that the beforeRemove callback will usually be used to remove the nodes using
+        // some sort of animation, which is why we first reorder the nodes that will be removed. If the
+        // callback instead removes the nodes right away, it would be more efficient to skip reordering them.
+        // Perhaps we'll make that change in the future if this scenario becomes more common.
         callCallback(options['beforeRemove'], itemsForBeforeRemoveCallbacks);
 
         // Finally call afterMove and afterAdd callbacks


### PR DESCRIPTION
I had [originally done it before](https://github.com/SteveSanderson/knockout/blob/33cecba029cbcfbc8b79d6f9e4f90dbcefc3eeb4/src/binding/editDetection/arrayToDomNodeChildren.js#L158), but then found a problem with the `beforeRemove` callback. If the callback removed the nodes right away, they would added back by the add/reorder loop. To solve this problem, I [moved the remove code to after the add/reorder code](https://github.com/SteveSanderson/knockout/commit/1841cdb202207259cdee0dfef8af29d806bfbf63).

But as @jpa00 [pointed out](https://github.com/SteveSanderson/knockout/pull/259#issuecomment-9258367), this change causes performance problems that didn't exist before. The fix is to move the first line that calls `removeNode` or `cleanNode` to before the add/reorder loop, and keep the second line that calls the `beforeRemove` callback after.
