### PR TITLE
bindingHandler.value's valueHasChanged field is 'false' but maybe should be 'true'  

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -34,6 +34,15 @@ describe('Binding: Value', function() {
         expect(testNode.childNodes[0].value).toEqual("456");
     });
 
+    it('For observable values, should update on change if new value is \'strictly\' different from previous value', function() {
+        var myobservable = new ko.observable("+123");
+        testNode.innerHTML = "<input data-bind='value:someProp' />";
+        ko.applyBindings({ someProp: myobservable }, testNode);
+        expect(testNode.childNodes[0].value).toEqual("+123");
+        myobservable(123);
+        expect(testNode.childNodes[0].value).toEqual("123");
+    });
+
     it('For writeable observable values, should catch the node\'s onchange and write values back to the observable', function () {
         var myobservable = new ko.observable(123);
         testNode.innerHTML = "<input data-bind='value:someProp' />";

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -47,12 +47,7 @@ ko.bindingHandlers['value'] = {
         var valueIsSelectOption = ko.utils.tagNameLower(element) === "select";
         var newValue = ko.utils.unwrapObservable(valueAccessor());
         var elementValue = ko.selectExtensions.readValue(element);
-        var valueHasChanged = (newValue != elementValue);
-
-        // JavaScript's 0 == "" behavious is unfortunate here as it prevents writing 0 to an empty text box (loose equality suggests the values are the same).
-        // We don't want to do a strict equality comparison as that is more confusing for developers in certain cases, so we specifically special case 0 != "" here.
-        if ((newValue === 0) && (elementValue !== 0) && (elementValue !== "0"))
-            valueHasChanged = true;
+        var valueHasChanged = (newValue !== elementValue);
 
         if (valueHasChanged) {
             var applyValueAction = function () { ko.selectExtensions.writeValue(element, newValue); };


### PR DESCRIPTION
Today I encountered the following issue: http://jsfiddle.net/philipooo/2mSNt/
I entered +1 into an text input which is bound to an computed observable. Internally I parseInt the input to get a number, and write it back to the computed behaviour. But the value bindingHandler doesnt recognize the change because it does this...

``` js
var valueHasChanged = (newValue != elementValue);
```

...and as you know 1 == "+1" is true.

The text bindingHandler of the span (see example link) updates the value as expected.

Because I needed to solve the problem I extended the code like you did
it with the 'JavaScripts 0 == "" behavious..'

``` js
if(typeof newValue === 'number' && newValue.toString() !==
elementValue)
    valueHasChanged = true;
```

Greetings
