### PR TITLE
Fix error message in bindingProvider.js

### DIFF
--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -36,7 +36,7 @@
                 var bindingFunction = createBindingsStringEvaluatorViaCache(bindingsString, this.bindingCache);
                 return bindingFunction(bindingContext, node);
             } catch (ex) {
-                throw new Error("Unable to parse bindings.\nMessage: " + ex + ";\nBindings value: " + bindingsString);
+                throw new Error("Unable to parse bindings.\nMessage: " + ex.message + ";\nBindings value: " + bindingsString);
             }
         }
     });


### PR DESCRIPTION
The error message in the parseBindingsString function was burying the error passed to it and returning [error Object]. This meant it took some digging to work out what the real problem was. I just added the message property name. 
