### PR TITLE
css binding doesn't work with class names with slashes, etc. in 2.2

### DIFF
--- a/spec/defaultBindings/cssBehaviors.js
+++ b/spec/defaultBindings/cssBehaviors.js
@@ -49,4 +49,15 @@ describe('Binding: CSS class name', function() {
         observable1(undefined);
         expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
     });
+
+    it('Should work with any arbitrary class names', function() {
+        // See https://github.com/SteveSanderson/knockout/issues/704
+        var observable1 = new ko.observable();
+        testNode.innerHTML = "<div data-bind='css: { \"complex/className complex.className\" : someModelProperty }'>Something</div>";
+        ko.applyBindings({ someModelProperty: observable1 }, testNode);
+
+        expect(testNode.childNodes[0].className).toEqual("");
+        observable1(true);
+        expect(testNode.childNodes[0].className).toEqual("complex/className complex.className");
+    });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,6 +105,17 @@ ko.utils = new (function () {
             return array;
         },
 
+        addOrRemoveItem: function(array, value, included) {
+            var existingEntryIndex = array.indexOf ? array.indexOf(value) : utils.arrayIndexOf(array, value);
+            if (existingEntryIndex < 0) {
+                if (included)
+                    array.push(value);
+            } else {
+                if (!included)
+                    array.splice(existingEntryIndex, 1);
+            }
+        },
+
         extend: function (target, source) {
             if (source) {
                 for(var prop in source) {
@@ -288,17 +299,10 @@ ko.utils = new (function () {
 
         toggleDomNodeCssClass: function (node, classNames, shouldHaveClass) {
             if (classNames) {
-                var cssClassNameRegex = /[\w-]+/g,
+                var cssClassNameRegex = /\S+/g,
                     currentClassNames = node.className.match(cssClassNameRegex) || [];
                 ko.utils.arrayForEach(classNames.match(cssClassNameRegex), function(className) {
-                    var indexOfClass = ko.utils.arrayIndexOf(currentClassNames, className);
-                    if (indexOfClass >= 0) {
-                        if (!shouldHaveClass)
-                            currentClassNames.splice(indexOfClass, 1);
-                    } else {
-                        if (shouldHaveClass)
-                            currentClassNames.push(className);
-                    }
+                    ko.utils.addOrRemoveItem(currentClassNames, className, shouldHaveClass);
                 });
                 node.className = currentClassNames.join(" ");
             }


### PR DESCRIPTION
See https://groups.google.com/d/topic/knockoutjs/5TLU9hqEqtE/discussion

Previously we had been able to use complex css class names in the css binding, like so

```
<div class="box" data-bind="css: { 'complex/className' : someBoolean() }">
    Dom element with breaking binding
</div>​
```

[Fiddle (2.1, working)](http://jsfiddle.net/allen/MRAx3/)

Now, the class name that is applied is `complex className`

[Fiddle (2.2, not working)](http://jsfiddle.net/allen/MRAx3/1/)
