### PR TITLE
Allow observables to be directly passed to template.name

### DIFF
--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -184,7 +184,7 @@
 
             if (typeof templateName != "string") {
                 options = templateName;
-                templateName = options['name'];
+                templateName = ko.utils.unwrapObservable(options['name']);
 
                 // Support "if"/"ifnot" conditions
                 if ('if' in options)


### PR DESCRIPTION
Per http://www.knockmeout.net/2011/03/quick-tip-dynamically-changing.html , template: {name} binding has to be wrapped in an anonymous function to use observables.

This patch means instead of
`<div data-bind="template: { name: function() { return selectedView(); }, data: obj }"></div>`
you can just use
`<div data-bind="template: { name: selectedView, data: obj }"></div>`

The 'old way', functions and plain strings still work as before
