### PR TITLE
hasfocus fix for focussing hidden elements (focus asynchronously)

### DIFF
--- a/src/binding/defaultBindings/hasfocus.js
+++ b/src/binding/defaultBindings/hasfocus.js
@@ -28,7 +28,12 @@ ko.bindingHandlers['hasfocus'] = {
     'update': function(element, valueAccessor) {
         if (!element[hasfocusUpdatingProperty]) {
             var value = ko.utils.unwrapObservable(valueAccessor());
-            value ? element.focus() : element.blur();
+            var doUpdate = function(){value ? element.focus() : element.blur()}; 
+            if (element.offsetWidth === 0) {
+                setTimeout(doUpdate);
+            } else {
+                doUpdate();
+            }
             ko.dependencyDetection.ignore(ko.utils.triggerEvent, null, [element, value ? "focusin" : "focusout"]); // For IE, which doesn't reliably fire "focus" or "blur" events synchronously
         }
     }


### PR DESCRIPTION
Check it out here: http://jsfiddle.net/mhrf2/

I'm not really sure if this opens up for race conditions; but it is better than now, at least.
