### PR TITLE
Knockout overwrites computed observable

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -80,6 +80,21 @@ describe('Binding: Value', function() {
         expect(isValid()).toEqual(true);
     });
 
+    it('Should ignore node changes when bound to a read-only observable', function() {
+        var computedValue = ko.computed(function() { return 'zzz' });
+        var vm = { prop: computedValue };
+
+        testNode.innerHTML = "<input data-bind='value: prop' />";
+        ko.applyBindings(vm, testNode);
+        expect(testNode.childNodes[0].value).toEqual("zzz");
+
+        // Change the input value and trigger change event; verify that the view model wasn't changed
+        testNode.childNodes[0].value = "yyy";
+        ko.utils.triggerEvent(testNode.childNodes[0], "change");
+        expect(vm.prop).toEqual(computedValue);
+        expect(computedValue()).toEqual('zzz');
+    });
+
     it('For non-observable property values, should catch the node\'s onchange and write values back to the property', function () {
         var model = { modelProperty123: 456 };
         testNode.innerHTML = "<input data-bind='value: modelProperty123' />";

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -177,11 +177,11 @@ ko.expressionRewriting = (function () {
         // checkIfDifferent:    If true, and if the property being written is a writable observable, the value will only be written if
         //                      it is !== existing value on that writable observable
         writeValueToProperty: function(property, allBindingsAccessor, key, value, checkIfDifferent) {
-            if (!property || !ko.isWriteableObservable(property)) {
+            if (!property || !ko.isObservable(property)) {
                 var propWriters = allBindingsAccessor()['_ko_property_writers'];
                 if (propWriters && propWriters[key])
                     propWriters[key](value);
-            } else if (!checkIfDifferent || property.peek() !== value) {
+            } else if (ko.isWriteableObservable(property) && (!checkIfDifferent || property.peek() !== value)) {
                 property(value);
             }
         }


### PR DESCRIPTION
Hi,

When you bind an input element to a computed it appears that knockout simply overwrites the computed with the input's value.

I think it is preferable that knockout throws an exception - similar to "Cannot write a value to a ko.computed unless you specify a 'write' option".

http://jsfiddle.net/nabog/Z4jZ7/ 

Thanks.
