### PR TITLE
Adding support for ES5 arrays on ObservableArrays

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -298,4 +298,22 @@ describe('Observable Array', function() {
 
         expect(result[0]).toEqual(4);
     });
+
+    it('Should expose an every method for matching all items', function () {
+        testObservableArray([12, 24, 42, 130, 44]);
+        var result = testObservableArray.every(function (element, index, array) {
+            return (element >= 10);
+        });
+
+        expect(result).toEqual(true);
+    });
+
+    it('Should expose a some method for matching some items', function () {
+        testObservableArray([12, 5, 8, 1, 4]);
+        var result = testObservableArray.some(function (element, index, array) {
+            return (element >= 10);
+        });
+
+        expect(result).toEqual(true);
+    });
 })

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -312,4 +312,62 @@ ko.observableArray['fn']['reduceRight'] = function () {
     return reduceRight.apply(underlyingArray, arguments);
 };
 
+var every = Array.prototype.every;
+
+if (!every) {
+    every = function(fun /*, thisp */) {
+        "use strict";
+
+        if (this == null)
+          throw new TypeError();
+
+        var t = Object(this);
+        var len = t.length >>> 0;
+        if (typeof fun != "function")
+          throw new TypeError();
+
+        var thisp = arguments[1];
+        for (var i = 0; i < len; i++) {
+          if (i in t && !fun.call(thisp, t[i], i, t))
+            return false;
+        }
+
+        return true;
+    };
+}
+
+ko.observableArray['fn']['every'] = function () {
+    var underlyingArray = this();
+    return every.apply(underlyingArray, arguments);
+};
+
+var some = Array.prototype.some;
+
+if (!some) {
+    some = function(fun /*, thisp */) {
+        "use strict";
+
+        if (this == null)
+          throw new TypeError();
+
+        var t = Object(this);
+        var len = t.length >>> 0;
+        if (typeof fun != "function")
+          throw new TypeError();
+
+        var thisp = arguments[1];
+        for (var i = 0; i < len; i++) {
+          if (i in t && fun.call(thisp, t[i], i, t))
+            return true;
+        }
+
+        return false;
+    };
+}
+
+ko.observableArray['fn']['some'] = function () {
+    var underlyingArray = this();
+    return some.apply(underlyingArray, arguments);
+};
+
 ko.exportSymbol('observableArray', ko.observableArray);


### PR DESCRIPTION
Quite often I find myself needing to use ES5 array methods (particularly `map` and `filter`) but for that you need to unwrap the observable array before it can be used.

I've added these as methods to the observableArray so they can be used like so:

```
it('Should expose a some method for matching some items', function () {
    testObservableArray([12, 5, 8, 1, 4]);
    var result = testObservableArray.some(function (element, index, array) {
        return (element >= 10);
    });

    expect(result).toEqual(true);
});
```

I've opted to not use any of the mutation notification as (in theory) all of the methods are for data transformation and not for data mutation.

Test coverage has also been included.
