### PR TITLE
/spec/runner.html failure

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -28,7 +28,7 @@ describe("Throttled observables", function() {
         // Wait until after timeout
         waitsFor(function() {
             return notifiedValues.length > 0;
-        }, 150);
+        }, 300);
         runs(function() {
             expect(notifiedValues.length).toEqual(1);
             expect(notifiedValues[0]).toEqual("F");
@@ -68,7 +68,7 @@ describe("Throttled dependent observables", function() {
         // Now wait for throttle timeout
         waitsFor(function() {
             return notifiedValues.length > 0;
-        }, 150);
+        }, 300);
         runs(function() {
             expect(asyncDepObs()).toEqual('New value');
             expect(notifiedValues.length).toEqual(1);
@@ -103,7 +103,7 @@ describe("Throttled dependent observables", function() {
         // Now wait for throttle timeout
         waitsFor(function() {
             return evaluationCount > 1;
-        }, 150);
+        }, 300);
         runs(function() {
             expect(evaluationCount).toEqual(2); // Finally, it's evaluated
             expect(asyncDepObs()).toEqual("D");


### PR DESCRIPTION
i have been trying the spec/runner.html test against 2 versions of firfox:

ff 20.0 on linux 64.
ff 15.0 on windows 7.

both are failing to execute all tests in asyncBehaviors.js: is this a problem ? 
are these tests still significant for the use of knockout on these browsers ?
