### PR TITLE
new property isObservableArray, check value is array when using observable array

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -260,4 +260,40 @@ describe('Observable Array', function() {
         newArray.push("Another");
         expect(timesEvaluated).toEqual(1);
     });
-})
+
+    it('Should return true when you call isObservableArray', function() {
+        expect(testObservableArray.isObservableArray).toBeTruthy();
+    });
+
+    it('Should throw an exception if value passed to observable array is not of array, null or undefined', function() {
+        var threw;
+
+        // should not throw exception
+        try { threw = false; testObservableArray([]); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+        try { threw = false; testObservableArray([5,6,7]); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+        try { threw = false; testObservableArray([{'size': 10}]); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+        try { threw = false; testObservableArray(null); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+        try { threw = false; testObservableArray(undefined); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+        try { threw = false; testObservableArray(); } catch(ex) { threw = true }
+        expect(threw).toEqual(false);
+
+        // should throw exception
+        try { threw = false; testObservableArray('test value'); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+        try { threw = false; testObservableArray(true); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+        try { threw = false; testObservableArray(10); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+        try { threw = false; testObservableArray({'size': 10}); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+        try { threw = false; testObservableArray(new Date()); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+        try { threw = false; testObservableArray(function(){return true;}); } catch(ex) { threw = true }
+        expect(threw).toEqual(true);
+    });
+});

--- a/spec/observableBehaviors.js
+++ b/spec/observableBehaviors.js
@@ -251,4 +251,10 @@ describe('Observable', function() {
         expect(interceptedNotifications[0].value).toEqual(123);
         expect(interceptedNotifications[1].value).toEqual(456);
     });
+
+    it('Should return false when you call isObservableArray', function() {
+        var instance = new ko.observable();
+        expect(instance.isObservableArray).toBeFalsy();
+        expect(instance.isObservableArray).toBeUndefined();
+    });
 });

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -14,6 +14,11 @@ ko.observable = function (initialValue) {
                 if (DEBUG) observable._latestValue = _latestValue;
                 observable.valueHasMutated();
             }
+
+            // check for array value for updating observable arrays
+            if (observable.isObservableArray && arguments[0] && (typeof arguments[0] !== 'object' || !('length' in arguments[0])))
+                throw new Error("The argument passed when updating an observable array must be an array, or null, or undefined.");
+
             return this; // Permits chained assignments
         }
         else {

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -86,7 +86,9 @@ ko.observableArray['fn'] = {
             this.peek()[index] = newItem;
             this.valueHasMutated();
         }
-    }
+    },
+
+    'isObservableArray': true
 };
 
 // Populate ko.observableArray.fn with read/write functions from native arrays


### PR DESCRIPTION
1) Added new property isObservableArray for observable arrays, so it is easier to determine if property is of observable array or just observable.

2) When an observable array gets initialized other then array, null or undefined an error is thrown. When passing a value other than array, null or undefined to an already initialized observable array, no error is thrown and the observable array loses array functionality (can't push or pull anymore) and isn't observable anymore.
