### PR TITLE
Fix for dragging and dropping text in Firefox

### DIFF
--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -1,7 +1,7 @@
 ko.bindingHandlers['value'] = {
     'init': function (element, valueAccessor, allBindingsAccessor) {
         // Always catch "change" event; possibly other events too if asked
-        var eventsToCatch = ["change"];
+        var eventsToCatch = ["change", "input"];
         var requestedEventsToCatch = allBindingsAccessor()["valueUpdate"];
         var propertyChangedFired = false;
         if (requestedEventsToCatch) {


### PR DESCRIPTION
Pretty simple fix to listen for the "input" event for the value binding as well as the "change" event.
