### PR TITLE
(jQuery template foreach) + (spaces around = in data-bind attribute) = exception

### DIFF
--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -331,6 +331,12 @@ describe('Templating', function() {
         expect(testNode.childNodes[0].value).toEqual("hello");
     });
 
+    it('Should handle data-bind attributes with spaces around equals sign from inside templates and reference variables', function () {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<input data-bind = 'value:message' />" }));
+        ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { message: "hello"} }, testNode);
+        expect(testNode.childNodes[0].value).toEqual("hello");
+    });
+
     it('Data binding syntax should be able to use $element in binding value', function() {
         ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: $element.tagName'></div>" }));
         ko.renderTemplate("someTemplate", null, null, testNode);

--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -1,6 +1,6 @@
 
 ko.templateRewriting = (function () {
-    var memoizeDataBindingAttributeSyntaxRegex = /(<([a-z]+\d*)(?:\s+(?!data-bind=)[a-z0-9\-]+(?:=(?:\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind=(["'])([\s\S]*?)\3/gi;
+    var memoizeDataBindingAttributeSyntaxRegex = /(<([a-z]+\d*)(?:\s+(?!data-bind\s*=\s*)[a-z0-9\-]+(?:=(?:\"[^\"]*\"|\'[^\']*\'))?)*\s+)data-bind\s*=\s*(["'])([\s\S]*?)\3/gi;
     var memoizeVirtualContainerBindingSyntaxRegex = /<!--\s*ko\b\s*([\s\S]*?)\s*-->/g;
 
     function validateDataBindValuesForRewriting(keyValueArray) {


### PR DESCRIPTION
The HTML5 spec allows for any number of spaces between an attribute name and the equals sign, and between the equals sign and the attribute value.  Such as:

``` xml
    <p class             =     

    "myclass" />
```

[HTML5 Source](http://dev.w3.org/html5/spec/Overview.html#attributes-0) (I can't find an explicit reference in the HTML 4.01 spec, but I haven't ever met a browser that didn't like spaces.)

I ran into an issue where I had an element with data-bind inside a template.  Here is the exact template, from my ColorPal project:

``` xml
    <script id="CP_PaletteTemplate" type="text/html">
        <div id="cp-swatches"
             data-bind = "visible: palette_created()">
        {{each(index,hex) colors}}
        <div 
                class = "cp-border cp-swatch grid_3 " 
                   id = "cp-swatch-${index}" 
            data-bind = "style: { backgroundColor: hex }"> <!-- problem line -->
        </div>
        {{/each}}
        </div> <!-- /#cp-swatches -->
    </script>
```

Note the spaces on either side of the equals sign.  This resulted in:

```
Uncaught Error: Unable to parse bindings.
Message: ReferenceError: hex is not defined;
Bindings value: style: { backgroundColor: hex }
```

Only the data-bind attribute inside the template's foreach loop was problematic.  `hex` _is_ defined, and the exception goes away when I remove the spaces, like so:

```
data-bind="style: { backgroundColor: hex }"
```

I have a fix to the data-bind regex (memoizeDataBindingAttributeSyntaxRegex) and will submit a pull request right away.  I just wish I knew what the strange interplay is between jQuery.tmpl's foreach and Knockout.
