### PR TITLE
fix specs that fail in IE because of sync issues

### DIFF
--- a/spec/defaultBindings/hasfocusBehaviors.js
+++ b/spec/defaultBindings/hasfocusBehaviors.js
@@ -1,5 +1,6 @@
 describe('Binding: Hasfocus', function() {
     beforeEach(jasmine.prepareTestNode);
+    beforeEach(function() { waits(1); }); // Workaround for spurious focus-timing-related failures on IE8 (issue #736)
 
     it('Should respond to changes on an observable value by blurring or focusing the element', function() {
         var currentState;

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -70,7 +70,7 @@
         <script type="text/javascript">
           (function() {
             var jasmineEnv = jasmine.getEnv();
-            jasmineEnv.updateInterval = 100;
+            jasmineEnv.updateInterval = 500;
 
             var htmlReporter = new jasmine.HtmlReporter();
             jasmineEnv.addReporter(htmlReporter);


### PR DESCRIPTION
When testing on IE8, I found some specs that were failing sometimes because of sync issues. Hopefully this will fix them.
