### PR TITLE
Fixes error in chrome when you try to inline knockout in your page

### DIFF
--- a/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
+++ b/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
@@ -57,7 +57,7 @@
         };
 
         this['addTemplate'] = function(templateName, templateMarkup) {
-            document.write("<script type='text/html' id='" + templateName + "'>" + templateMarkup + "</script>");
+            document.write("<script type='text/html' id='" + templateName + "'>" + templateMarkup + "<" + "/script>");
         };
 
         if (jQueryTmplVersion > 0) {


### PR DESCRIPTION
Hello,
Came across this whilst trying to inline knockout (for a single file web app).

Error: "Uncaught SyntaxError: Unexpected token ILLEGAL"
Reproduce by just pasting knockout code into a script tag in a page and
viewing.
Caused by the script tag in a string
Changed to "<" + "/script>"

Silly I know. Thanks!
