### PR TITLE
exception in ko.computed read function kills the computed

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -364,4 +364,33 @@ describe('Dependent Observable', function() {
         expect(computedInner.getDependenciesCount()).toEqual(1);
         expect(computedOuter.getDependenciesCount()).toEqual(1);
     });
+
+    it('Should be able to re-evaluate a computed that previously threw an exception', function() {
+        var observable = ko.observable(true),
+            computed = ko.computed(function() {
+                if (!observable()) {
+                    throw Error("Some dummy error");
+                } else {
+                    return observable();
+                }
+            });
+
+        // Initially the computed value is true (executed sucessfully -> same value as observable)
+        expect(computed()).toEqual(true);
+
+        var didThrow = false;
+        try {
+            // Update observable to cause computed to throw an exception
+            observable(false);
+        } catch(e) {
+            didThrow = true;
+        }
+        expect(didThrow).toEqual(true);
+        // The value of the computed is now undefined, although currently it keeps the previous value
+        expect(computed()).toEqual(true);
+
+        // Update observable to cause computed to re-evaluate
+        observable(1);
+        expect(computed()).toEqual(1);
+    });
 })

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -78,14 +78,16 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             _hasBeenEvaluated = true;
 
             dependentObservable["notifySubscribers"](_latestValue, "beforeChange");
+
             _latestValue = newValue;
             if (DEBUG) dependentObservable._latestValue = _latestValue;
+            dependentObservable["notifySubscribers"](_latestValue);
+
         } finally {
             ko.dependencyDetection.end();
+            _isBeingEvaluated = false;
         }
 
-        dependentObservable["notifySubscribers"](_latestValue);
-        _isBeingEvaluated = false;
         if (!_subscriptionsToDependencies.length)
             dispose();
     }


### PR DESCRIPTION
Once there's an exception in the read function of a `ko.computed`, its `_isBeingEvaluated` value is stuck at `true`, and the computed won't ever be evaluated again.
