### PR TITLE
Binding provider rethrow in DEBUG mode

### DIFF
--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -36,6 +36,7 @@
                 var bindingFunction = createBindingsStringEvaluatorViaCache(bindingsString, this.bindingCache);
                 return bindingFunction(bindingContext, node);
             } catch (ex) {
+                if (DEBUG) throw ex;
                 throw new Error("Unable to parse bindings.\nMessage: " + ex + ";\nBindings value: " + bindingsString);
             }
         }


### PR DESCRIPTION
When building a page we typically use Knockout in `DEBUG` mode. When there are parse binding failures, currently it throws an `Error` exception which removes the stack trace, which can make it fairly tricky to find where the binding failure occured.

This pull request disables this behavior in `DEBUG` mode and lets the exception propagate by rethrowing.

The original binding failure message is not shown (mainly because I wasn't sure how to do that cleanly since the rest of Knockout doesn't use `console` anywhere, for instance).
