### PR TITLE
Add templating callback 'beforeAdd'; add callback arg 'isFirstExecution'

### DIFF
--- a/spec/defaultBindings/foreachBehaviors.js
+++ b/spec/defaultBindings/foreachBehaviors.js
@@ -143,6 +143,48 @@ describe('Binding: Foreach', function() {
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span>');
     });
 
+    // Verify that callback data are as expected
+    function checkCallbackData(data, items, index, isFirstExecution, shouldBeInserted) {
+        expect(data.index).toEqual(index);
+        expect(data.value).toEqual(items()[index]);
+        expect(data.isFirstExecution).toEqual(isFirstExecution);
+        if (!shouldBeInserted) {
+            // The element's parent should be an anonymous template
+            expect(data.currentParentClone.parentNode).toEqual(undefined);
+        }
+    }
+
+    it('Should call a beforeAdd callback', function () {
+        var someItems = ko.observableArray([{ childprop: 'first child' }]);
+        var beforeAddCallbackData = [];
+        testNode.innerHTML = "<div data-bind='foreach: { data: someItems, beforeAdd: myBeforeAdd }'><span data-bind='text: childprop'></span></div>";
+
+        ko.applyBindings({
+            someItems: someItems,
+            myBeforeAdd: function(node, index, value, isFirstExecution) {
+                beforeAddCallbackData.push({
+                    node: node,
+                    index: index,
+                    value: value,
+                    isFirstExecution: isFirstExecution,
+                    currentParentClone: node.parentNode.cloneNode(true)
+                });
+            },
+        }, testNode);
+
+        expect(beforeAddCallbackData.length).toEqual(1);
+        checkCallbackData(beforeAddCallbackData[0], someItems, 0, true, false);
+        expect(testNode.childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">first child</span>');
+
+        someItems.push({ childprop: 'second child' });
+
+        checkCallbackData(beforeAddCallbackData[1], someItems, 1, false, false);
+        expect(beforeAddCallbackData.length).toEqual(2);
+        expect(testNode.childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span>');
+    });
+
     it('Should be able to supply afterAdd and beforeRemove callbacks', function() {
         testNode.innerHTML = "<div data-bind='foreach: { data: someItems, afterAdd: myAfterAdd, beforeRemove: myBeforeRemove }'><span data-bind='text: childprop'></span></div>";
         var someItems = ko.observableArray([{ childprop: 'first child' }]);

--- a/src/binding/defaultBindings/foreach.js
+++ b/src/binding/defaultBindings/foreach.js
@@ -18,6 +18,7 @@ ko.bindingHandlers['foreach'] = {
                 'foreach': unwrappedValue['data'],
                 'as': unwrappedValue['as'],
                 'includeDestroyed': unwrappedValue['includeDestroyed'],
+                'beforeAdd': unwrappedValue['beforeAdd'],
                 'afterAdd': unwrappedValue['afterAdd'],
                 'beforeRemove': unwrappedValue['beforeRemove'],
                 'afterRender': unwrappedValue['afterRender'],

--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -106,7 +106,7 @@
                 for (var i = 0, n = items.length; i < n; i++) {
                     if (items[i]) {
                         ko.utils.arrayForEach(items[i].mappedNodes, function(node) {
-                            callback(node, i, items[i].arrayEntry);
+                            callback(node, i, items[i].arrayEntry, isFirstExecution);
                         });
                     }
                 }
@@ -161,8 +161,14 @@
         // Next add/reorder the remaining items (will include deleted items if there's a beforeRemove callback)
         for (var i = 0, nextNode = ko.virtualElements.firstChild(domNode), lastNode, node; mapData = itemsToProcess[i]; i++) {
             // Get nodes for newly added items
-            if (!mapData.mappedNodes)
-                ko.utils.extend(mapData, mapNodeAndRefreshWhenChanged(domNode, mapping, mapData.arrayEntry, callbackAfterAddingNodes, mapData.indexObservable));
+            if (!mapData.mappedNodes) {
+                var newMapData = mapNodeAndRefreshWhenChanged(domNode, mapping, mapData.arrayEntry, callbackAfterAddingNodes, mapData.indexObservable),
+                    beforeAddItems = [];
+                ko.utils.extend(mapData, newMapData);
+                // Invoke callback to process new nodes
+                beforeAddItems[mapData.indexObservable()] = mapData;
+                callCallback(options['beforeAdd'], beforeAddItems);
+            }
 
             // Put nodes in the right place if they aren't there already
             for (var j = 0; node = mapData.mappedNodes[j]; nextNode = node.nextSibling, lastNode = node, j++) {


### PR DESCRIPTION
I've added this callback 'beforeAdd' to the foreach/templating bindings, so that KO clients can be informed before elements are added to the DOM. This was necessary to make my [Isotope binding for Knockout](https://github.com/aknuds1/knockout-isotope) work properly (Isotope needs to be able to filter elements before they are added to the DOM, otherwise new elements are briefly visible before Isotope hides them).

I've written a corresponding spec for the foreach binding, and verified that all tests pass (by running build.sh, so that tests are run under Node and PhantomJS).
