### PR TITLE
Conditionally included select gets close to zero width in IE7-8

### DIFF
--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -113,7 +113,7 @@ ko.bindingHandlers['options'] = {
             ensureDropdownSelectionIsConsistentWithModelValue(element, ko.utils.peekObservable(allBindings['value']), /* preferModelValue */ true);
         }
 
-        // Workaround for IE9 bug
+        // Workaround for IE bug
         ko.utils.ensureSelectElementIsRenderedCorrectly(element);
 
         if (Math.abs(previousScrollTop - element.scrollTop) > 20)

--- a/src/utils.js
+++ b/src/utils.js
@@ -369,7 +369,8 @@ ko.utils = (function () {
         ensureSelectElementIsRenderedCorrectly: function(selectElement) {
             // Workaround for IE9 rendering bug - it doesn't reliably display all the text in dynamically-added select boxes unless you force it to re-render by updating the width.
             // (See https://github.com/SteveSanderson/knockout/issues/312, http://stackoverflow.com/questions/5908494/select-only-shows-first-char-of-selected-option)
-            if (ieVersion >= 9) {
+            // Also fixes IE7 and IE8 bug that causes selects to be zero width if enclosed by 'if' or 'with'. (See issue #839)
+            if (ieVersion) {
                 var originalWidth = selectElement.style.width;
                 selectElement.style.width = 0;
                 selectElement.style.width = originalWidth;


### PR DESCRIPTION
Wrapping a `<select>`, with an `options`-binding, in an element with an `if`-binding makes the drop down list very narrow in IE7 and IE8. In IE7, it's also practically impossible to make a selection. It worked as expected in 2.1.0, but is broken in 2.2.0 and 2.2.1.

It appears pretty irregularly, and including a second element in the wrapper can magically fix the first one. As a temporary workaround, I've applied a `width: auto` CSS-style  to the element. (Once the width has been fixed, it appears as if the style declaration can be removed.)

JS Bin that demonstrates the problem: http://jsbin.com/uqugar/1
