### PR TITLE
New toJS mapping handler to generate JS along with a model prototype

### DIFF
--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -84,7 +84,7 @@ if (!Object.keys) {
             };
         }
         var toInnerJSON = function(obj, dataModel, viewModel){
-            var _keys = keys(),
+            var _keys = keys( dataModel ),
                 index = 0;
             for(index=0;index<_keys.length;++index){
                 var key = _keys[index];


### PR DESCRIPTION
Dear Knockout team,

I added a new function to the mapping handler: toJSByPrototype

Using this function, one can generate the JS by a prototype. So walking through recursively the prototype, every matching observables function will be taken into account.

Helps me a lot in my projects where models are coming from the server and the viewmodel is created according to that and when sending back, the JS has to follow and must be restricted to that original model.

I hope you consider it useful enough to merge to. 