### PR TITLE
Update src/binding/defaultBindings/options.js

### DIFF
--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -42,7 +42,7 @@ ko.bindingHandlers['options'] = {
                 value = [value];
             if (allBindings['optionsCaption']) {
                 var option = document.createElement("option");
-                ko.utils.setHtml(option, allBindings['optionsCaption']);
+                ko.utils.setHtml(option, ko.utils.unwrapObservable(allBindings['optionsCaption']);
                 ko.selectExtensions.writeValue(option, undefined);
                 element.appendChild(option);
             }


### PR DESCRIPTION
Allow optionsCaption to bind to an observable.
This way the caption is not hard-coded!

In order to update the binding you still need to manually call

``` javascript
y("Some new caption")
x.valueHasMutated() // to get the refresh
```

where x is the one from 

``` html
<select data-bind="options: x, optionsCaption: y" />
```
