### PR TITLE
Prevent triggering browser reflow needlessly from options binding

### DIFF
--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -23,7 +23,7 @@ ko.bindingHandlers['options'] = {
     },
     'update': function (element, valueAccessor, allBindingsAccessor) {
         var selectWasPreviouslyEmpty = element.length == 0;
-        var previousScrollTop = selectWasPreviouslyEmpty ? null : element.scrollTop;
+        var previousScrollTop = (!selectWasPreviouslyEmpty && element.multiple) ? element.scrollTop : null;
 
         var unwrappedArray = ko.utils.unwrapObservable(valueAccessor());
         var allBindings = allBindingsAccessor();


### PR DESCRIPTION
In an effort to keep the user's place when updating a multiple `<select>` element's options, the options binding caches its `scrollTop`, redraws the options, then restores the `scrollTop`. Unfortunately, querying the element's `scrollTop` [forces an expensive, synchronous reflow](http://calendar.perfplanet.com/2009/rendering-repaint-reflow-relayout-restyle/).

This patch avoids querying scrollTop if:
1. we're not dealing with a multiple `<select>`
2. we didn't have any options to start with
