### PR TITLE
Fix javaScriptAssignmentTarget regular expression

### DIFF
--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -4,7 +4,7 @@ ko.expressionRewriting = (function () {
 
     // Matches something that can be assigned to--either an isolated identifier or something ending with a property accessor
     // This is designed to be simple and avoid false negatives, but could produce false positives (e.g., a+b.c).
-    var javaScriptAssignmentTarget = /^(?:[$_a-z][$\w]*|(.+)(\.\s*[$_a-z][$\w]*|\[.+\]))$/i;
+    var javaScriptAssignmentTarget = /^(?:[$_a-z][$\w]*|(.+?)(\.\s*[$_a-z][$\w]*|\[.+\]))$/i;
 
     function restoreTokens(string, tokens) {
         var prevValue = null;


### PR DESCRIPTION
old re fail to parse expressions like this: VG[foo['param']]