### PR TITLE
Support namespaced attributes with default attr binding

### DIFF
--- a/spec/defaultBindings/attrBehaviors.js
+++ b/spec/defaultBindings/attrBehaviors.js
@@ -9,6 +9,24 @@ describe('Binding: Attr', function() {
         expect(testNode.childNodes[0].getAttribute("second-attribute")).toEqual("true");
     });
 
+		it('Should be able to set namespaced attribute values', function() {
+				var model = { myValue: "first value" };
+				testNode.innerHTML = [
+					'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">',
+						'<g>',
+							'<a data-bind="attr: { \'xlink:href\': myValue }">',
+								'<text>foo</text>',
+							'</a>',
+						'</g>',
+					'</svg>'
+				].join('');
+
+        ko.applyBindings(model, testNode);
+				var anchor = testNode.childNodes[0]/*svg*/.childNodes[0]/*g*/.childNodes[0]/*a*/;
+				expect( anchor.getAttributeNode('xlink:href').value ).toEqual( 'first value' );
+				expect( anchor.getAttributeNode('xlink:href').namespaceURI ).toEqual( 'http://www.w3.org/1999/xlink' );
+		});
+
     it('Should be able to set \"name\" attribute, even on IE6-7', function() {
         var myValue = ko.observable("myName");
         testNode.innerHTML = "<input data-bind='attr: { name: myValue }' />";

--- a/src/binding/defaultBindings/attr.js
+++ b/src/binding/defaultBindings/attr.js
@@ -5,12 +5,21 @@ ko.bindingHandlers['attr'] = {
         ko.utils.objectForEach(value, function(attrName, attrValue) {
             attrValue = ko.utils.unwrapObservable(attrValue);
 
+            // Find the namespace of this attribute, if any.
+            // Defaulting to `null` should be ok, as
+            //
+            //  element.setAttributeNS( null, name, value ) ~ element.setAttribute( name, value )
+            //  element.removetAttributeNS( null, name ) ~ element.removeAttribute( name )
+            //
+            var prefixLen = attrName.indexOf(':');
+            var namespace = prefixLen < 0 ? null : element.lookupNamespaceURI( attrName.substr(0, prefixLen) );
+
             // To cover cases like "attr: { checked:someProp }", we want to remove the attribute entirely
             // when someProp is a "no value"-like value (strictly null, false, or undefined)
             // (because the absence of the "checked" attr is how to mark an element as not checked, etc.)
             var toRemove = (attrValue === false) || (attrValue === null) || (attrValue === undefined);
             if (toRemove)
-                element.removeAttribute(attrName);
+                element.removeAttributeNS(namespace, attrName);
 
             // In IE <= 7 and IE8 Quirks Mode, you have to use the Javascript property name instead of the
             // HTML attribute name for certain attributes. IE8 Standards Mode supports the correct behavior,
@@ -23,7 +32,7 @@ ko.bindingHandlers['attr'] = {
                 else
                     element[attrName] = attrValue;
             } else if (!toRemove) {
-                element.setAttribute(attrName, attrValue.toString());
+                element.setAttributeNS(namespace, attrName, attrValue.toString());
             }
 
             // Treat "name" specially - although you can think of it as an attribute, it also needs


### PR DESCRIPTION
When using knockout to create manage SVG or XML nodes, it is sometimes desirable to have it manage attributes from specific namespaces.  For example, links in SVG documents use the `xlink` namespace. Currently, the `attr` binding doesn't support attribute namespaces, as can be seen in [this fiddle](http://jsfiddle.net/ZghP7/).  The hardcoded `xlink:href` works as a link, while the `xlink:href` attribute created by knockout doesn't, because it doesn't have the right namespace.

This could certainly be compensated for by creating a `attr-ns` binding just to handle namespaced attributes, however not only would this have a high degree of code repetition, but this breaks the similarity between hardcoded attribute and attributes defined by `attr`. The HTML parser is smart enough to figure out which attributes have namespaces, why shouldn't knockout do the same? The DOM provides the `Node.lookupNamespaceURI()`, `Node.setAttributeNS()` and `Node.removeAttributeNS()` methods just for this purpose.

This pull request uses these API functions to add namespace support to the default `attr` binding. It also adds a test to the spec to check that namespace support is working properly.

ref: http://stackoverflow.com/questions/18083723/how-can-i-get-knockout-js-to-set-the-namespaceuri-for-attributes
