### PR TITLE
Make buildEvalWithinScopeFunction() work with AMD-knockout

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -184,14 +184,16 @@ ko.utils = new (function () {
         },
 
         buildEvalWithinScopeFunction: function (expression, scopeLevels) {
-            // Build the source for a function that evaluates "expression"
+            // Build a scoped expression that evaluates "expression"
             // For each scope variable, add an extra level of "with" nesting
-            // Example result: with(sc[1]) { with(sc[0]) { return (expression) } }
-            var functionBody = "return (" + expression + ")";
+            // Example result: with(sc[1]) { with(sc[0]) { (expression) } }
+            var expressionBody = "(" + expression + ")";
             for (var i = 0; i < scopeLevels; i++) {
-                functionBody = "with(sc[" + i + "]) { " + functionBody + " } ";
+                expressionBody = "with(sc[" + i + "]) { " + expressionBody + " } ";
             }
-            return new Function("sc", functionBody);
+            return function (sc) {
+                return eval(expressionBody);
+            };
         },
 
         domNodeIsContainedBy: function (node, containedByNode) {


### PR DESCRIPTION
I tried using [Ryan's advice](http://stackoverflow.com/questions/9261296/any-good-techniques-to-debug-template-binding-faults-for-knockout-js) to debug some bindings in a project RequireJS to load Knockout, and got a 'ko is undefined' error. I found the reason to be that Knockout's buildEvalWithinScopeFunction() uses the Function construcor to create an evaluator for the binding expression: that means it gets evaluated in the global scope, which in my AMD environment did not contain the ko variable. In contrast, using eval() allows the evaluator function to be defined normally and run in the local scope, where ko is accessible as a loaded AMD module. I altered the function as in this commit and got binding expressions referring to ko working. Not sure if this has performance or other important implications.

There seem to be some similarities with this issue and issue #490.
