### PR TITLE
Prevent invalid binding in re-written templates

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -309,21 +309,17 @@ ko.utils = new (function () {
             if ((value === null) || (value === undefined))
                 value = "";
 
-            if (element.nodeType === 3) {
-                element.data = value;
+            // We need there to be exactly one child: a text node.
+            // If there are no children, more than one, or if it's not a text node,
+            // we'll clear everything and create a single text node.
+            var innerTextNode = ko.virtualElements.firstChild(element);
+            if (!innerTextNode || innerTextNode.nodeType != 3 || ko.virtualElements.nextSibling(innerTextNode)) {
+                ko.virtualElements.setDomNodeChildren(element, [document.createTextNode(value)]);
             } else {
-                // We need there to be exactly one child: a text node.
-                // If there are no children, more than one, or if it's not a text node,
-                // we'll clear everything and create a single text node.
-                var innerTextNode = ko.virtualElements.firstChild(element);
-                if (!innerTextNode || innerTextNode.nodeType != 3 || ko.virtualElements.nextSibling(innerTextNode)) {
-                    ko.virtualElements.setDomNodeChildren(element, [document.createTextNode(value)]);
-                } else {
-                    innerTextNode.data = value;
-                }
-
-                ko.utils.forceRefresh(element);
+                innerTextNode.data = value;
             }
+
+            ko.utils.forceRefresh(element);
         },
 
         setElementName: function(element, name) {


### PR DESCRIPTION
With string templates, if the HTML is invalid in some way, the browser will attempt to fix it, often by removing invalid elements. If that invalid element has a binding, Knockout still tries to do that binding on whichever element is after it.

We fixed a particular consequence of this in #660, but should probably fix the problem more generally. Likely this will mean that we track the `tagName` of the binding's element and ensure that the binding is applied to an element with the same name.
