### PR TITLE
value binding on select doesn't respond to null when not using options binding

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -264,13 +264,52 @@ describe('Binding: Value', function() {
             expect(observable()).toEqual('A');
         });
 
-        it('Should display the caption when the model value changes to undefined', function() {
+        it('Should display the caption when the model value changes to undefined, null, or \"\" when using \'options\' binding', function() {
             var observable = new ko.observable('B');
             testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], optionsCaption:\"Select...\", value:myObservable'></select>";
             ko.applyBindings({ myObservable: observable }, testNode);
+
+            // Caption is selected when observable changed to undefined
             expect(testNode.childNodes[0].selectedIndex).toEqual(2);
             observable(undefined);
             expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
+            // Caption is selected when observable changed to null
+            observable("B");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(2);
+            observable(null);
+            expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
+            // Caption is selected when observable changed to ""
+            observable("B");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(2);
+            observable("");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
+        });
+
+        it('Should display the caption when the model value changes to undefined, null, or \"\" when options specified directly', function() {
+            var observable = new ko.observable('B');
+            testNode.innerHTML = "<select data-bind='value:myObservable'><option value=''>Select...</option><option>A</option><option>B</option></select>";
+            ko.applyBindings({ myObservable: observable }, testNode);
+
+            // Caption is selected when observable changed to undefined
+            expect(testNode.childNodes[0].selectedIndex).toEqual(2);
+            observable(undefined);
+            expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
+            // Caption is selected when observable changed to null
+            observable("B");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(2);
+            observable(null);
+            expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
+            // Caption is selected when observable changed to ""
+            observable("B");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(2);
+            observable("");
+            expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+
         });
 
         it('Should update the model value when the UI is changed (setting it to undefined when the caption is selected)', function () {

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -42,11 +42,19 @@
                     }
                     break;
                 case 'select':
+                    if (value === "")
+                        value = undefined;
+                    if (value === null || value === undefined)
+                        element.selectedIndex = -1;
                     for (var i = element.options.length - 1; i >= 0; i--) {
                         if (ko.selectExtensions.readValue(element.options[i]) == value) {
                             element.selectedIndex = i;
                             break;
                         }
+                    }
+                    // for drop-down select, ensure first is selected
+                    if (!(element.size > 1) && element.selectedIndex === -1) {
+                        element.selectedIndex = 0;
                     }
                     break;
                 default:


### PR DESCRIPTION
Discovered when trying to work around #472 if you don't use the options binding, it doesn't appear that knockout will drive the value binding when using null.  

Example case: http://jsfiddle.net/SfpVd/1/

Steps
1. go to the fiddle above
2. change the selection to 3
3. click the button
4. see how it does not reset
