### PR TITLE
Have "this" refer to the binding handler inside an init() or update() method

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -467,4 +467,19 @@ describe('Binding attribute syntax', function() {
         ko.applyBindings({ sometext: 'hello' }, testNode);
         expect(testNode).toContainHtml('<p>replaced</p><script>alert(123);</script><p>replaced</p>');
     });
+
+    it('Should have "this" refer to the binding handler inside an init() or update() method', function () {
+        ko.bindingHandlers.testThisValue = {
+            init: function () {
+                expect(this.otherProperty).toBe("abc");
+            },
+            update: function () {
+                expect(this.otherProperty).toBe("abc");
+            },
+            otherProperty: "abc"
+        };
+
+        testNode.innerHTML = "<div data-bind='testThisValue: true'></div>";
+        ko.applyBindings({}, testNode);
+    });
 });

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -344,9 +344,8 @@
             ko.utils.arrayForEach(orderedBindings, function(bindingKeyAndHandler) {
                 // Note that topologicalSortBindings has already filtered out any nonexistent binding handlers,
                 // so bindingKeyAndHandler.handler will always be nonnull.
-                var handlerInitFn = bindingKeyAndHandler.handler["init"],
-                    handlerUpdateFn = bindingKeyAndHandler.handler["update"],
-                    bindingKey = bindingKeyAndHandler.key;
+                var bindingKey = bindingKeyAndHandler.key,
+                    bindingHandler = bindingKeyAndHandler.handler;
 
                 if (node.nodeType === 8) {
                     validateThatBindingIsAllowedForVirtualElements(bindingKey);
@@ -354,9 +353,9 @@
 
                 try {
                     // Run init, ignoring any dependencies
-                    if (typeof handlerInitFn == "function") {
+                    if (typeof bindingHandler["init"] == "function") {
                         ko.dependencyDetection.ignore(function() {
-                            var initResult = handlerInitFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+                            var initResult = bindingHandler["init"](node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
 
                             // If this binding handler claims to control descendant bindings, make a note of this
                             if (initResult && initResult['controlsDescendantBindings']) {
@@ -368,10 +367,10 @@
                     }
 
                     // Run update in its own computed wrapper
-                    if (typeof handlerUpdateFn == "function") {
+                    if (typeof bindingHandler["update"] == "function") {
                         ko.dependentObservable(
                             function() {
-                                handlerUpdateFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+                                bindingHandler["update"](node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
                             },
                             null,
                             { disposeWhenNodeIsRemoved: node }


### PR DESCRIPTION
Since the binding handler is the "owner" of these methods in this context, I expected "this" to be the binding handler itself, but instead it's the Window object.

The reason this is useful to me is that I often have complex binding handlers that have their own self-contained functions. Often I'd wrap all the handler's logic inside a closure (which returns the handler), but it's much nicer to be able to save a level of indentation (or not have to type `var self = ko.bindingHandlers.foo;`).
