### PR TITLE
Event binding init fails if Object prototype is extended

### DIFF
--- a/spec/defaultBindings/eventBehaviors.js
+++ b/spec/defaultBindings/eventBehaviors.js
@@ -87,5 +87,24 @@ describe('Binding: Event', {
         ko.applyBindings(viewModel, testNode);
         ko.utils.triggerEvent(testNode.childNodes[0], "mouseover");
         value_of(didCallHandler).should_be(true);
+    },
+
+    'Should skip properties added to Object.prototype when looping on the supplied events': function() {
+        //add an extra property to Object.prototype
+        Object.prototype.someExtraMethod = function() { };
+
+        var didCallHandler = false;
+        var myHandler = function() {
+            didCallHandler = true;
+        };
+
+        testNode.innerHTML = "<button data-bind='event:{ mouseover: myHandler }'>hey</button>";
+        var viewModel = { myHandler: myHandler };
+        ko.applyBindings(viewModel, testNode);
+        ko.utils.triggerEvent(testNode.childNodes[0], "mouseover");
+        value_of(didCallHandler).should_be(true);
+
+        //remove the extra property
+        delete Object.prototype.someExtraMethod;
     }
 });

--- a/src/binding/defaultBindings/event.js
+++ b/src/binding/defaultBindings/event.js
@@ -17,39 +17,41 @@ ko.bindingHandlers['event'] = {
     'init' : function (element, valueAccessor, allBindingsAccessor, viewModel) {
         var eventsToHandle = valueAccessor() || {};
         for(var eventNameOutsideClosure in eventsToHandle) {
-            (function() {
-                var eventName = eventNameOutsideClosure; // Separate variable to be captured by event handler closure
-                if (typeof eventName == "string") {
-                    ko.utils.registerEventHandler(element, eventName, function (event) {
-                        var handlerReturnValue;
-                        var handlerFunction = valueAccessor()[eventName];
-                        if (!handlerFunction)
-                            return;
-                        var allBindings = allBindingsAccessor();
+            if (eventsToHandle.hasOwnProperty(eventNameOutsideClosure)) {
+                (function() {
+                    var eventName = eventNameOutsideClosure; // Separate variable to be captured by event handler closure
+                    if (typeof eventName == "string") {
+                        ko.utils.registerEventHandler(element, eventName, function (event) {
+                            var handlerReturnValue;
+                            var handlerFunction = valueAccessor()[eventName];
+                            if (!handlerFunction)
+                                return;
+                            var allBindings = allBindingsAccessor();
 
-                        try {
-                            // Take all the event args, and prefix with the viewmodel
-                            var argsForHandler = ko.utils.makeArray(arguments);
-                            argsForHandler.unshift(viewModel);
-                            handlerReturnValue = handlerFunction.apply(viewModel, argsForHandler);
-                        } finally {
-                            if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
-                                if (event.preventDefault)
-                                    event.preventDefault();
-                                else
-                                    event.returnValue = false;
+                            try {
+                                // Take all the event args, and prefix with the viewmodel
+                                var argsForHandler = ko.utils.makeArray(arguments);
+                                argsForHandler.unshift(viewModel);
+                                handlerReturnValue = handlerFunction.apply(viewModel, argsForHandler);
+                            } finally {
+                                if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
+                                    if (event.preventDefault)
+                                        event.preventDefault();
+                                    else
+                                        event.returnValue = false;
+                                }
                             }
-                        }
 
-                        var bubble = allBindings[eventName + 'Bubble'] !== false;
-                        if (!bubble) {
-                            event.cancelBubble = true;
-                            if (event.stopPropagation)
-                                event.stopPropagation();
-                        }
-                    });
-                }
-            })();
+                            var bubble = allBindings[eventName + 'Bubble'] !== false;
+                            if (!bubble) {
+                                event.cancelBubble = true;
+                                if (event.stopPropagation)
+                                    event.stopPropagation();
+                            }
+                        });
+                    }
+                })();
+            }
         }
     }
 };


### PR DESCRIPTION
Inside the init function of the event binding handler the for loops over the event names in eventsToHandle, but it picks up extra functions from the object prototype and attempts to register as an event handler.

JQuery throws exception : Uncaught TypeError: [Method Code] has no method 'push'

jsFiddle to replicate : http://jsfiddle.net/slaneyrw/S6VaW/9/

Potential resolution: Need to check if the eventsTohandle "owns" the event name or if it comes from the prototype chain.

see discussion https://groups.google.com/forum/?fromgroups=#!topic/knockoutjs/ixlSf_qg1BE for more information
