### PR TITLE
Bind HTML 5 input type 'file'

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -198,6 +198,22 @@ describe('Binding: Value', function() {
         expect(myobservable()).toEqual("some user-entered value");
     });
 
+    it('For input of type file, should bind the FileList object associated with the input', function () {
+        var myobservable = new ko.observable();
+        testNode.innerHTML = "<input type='file' data-bind='value:someProp' name='files' />";
+        ko.applyBindings({ someProp: myobservable }, testNode);
+        ko.utils.triggerEvent(testNode.childNodes[0], "change");
+        expect(myobservable()).toEqual(testNode.childNodes[0].files);
+    });
+
+    it('For input of type file with multiple attribute, should bind the FileList object associated with the input', function () {
+        var myobservable = new ko.observable();
+        testNode.innerHTML = "<input type='file' name='files' data-bind='value:someProp' multiple />";
+        ko.applyBindings({ someProp: myobservable }, testNode);
+        ko.utils.triggerEvent(testNode.childNodes[0], "change");
+        expect(myobservable()).toEqual(testNode.childNodes[0].files);
+    });
+
     it('For select boxes, should update selectedIndex when the model changes (options specified before value)', function() {
         var observable = new ko.observable('B');
         testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], value:myObservable'></select>";

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -15,6 +15,8 @@
                         : element.value;
                 case 'select':
                     return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;
+                case 'input':
+                    return element.getAttribute('type') === 'file' ? element.files : element.value;
                 default:
                     return element.value;
             }


### PR DESCRIPTION
The HTML 5 'file' input type exposes a [FileList](https://developer.mozilla.org/en-US/docs/DOM/FileList) object through a 'files' attribute, allowing the user-chosen files to be accessible through an API. In those cases, the 'value' attribute is simply a string of the path of the selected file, and (in my opinion) isn't very useful. 

Therefore, I added a small change to selectExtensions.js to read the 'files' attribute where applicable.

I'd like to also note that I didn't change the write behavior. As pointed out in another [pull request](https://github.com/SteveSanderson/knockout/pull/851), writing to the value attribute for a file input generally isn't allowed, however writing an _empty string_ to the value attribute is allowed and is how one can [programmatically clear the list of user-chosen files](http://stackoverflow.com/questions/3144419/how-do-i-remove-a-file-from-the-filelist). 

Since I want to do that in the application I'm working on, I let things be, however this does mean that if someone tries to set values other than undefined, null, or an empty string on an observable, they'll get some unhelpful browser errors.
