### PR TITLE
Revert to old caption check, but add allowance for blank caption

### DIFF
--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -53,7 +53,7 @@ ko.bindingHandlers['options'] = {
             });
 
             // If caption is included, add it to the array
-            if ('optionsCaption' in allBindings) {
+            if (allBindings['optionsCaption'] === "" || allBindings['optionsCaption']) {
                 filteredArray.unshift(caption);
             }
         } else {


### PR DESCRIPTION
This partly reverts a change made in response to #897, so that it still passes the test for a blank caption but also restores the ability for the developer to dynamically disable the caption entirely, e.g. with `undefined`. Also see #997.
