### PR TITLE
Made observables send change notifications for Date values

### DIFF
--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -1,4 +1,4 @@
-var primitiveTypes = { 'undefined':true, 'boolean':true, 'number':true, 'string':true };
+var primitiveTypes = { '[object Undefined]': true, '[object Boolean]': true, '[object Number]': true, '[object String]': true, '[object Date]': true };
 
 ko.observable = function (initialValue) {
     var _latestValue = initialValue;
@@ -38,7 +38,8 @@ ko.observable = function (initialValue) {
 
 ko.observable['fn'] = {
     "equalityComparer": function valuesArePrimitiveAndEqual(a, b) {
-        var oldValueIsPrimitive = (a === null) || (typeof(a) in primitiveTypes);
+        var typeName = Object.prototype.toString.call(a);
+        var oldValueIsPrimitive = (a === null) || (typeName in primitiveTypes);
         return oldValueIsPrimitive ? (a === b) : false;
     }
 };


### PR DESCRIPTION
Currently observables don't send change notifications when using Date values. The reason for this is that the primitive types list does not include the Date type. The code changes help in using Date values as well.
