### PR TITLE
Check subscription truthy before calling dispose()

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -72,8 +72,11 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
 
             // For each subscription no longer being used, remove it from the active subscriptions list and dispose it
             for (var i = disposalCandidates.length - 1; i >= 0; i--) {
-                if (disposalCandidates[i])
-                    _subscriptionsToDependencies.splice(i, 1)[0].dispose();
+                if (disposalCandidates[i]) {
+                    var subscription = _subscriptionsToDependencies.splice(i, 1)[0];
+                    if (subscription)
+                        subscription.dispose();
+                }
             }
             _hasBeenEvaluated = true;
 


### PR DESCRIPTION
A TypeErorr is thrown when _subscriptionsToDependencies is an empty array
because splice() will return undefined on which the old code would try to call
dispose(). So we first ensure the subscription is valid before making the call.

Fixes #1041
