### PR TITLE
Fix for LastPass form filler not updating ViewModel

### DIFF
--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -29,7 +29,15 @@ ko.bindingHandlers['value'] = {
                     valueUpdateHandler();
                 }
             });
+
+	    // Workaround for LastPass form filler in IE9. Allows ViewModel to update properly.
+	    ko.utils.registerEventHandler(element, "propertychange", function () {
+                if (propertyChangedFired) {
+                    valueUpdateHandler();
+                }
+            });
         }
+
 
         ko.utils.arrayForEach(eventsToCatch, function(eventName) {
             // The syntax "after<eventname>" means "run the handler asynchronously after the event"


### PR DESCRIPTION
I was having a problem with the ViewModel getting it's properties
updated when filling  a form with LastPass in IE9. This fix seems to
work.
