### PR TITLE
Force option to be selected.

### DIFF
--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -49,6 +49,7 @@
                     for (var i = element.options.length - 1; i >= 0; i--) {
                         if (ko.selectExtensions.readValue(element.options[i]) == value) {
                             element.selectedIndex = i;
+                            ko.utils.setOptionNodeSelectionState(element.options[i], true)
                             break;
                         }
                     }


### PR DESCRIPTION
This is the result of about 2 days of debugging knockback, and then knockout, I've found that under certain conditions (which, I'm not sure) the selected index/value isn't set correctly and the UI isn't updated. This patch seems to fix these issues by forcing `select.options[select.selectedIndex].selected = true`

My test case involves switching a model inside of a view model.

Non-working version: http://jsfiddle.net/sPFZP/12/
Working version: http://jsfiddle.net/sPFZP/11/

Reference to knockback issue: kmalakoff/knockback#74

P.S, if this is accepted, please backport to the 2.3 branch.
