### PR TITLE
Issue when binding 'type' on IE8

### DIFF
--- a/src/binding/defaultBindings/attr.js
+++ b/src/binding/defaultBindings/attr.js
@@ -1,4 +1,4 @@
-var attrHtmlToJavascriptMap = { 'class': 'className', 'for': 'htmlFor' };
+var attrHtmlToJavascriptMap = { 'class': 'className', 'for': 'htmlFor', 'type': 'type' };
 ko.bindingHandlers['attr'] = {
     'update': function(element, valueAccessor, allBindingsAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor()) || {};


### PR DESCRIPTION
When binding the 'type' attribute on IE8, I get the error "This command is not supported" when executing code from the 'attr' binding:

    element.setAttribute(attrName, attrValue.toString());

Applying this change fix that problem and it keeps working in other browsers (tested Chrome and Firefox).

Let me know if this makes sense. Thanks!