### PR TITLE
ko.toJS changes

### DIFF
--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -76,10 +76,6 @@ describe('Mapping helpers', function() {
         expect(result.due instanceof Date).toEqual(true);
         expect(result.due).toEqual(date);
 
-<<<<<<< HEAD
-        console.log(string instanceof String, result.string instanceof String);
-=======
->>>>>>> toJS
         expect(result.string instanceof String).toEqual(true);
         expect(result.string).toEqual(string);
 
@@ -88,8 +84,6 @@ describe('Mapping helpers', function() {
 
         expect(result.booleanValue instanceof Boolean).toEqual(true);
         expect(result.booleanValue).toEqual(booleanValue);
-<<<<<<< HEAD
-=======
     });
 
     it('ko.toJS shouldn\'t serialize functions', function() {
@@ -103,7 +97,6 @@ describe('Mapping helpers', function() {
         var result = ko.toJS(obj);
         expect(result.include).toEqual("I should be serialized");
         expect(result.exclude).toEqual(undefined);
->>>>>>> toJS
     });
 
     it('ko.toJSON should unwrap everything and then stringify', function() {

--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -63,21 +63,9 @@
             if (typeof rootObject['toJSON'] == 'function')
                 visitorCallback('toJSON');
         } else {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            for (var propertyName in rootObject) {
-                visitorCallback(propertyName);
-            }
-=======
             for (var propertyName in rootObject)
                 if ( !(typeof rootObject[propertyName] === 'function') || ko.isObservable(rootObject[propertyName]) )
                     visitorCallback(propertyName);
->>>>>>> 3cf90eb... ko.toJS should not serialize functions, fixes #251
-=======
-            for (var propertyName in rootObject)
-                if ( !(typeof rootObject[propertyName] === 'function') || ko.isObservable(rootObject[propertyName]) )
-                    visitorCallback(propertyName);
->>>>>>> toJS
         }
     };
 


### PR DESCRIPTION
This pull request:
- fixes #251, now `ko.toJS` won't serialize ordinal functions. It's checking only for functions in objects since I don't think anyone is making an array of function, but if you think it's necessary I'll make it also checking for functions in arrays. There is also a spec for that
- objectLookup using `prototype`
- it also fixes #577 so that instance of Number, String and Boolean are correctly serialized, they are treated like instances of `Data`. (there was a similar pull request, #524, but with this there's also a spec)
