### PR TITLE
Adding ko.bindingHandlers.css support for Array<string> values

### DIFF
--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -2,6 +2,12 @@ var classesWrittenByBindingKey = '__ko__cssValue';
 ko.bindingHandlers['css'] = {
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor());
+
+        //this needs to be called first since an array will pass the typeof -> "object" test
+        if(Object.prototype.toString.call(value) === '[object Array]'){
+            value = value.join(' '); // if array, assume they are passing array of string class names to apply.
+        }
+
         if (typeof value == "object") {
             ko.utils.objectForEach(value, function(className, shouldHaveClass) {
                 shouldHaveClass = ko.utils.unwrapObservable(shouldHaveClass);


### PR DESCRIPTION
added a simple check for value being an array, and converted to a
space-separated string if true.

I believe this to be the expected behavior - since currently it ends up
serializing the array indices to a string which doesn't even result in
valid CSS classes.
