### PR TITLE
Correct minor spelling error of 'callback'

### DIFF
--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -113,7 +113,7 @@ describe('Templating', function() {
         expect(testNode.childNodes.length).toEqual(0);
     });
 
-    it('Should be able to access newly rendered/inserted elements in \'afterRender\' callaback', function () {
+    it('Should be able to access newly rendered/inserted elements in \'afterRender\' callback', function () {
         var passedElement, passedDataItem;
         var myCallback = function(elementsArray, dataItem) {
             expect(elementsArray.length).toEqual(1);
@@ -143,7 +143,7 @@ describe('Templating', function() {
         expect(testNode.innerHTML).toEqual("Value = B");
     });
 
-    it('Should not rerender DOM element if observable accessed in \'afterRender\' callaback is changed', function () {
+    it('Should not rerender DOM element if observable accessed in \'afterRender\' callback is changed', function () {
         var observable = new ko.observable("A"), count = 0;
         var myCallback = function(elementsArray, dataItem) {
             observable();   // access observable in callback


### PR DESCRIPTION
Trivial, but saw it while poking around so might as well correct.
