### PR TITLE
Memory leak in IE 7, 8 and 9 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -259,11 +259,17 @@ ko.utils = (function () {
                 jQuery(element)['bind'](eventType, handler);
             } else if (!mustUseAttachEvent && typeof element.addEventListener == "function")
                 element.addEventListener(eventType, handler, false);
-            else if (typeof element.attachEvent != "undefined")
-                element.attachEvent("on" + eventType, function (event) {
-                    handler.call(element, event);
+            else if (typeof element.attachEvent != "undefined") {
+                var attachEventHandler = function (event) { handler.call(element, event); },
+                    attachEventName = "on" + eventType;
+                element.attachEvent(attachEventName, attachEventHandler);
+
+                // IE does not dispose attachEvent handlers automatically (unlike with addEventListener)
+                // so to avoid leaks, we have to remove them manually. See bug #856
+                ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                    element.detachEvent(attachEventName, attachEventHandler);
                 });
-            else
+            } else
                 throw new Error("Browser doesn't support addEventListener or attachEvent");
         },
 


### PR DESCRIPTION
Knockout: 2.1.0 and 2.2.1
Browsers: IE7, IE8 and IE9 

I think this happens in Firefox 19 too, though it does reclaim some memory back.

This fiddle http://jsfiddle.net/sGDpb/ demonstrates the leak.

Steps
1- click Create Items and note memory usage
2- click Create Items a couple of times and note memory usage increase
3- wait some time for GC to run, memory will not be reclaimed
