### PR TITLE
Issue with asynchronous load of options and a caption

### DIFF
--- a/build/output/knockout-latest.debug.js
+++ b/build/output/knockout-latest.debug.js
@@ -1450,7 +1450,10 @@ ko.exportSymbol('toJSON', ko.toJSON);
                         ? (element.getAttributeNode('value').specified ? element.value : element.text)
                         : element.value;
                 case 'select':
-                    return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
+					var value = element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
+					if (element.selectedIndex == 0 && element.options.length == 1 && value == null)
+						return undefined;
+                    return value;
                 default:
                     return element.value;
             }
@@ -2504,7 +2507,7 @@ ko.bindingHandlers['options'] = {
             if (allBindings['optionsCaption']) {
                 var option = document.createElement("option");
                 ko.utils.setHtml(option, allBindings['optionsCaption']);
-                ko.selectExtensions.writeValue(option, undefined);
+                ko.selectExtensions.writeValue(option, null);
                 element.appendChild(option);
             }
 

--- a/build/output/knockout-latest.debug.js
+++ b/build/output/knockout-latest.debug.js
@@ -1,4 +1,4 @@
-// Knockout JavaScript library v2.2.0
+// Knockout JavaScript library v##VERSION##
 // (c) Steven Sanderson - http://knockoutjs.com/
 // License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
@@ -37,7 +37,7 @@ ko.exportSymbol = function(koPath, object) {
 ko.exportProperty = function(owner, publicName, object) {
   owner[publicName] = object;
 };
-ko.version = "2.2.0";
+ko.version = "##VERSION##";
 
 ko.exportSymbol('version', ko.version);
 ko.utils = new (function () {
@@ -2649,7 +2649,8 @@ ko.bindingHandlers['value'] = {
             propertyChangedFired = false;
             var modelValue = valueAccessor();
             var elementValue = ko.selectExtensions.readValue(element);
-            ko.expressionRewriting.writeValueToProperty(modelValue, allBindingsAccessor, 'value', elementValue);
+			if (elementValue !== undefined)
+				ko.expressionRewriting.writeValueToProperty(modelValue, allBindingsAccessor, 'value', elementValue);
         }
 
         // Workaround for https://github.com/SteveSanderson/knockout/issues/122

--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -216,7 +216,7 @@ describe('Binding: Value', {
         value_of(testNode.childNodes[0].selectedIndex).should_be(0);
     },
 
-    'For select boxes, should update the model value when the UI is changed (setting it to undefined when the caption is selected)': function () {
+    'For select boxes, should update the model value when the UI is changed (setting it to null when the caption is selected)': function () {
         var observable = new ko.observable('B');
         testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], optionsCaption:\"Select...\", value:myObservable'></select>";
         ko.applyBindings({ myObservable: observable }, testNode);
@@ -228,7 +228,7 @@ describe('Binding: Value', {
 
         dropdown.selectedIndex = 0;
         ko.utils.triggerEvent(dropdown, "change");
-        value_of(observable()).should_be(undefined);
+        value_of(observable()).should_be(null);
     },
 
     'For select boxes, should be able to associate option values with arbitrary objects (not just strings)': function() {

--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -43,7 +43,7 @@ ko.bindingHandlers['options'] = {
             if (allBindings['optionsCaption']) {
                 var option = document.createElement("option");
                 ko.utils.setHtml(option, allBindings['optionsCaption']);
-                ko.selectExtensions.writeValue(option, undefined);
+                ko.selectExtensions.writeValue(option, null);
                 element.appendChild(option);
             }
 

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -15,7 +15,8 @@ ko.bindingHandlers['value'] = {
             propertyChangedFired = false;
             var modelValue = valueAccessor();
             var elementValue = ko.selectExtensions.readValue(element);
-            ko.expressionRewriting.writeValueToProperty(modelValue, allBindingsAccessor, 'value', elementValue);
+			if (elementValue !== undefined)
+				ko.expressionRewriting.writeValueToProperty(modelValue, allBindingsAccessor, 'value', elementValue);
         }
 
         // Workaround for https://github.com/SteveSanderson/knockout/issues/122

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -14,7 +14,10 @@
                         ? (element.getAttributeNode('value').specified ? element.value : element.text)
                         : element.value;
                 case 'select':
-                    return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
+					var value = element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
+					if (element.selectedIndex == 0 && element.options.length == 1 && value == null)
+						return undefined;
+                    return value;
                 default:
                     return element.value;
             }


### PR DESCRIPTION
I have an issue in knockout where the "value" binding for a select is ready before the "options", so knockout sets the value to the caption's _undefined_.
In the production system I'm working on, we've created a custom "nonNullableObservable" that prevents writing _null_ or _undefined_ to the observable, in order to prevent this from happening, but the ideal would be to use an official solution as part of the framework.
The issue is easily reproduced: http://jsfiddle.net/IanYates83/QQNG8/
(Due to work limitations, I have only currently tested this in IE8)

I tried to keep the fix to as few changes as possible, however there may be some unintended consequences that I'm not aware of. We use KO pretty extensively, and everything else is working for us.
Since the issue is the framework taking the caption value as it is the only correct option at the time of binding, I changed "readValue" in selectExtensions to return _undefined_ if the caption is selected and the only possible value - making the assumption that if the model has a value, there must have been some legitimate options.

By changing the caption value to _null_ in order to be able to single out _undefined_ as an unprocessed value, potentially this could be a breaking change, although _undefined_ shouldn't come from any UI element as a legitimate user input.

The same example using my modified code: http://jsfiddle.net/IanYates83/QQNG8/2/

Apologies for not doing a complete build, but I can't access appspot and thus closure-compiler from work.