### PR TITLE
Make sure the original line location is shown

### DIFF
--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -36,7 +36,8 @@
                 var bindingFunction = createBindingsStringEvaluatorViaCache(bindingsString, this.bindingCache);
                 return bindingFunction(bindingContext, node);
             } catch (ex) {
-                throw new Error("Unable to parse bindings.\nMessage: " + ex + ";\nBindings value: " + bindingsString);
+                ex.message = "Unable to parse bindings.\nBindings value: " + bindingsString + "\nMessage: " + ex.message;
+            	throw ex;
             }
         }
     });


### PR DESCRIPTION
# Before

![Before](https://f.cloud.github.com/assets/485535/187417/cc45cc20-7d59-11e2-9adb-fbbadb07b9c7.png)
Currently always when a binding error occurs, then in the console the error occurs at line 1936 (or so) in knockout-2.2.1.debug.js
That sucks.
The original line location is masked out and being lost.
# After

With this change we're displaying the same kockout-wish error message but preserve the original line location!
![After](https://f.cloud.github.com/assets/485535/187418/d4812ee8-7d59-11e2-8381-36c5612f199a.png)

This is very handful, please merge the pull request.
