### PR TITLE
Fix for #938: always export ko as global

### DIFF
--- a/build/fragments/amd-pre.js
+++ b/build/fragments/amd-pre.js
@@ -6,9 +6,10 @@
         factory(target);
     } else if (typeof define === 'function' && define['amd']) {
         // [2] AMD anonymous module
-        define(['exports'], factory);
-    } else {
+        define('ko', ['exports'], factory);//define own name 'ko' so other ko modules that are aware of amd can define their own shims config and not interact with them
+    } 
+        //always put it in the global namespace because it would cause issues to 3rd party plugins which are not supporting amd
         // [3] No module loader (plain <script> tag) - put directly in global namespace
         factory(window['ko'] = {});
-    }
+    
 }(function(koExports){


### PR DESCRIPTION
As per #938 and many other reported bugs on 3rd party libraries i.e. https://github.com/Knockout-Contrib/Knockout-Validation/issues/259

Because some of the third party libraries such as knockout validation are not aware of `AMD` we need to always export `ko` to the global namespace.
Otherwise when optimizing multiple modules with AMD including knockout itself, the other 3rd party modules would simply fail because they would always rely on the global `ko` variable.
This pull request easily fixes that case, and is also making sure the define is not anonymous, so that the shim configuration can be used side-by-side with the default ko module.
