### PR TITLE
Fixed registerDependency performance in IE8 and below

### DIFF
--- a/src/memoization.js
+++ b/src/memoization.js
@@ -2,12 +2,6 @@
 ko.memoization = (function () {
     var memos = {};
 
-    function randomMax8HexChars() {
-        return (((1 + Math.random()) * 0x100000000) | 0).toString(16).substring(1);
-    }
-    function generateRandomId() {
-        return randomMax8HexChars() + randomMax8HexChars();
-    }
     function findMemoNodes(rootNode, appendToArray) {
         if (!rootNode)
             return;
@@ -25,7 +19,7 @@ ko.memoization = (function () {
         memoize: function (callback) {
             if (typeof callback != "function")
                 throw new Error("You can only pass a function to ko.memoization.memoize()");
-            var memoId = generateRandomId();
+            var memoId = ko.utils.generateRandomId();
             memos[memoId] = callback;
             return "<!--[ko_memo:" + memoId + "]-->";
         },

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -1,10 +1,9 @@
-
 ko.dependencyDetection = (function () {
     var _frames = [];
 
     return {
         begin: function (callback) {
-            _frames.push({ callback: callback, distinctDependencies:[] });
+            _frames.push({ callback: callback, distinctDependencies: {} });
         },
 
         end: function () {
@@ -16,9 +15,11 @@ ko.dependencyDetection = (function () {
                 throw new Error("Only subscribable things can act as dependencies");
             if (_frames.length > 0) {
                 var topFrame = _frames[_frames.length - 1];
-                if (!topFrame || ko.utils.arrayIndexOf(topFrame.distinctDependencies, subscribable) >= 0)
+                subscribable.key = subscribable.key || ko.utils.generateRandomId();
+
+                if (!topFrame || topFrame.distinctDependencies[subscribable.key])
                     return;
-                topFrame.distinctDependencies.push(subscribable);
+                topFrame.distinctDependencies[subscribable.key] = true;
                 topFrame.callback(subscribable);
             }
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,8 +39,16 @@ ko.utils = new (function () {
         return (inputType == "checkbox") || (inputType == "radio");
     }
 
+    function randomMax8HexChars() {
+        return (((1 + Math.random()) * 0x100000000) | 0).toString(16).substring(1);
+    }
+
     return {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
+
+        generateRandomId: function() {
+                return randomMax8HexChars() + randomMax8HexChars();
+        },
 
         arrayForEach: function (array, action) {
             for (var i = 0, j = array.length; i < j; i++)


### PR DESCRIPTION
I have an app allows large numbers of records to be edited locally. Performance degrades severely in older versions of IE because the duplicate dependency tracking uses an array and older IE browsers lack of a native implementation of indexOf. A solution is needed that tracks  duplicate dependencies without an array. I'll be making a pull request momentarily, but here is the gist of my proposed solution (which passes unit tests):

```
    registerDependency: function (subscribable) {
        if (!ko.isSubscribable(subscribable))
            throw new Error("Only subscribable things can act as dependencies");
        if (_frames.length > 0) {
            var topFrame = _frames[_frames.length - 1];
            subscribable.key = subscribable.key || ko.utils.generateRandomId();

            if (!topFrame || topFrame.distinctDependencies[subscribable.key])
                return;

            topFrame.distinctDependencies[subscribable.key] = true;

            topFrame.callback(subscribable);
        }
    },
```

Note that I exposed generateRandomId via ko.utils for use between modules but did not call exportSymbol on it. For 1000 subscribables in IE8 this function originally took 1460ms. After this change it only took 243ms. In chrome the same example went from 1ms up to 14ms. Despite this small degredation of performance in chrome and likely other modern browsers, I believe it is worth while to lift application performance to a reasonable level in older IE browsers for so long as they are supported.

I am new to this project and hope I understood the intent of the code and that the fix is reasonable. Thanks so much for your consideration.

Dave Herren
