### PR TITLE
Allow css bindings to be specified by function

### DIFF
--- a/spec/defaultBindings/cssBehaviors.js
+++ b/spec/defaultBindings/cssBehaviors.js
@@ -36,17 +36,31 @@ describe('Binding: CSS class name', function() {
         expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
     });
 
-    it('Should set/change dynamic CSS class(es) if string is specified', function() {
-        var observable1 = new ko.observable("");
-        testNode.innerHTML = "<div class='unrelatedClass1' data-bind='css: someModelProperty'>Hallo</div>";
-        ko.applyBindings({ someModelProperty: observable1 }, testNode);
+    it('Should set/change dynamic CSS class(es) if string is specified', function () {
+    	var observable1 = new ko.observable("");
+    	testNode.innerHTML = "<div class='unrelatedClass1' data-bind='css: someModelProperty'>Hallo</div>";
+    	ko.applyBindings({ someModelProperty: observable1 }, testNode);
 
-        expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
-        observable1("my-Rule");
-        expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 my-Rule");
-        observable1("another_Rule  my-Rule");
-        expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 another_Rule my-Rule");
-        observable1(undefined);
-        expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
+    	observable1("my-Rule");
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 my-Rule");
+    	observable1("another_Rule  my-Rule");
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 another_Rule my-Rule");
+    	observable1(undefined);
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
+    });
+
+    it('Should set/change dynamic CSS class(es) if function is specified', function () {
+    	var observable1 = new ko.observable("");
+    	testNode.innerHTML = "<div class='unrelatedClass1' data-bind='css: function() { return someModelProperty(); }'>Hallo</div>";
+    	ko.applyBindings({ someModelProperty: observable1 }, testNode);
+
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
+    	observable1("my-Rule");
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 my-Rule");
+    	observable1("another_Rule  my-Rule");
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 another_Rule my-Rule");
+    	observable1(undefined);
+    	expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
     });
 });

--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -8,7 +8,10 @@ ko.bindingHandlers['css'] = {
                 ko.utils.toggleDomNodeCssClass(element, className, shouldHaveClass);
             }
         } else {
-            value = String(value || ''); // Make sure we don't try to store or set a non-string value
+            if (typeof value == "function") {
+                value = value(); // Run the function first
+            }
+		    value = String(value || ''); // Make sure we don't try to store or set a non-string value
             ko.utils.toggleDomNodeCssClass(element, element[classesWrittenByBindingKey], false);
             element[classesWrittenByBindingKey] = value;
             ko.utils.toggleDomNodeCssClass(element, value, true);


### PR DESCRIPTION
I was working with the css binding and when I tried to do a css binding to an inline function, it returned the text of the function instead of calling the function.  I've implemented a minor change and a unit test to allow doing function bindings.  Example:

```
data-bind="css: function() { return modelFunction(); }"
```
