### PR TITLE
Empty text node optimization

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -129,7 +129,14 @@ ko.utils = new (function () {
 
             var container = document.createElement('div');
             for (var i = 0, j = nodesArray.length; i < j; i++) {
-                container.appendChild(ko.cleanNode(nodesArray[i]));
+                var node = nodesArray[i];
+                var isEmptyTextNode = (node.nodeType == 3 && node.textContent.trim() == '');
+
+                // Skip empty text nodes; Some browsers are slow at appending such nodes.
+                if (isEmptyTextNode)
+                    node.parentNode.removeChild(node);
+                else 
+                    container.appendChild(ko.cleanNode(node));  
             }
             return container;
         },


### PR DESCRIPTION
Some browsers (e.g Chrome 23) are very slow at rendering empty text nodes added by ko (They seem to always be present when reading the childNodes property). A foreach binding with an anonymous template with just one **li** ends up appending 3 nodes per item:  text, li, text. Some browsers render this in about as much time as a single li, some others render it very slowly (About 3 times more than expected). The difference in speed is really noticeable when the number of items is moderate or high. 

This commit ignores the empty text nodes so that foreach is constantly fast.

Note that there will usually be further empty text nodes nested in the template markup but it doesn't incur a performance penalty as these don't get explicitly appended to the DOM by ko.
