### PR TITLE
SelectedOptions binding not updating non-observable properties

### DIFF
--- a/spec/defaultBindings/selectedOptionsBehaviors.js
+++ b/spec/defaultBindings/selectedOptionsBehaviors.js
@@ -46,6 +46,32 @@ describe('Binding: Selected Options', function() {
         expect(selection()[1] === cObject).toEqual(true); // Also check with strict equality, because we don't want to falsely accept [object Object] == cObject
     });
 
+    it('Should update the model when selection in the SELECT node changes for non-observable property values', function () {
+        function setMultiSelectOptionSelectionState(optionElement, state) {
+            // Workaround an IE 6 bug (http://benhollis.net/experiments/browserdemos/ie6-adding-options.html)
+            if (/MSIE 6/i.test(navigator.userAgent))
+                optionElement.setAttribute('selected', state);
+            else
+                optionElement.selected = state;
+        }
+
+        var cObject = {};
+        var values = new ko.observableArray(["A", "B", cObject]);
+        var selection = ["B"];
+        var myModel = { myValues: values, mySelection: selection };
+        testNode.innerHTML = "<select multiple='multiple' data-bind='options:myValues, selectedOptions:mySelection'></select>";
+        ko.applyBindings(myModel, testNode);
+
+        expect(myModel.mySelection).toEqual(["B"]);
+        setMultiSelectOptionSelectionState(testNode.childNodes[0].childNodes[0], true);
+        setMultiSelectOptionSelectionState(testNode.childNodes[0].childNodes[1], false);
+        setMultiSelectOptionSelectionState(testNode.childNodes[0].childNodes[2], true);
+        ko.utils.triggerEvent(testNode.childNodes[0], "change");
+
+        expect(myModel.mySelection).toEqual(["A", cObject]);
+        expect(myModel.mySelection[1] === cObject).toEqual(true); // Also check with strict equality, because we don't want to falsely accept [object Object] == cObject
+    });
+
     it('Should update the model when selection in the SELECT node inside an optgroup changes', function () {
         function setMultiSelectOptionSelectionState(optionElement, state) {
             // Workaround an IE 6 bug (http://benhollis.net/experiments/browserdemos/ie6-adding-options.html)

--- a/src/binding/defaultBindings/selectedOptions.js
+++ b/src/binding/defaultBindings/selectedOptions.js
@@ -6,7 +6,7 @@ ko.bindingHandlers['selectedOptions'] = {
                 if (node.selected)
                     valueToWrite.push(ko.selectExtensions.readValue(node));
             });
-            ko.expressionRewriting.writeValueToProperty(value, allBindingsAccessor, 'value', valueToWrite);
+            ko.expressionRewriting.writeValueToProperty(value, allBindingsAccessor, 'selectedOptions', valueToWrite);
         });
     },
     'update': function (element, valueAccessor) {


### PR DESCRIPTION
When you bind to a non-observable javascript property with the "selectedOptions" binding the value of the property is not updating when you change selection. As opposed to binding with a "value" binding.

Look at this JsFiddle http://jsfiddle.net/angelyordanov/6MCzp/.
1) Click the "check" button to see what's the current model state.
2) Change the selection in both selects.
3) Click again the button to see that just the "value" is correctly updated.

This is a minor issue. And the fix is even minor. I tracked the offending line back to the initial commit so i'm not sure if its actually a bug.

I've updated the specs too.
