### PR TITLE
IE7 element.getAttributeNode('value').specified == null

### DIFF
--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -11,7 +11,7 @@
                     if (element[hasDomDataExpandoProperty] === true)
                         return ko.utils.domData.get(element, ko.bindingHandlers.options.optionValueDomDataKey);
                     return ko.utils.ieVersion <= 7
-                        ? (element.getAttributeNode('value').specified ? element.value : element.text)
+                        ? (element.getAttributeNode('value') && element.getAttributeNode('value').specified ? element.value : element.text)
                         : element.value;
                 case 'select':
                     return element.selectedIndex >= 0 ? ko.selectExtensions.readValue(element.options[element.selectedIndex]) : undefined;


### PR DESCRIPTION
On IE

when element is dom node &lt;option&gt;
element.getAttributeNode('value').specified == null ko crashes
tested on ie8, ie9, ie10 in compatibility view

in knockout 2.2.1.debug.js

from line 1455

```
                            return ko.utils.ieVersion <= 7
                                ? (element.getAttributeNode('value').specified ? element.value : element.text)
                                : element.value;
```

should be 

```
                            return ko.utils.ieVersion <= 7
                                ? (element.getAttributeNode('value')!=null && element.getAttributeNode('value').specified ? element.value : element.text)
                                : element.value;
```
