### PR TITLE
Fix specs that were failing in IE6-8 when innerText was blank

### DIFF
--- a/spec/defaultBindings/optionsBehaviors.js
+++ b/spec/defaultBindings/optionsBehaviors.js
@@ -36,8 +36,7 @@ describe('Binding: Options', function() {
         ]);
         testNode.innerHTML = "<select data-bind='options:myValues, optionsText: function (v) { return v[\"name\"] + \" (\" + v[\"job\"] + \")\"; }'><option>should be deleted</option></select>";
         ko.applyBindings({ myValues: modelValues }, testNode);
-        var displayedText = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.innerText || node.textContent; });
-        expect(displayedText).toEqual(["bob (manager)", "frank (coder & tester)"]);
+        expect(testNode.childNodes[0]).toHaveTexts(["bob (manager)", "frank (coder & tester)"]);
     });
 
     it('Should accept a function in optionsValue param to select subproperties of the model values (and use that for the option text)', function() {
@@ -48,8 +47,7 @@ describe('Binding: Options', function() {
         testNode.innerHTML = "<select data-bind='options: myValues, optionsValue: function (v) { return v.name + \" (\" + v.job + \")\"; }'><option>should be deleted</option></select>";
         ko.applyBindings({ myValues: modelValues }, testNode);
         expect(testNode.childNodes[0]).toHaveValues(["bob (manager)", "frank (coder & tester)"]);
-        var displayedText = ko.utils.arrayMap(testNode.childNodes[0].childNodes, function (node) { return node.innerText || node.textContent; });
-        expect(displayedText).toEqual(["bob (manager)", "frank (coder & tester)"]);
+        expect(testNode.childNodes[0]).toHaveTexts(["bob (manager)", "frank (coder & tester)"]);
     });
 
     it('Should exclude any items marked as destroyed', function() {

--- a/spec/lib/jasmine.extensions.js
+++ b/spec/lib/jasmine.extensions.js
@@ -18,8 +18,12 @@ jasmine.Matchers.prototype.toContainHtml = function (expectedHtml) {
     return cleanedHtml === expectedHtml;
 };
 
+jasmine.nodeText = function(node) {
+    return 'textContent' in node ? node.textContent : node.innerText;
+}
+
 jasmine.Matchers.prototype.toContainText = function (expectedText) {
-    var actualText = 'textContent' in this.actual ? this.actual.textContent : this.actual.innerText;
+    var actualText = jasmine.nodeText(this.actual);
     var cleanedActualText = actualText.replace(/\r\n/g, "\n");
     this.actual = cleanedActualText;    // Fix explanatory message
     return cleanedActualText === expectedText;
@@ -36,7 +40,7 @@ jasmine.Matchers.prototype.toHaveOwnProperties = function (expectedProperties) {
 };
 
 jasmine.Matchers.prototype.toHaveTexts = function (expectedTexts) {
-    var texts = ko.utils.arrayMap(this.actual.childNodes, function (node) { return node.innerText || node.textContent; });
+    var texts = ko.utils.arrayMap(this.actual.childNodes, jasmine.nodeText);
     this.actual = texts;   // Fix explanatory message
     return this.env.equals_(texts, expectedTexts);
 };


### PR DESCRIPTION
New specs from #818 were failing because they were testing for a blank `innerText`, but the test code would try to read `textContent`, which was `undefined`.
