### PR TITLE
Short name for ko.utils.unwrapObservable

### DIFF
--- a/spec/runner.html
+++ b/spec/runner.html
@@ -45,6 +45,7 @@
         <script type="text/javascript" src="templatingBehaviors.js"></script>
         <script type="text/javascript" src="jsonPostingBehaviors.js"></script>
         <script type="text/javascript" src="nativeTemplateEngineBehaviors.js"></script>
+        <script type="text/javascript" src="utilsBehaviors.js"></script>
 
         <!-- Default bindings -->
         <script type="text/javascript" src="defaultBindings/attrBehaviors.js"></script>

--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -1,0 +1,30 @@
+describe('unwrapObservable', function() {
+    it('Should return the underlying value of observables', function() {
+        var someObject = { abc: 123 },
+            observablePrimitiveValue = ko.observable(123),
+            observableObjectValue = ko.observable(someObject),
+            observableNullValue = ko.observable(null),
+            observableUndefinedValue = ko.observable(undefined),
+            computedValue = ko.computed(function() { return observablePrimitiveValue() + 1; });
+
+        expect(ko.utils.unwrapObservable(observablePrimitiveValue)).toBe(123);
+        expect(ko.utils.unwrapObservable(observableObjectValue)).toBe(someObject);
+        expect(ko.utils.unwrapObservable(observableNullValue)).toBe(null);
+        expect(ko.utils.unwrapObservable(observableUndefinedValue)).toBe(undefined);
+        expect(ko.utils.unwrapObservable(computedValue)).toBe(124);
+    });
+
+    it('Should return the supplied value for non-observables', function() {
+        var someObject = { abc: 123 };
+
+        expect(ko.utils.unwrapObservable(123)).toBe(123);
+        expect(ko.utils.unwrapObservable(someObject)).toBe(someObject);
+        expect(ko.utils.unwrapObservable(null)).toBe(null);
+        expect(ko.utils.unwrapObservable(undefined)).toBe(undefined);
+    });
+
+    it('Should be aliased as ko.unwrap', function() {
+        expect(ko.unwrap).toBe(ko.utils.unwrapObservable);
+        expect(ko.unwrap(ko.observable('some value'))).toBe('some value');
+    });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -497,6 +497,7 @@ ko.exportSymbol('utils.triggerEvent', ko.utils.triggerEvent);
 ko.exportSymbol('utils.unwrapObservable', ko.utils.unwrapObservable);
 ko.exportSymbol('utils.objectForEach', ko.utils.objectForEach);
 ko.exportSymbol('utils.addOrRemoveItem', ko.utils.addOrRemoveItem);
+ko.exportSymbol('unwrap', ko.utils.unwrapObservable); // Convenient shorthand, because this is used so commonly
 
 if (!Function.prototype['bind']) {
     // Function.prototype.bind is a standard part of ECMAScript 5th Edition (December 2009, http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf)


### PR DESCRIPTION
I always found the name for this function way too long and after having it written so many times in my custom binding handlers and in various other places I added the following piece code to my own sources:

```
if (typeof ko.unwrap === 'undefined') {
    ko.unwrap = ko.utils.unwrapObservable;
}
```

How about adding the function `ko.unwrap` to knockout?
