### PR TITLE
Performance boost for templatized foreach

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -86,7 +86,11 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
             _latestValue = newValue;
             if (DEBUG) dependentObservable._latestValue = _latestValue;
 
-            dependentObservable["notifySubscribers"](_latestValue);
+            if (changeType) {
+              dependentObservable["notifySubscribers"](_latestValue, changeType);
+            } else {
+              dependentObservable["notifySubscribers"](_latestValue);
+            }
 
         } finally {
             ko.dependencyDetection.end();

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -28,16 +28,16 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
         _subscriptionsToDependencies = [];
     }
 
-    function evaluatePossiblyAsync() {
+    function evaluatePossiblyAsync(value, changeType) {
         var throttleEvaluationTimeout = dependentObservable['throttleEvaluation'];
         if (throttleEvaluationTimeout && throttleEvaluationTimeout >= 0) {
             clearTimeout(evaluationTimeoutInstance);
-            evaluationTimeoutInstance = setTimeout(evaluateImmediate, throttleEvaluationTimeout);
+            evaluationTimeoutInstance = setTimeout(function() { evaluateImmediate(changeType) }, throttleEvaluationTimeout);
         } else
-            evaluateImmediate();
+            evaluateImmediate(changeType);
     }
 
-    function evaluateImmediate() {
+    function evaluateImmediate(changeType) {
         if (_isBeingEvaluated) {
             // If the evaluation of a ko.computed causes side effects, it's possible that it will trigger its own re-evaluation.
             // This is not desirable (it's hard for a developer to realise a chain of dependencies might cause this, and they almost
@@ -68,7 +68,11 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
                     addSubscriptionToDependency(subscribable); // Brand new subscription - add it
             });
 
-            var newValue = readFunction.call(evaluatorFunctionTarget);
+            var args = [];
+            if (changeType)
+              args.push(changeType);
+
+            var newValue = readFunction.apply(evaluatorFunctionTarget, args);
 
             // For each subscription no longer being used, remove it from the active subscriptions list and dispose it
             for (var i = disposalCandidates.length - 1; i >= 0; i--) {
@@ -81,6 +85,7 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
 
             _latestValue = newValue;
             if (DEBUG) dependentObservable._latestValue = _latestValue;
+
             dependentObservable["notifySubscribers"](_latestValue);
 
         } finally {

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -25,7 +25,7 @@ ko.observable = function (initialValue) {
     if (DEBUG) observable._latestValue = _latestValue;
     ko.subscribable.call(observable);
     observable.peek = function() { return _latestValue };
-    observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
+    observable.valueHasMutated = function (changeType) { observable["notifySubscribers"](_latestValue, changeType); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
     ko.utils.extend(observable, ko.observable['fn']);
 

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -49,6 +49,17 @@ ko.observableArray['fn'] = {
         });
     },
 
+    'addAll': function (arrayOfValues) {
+        if (arrayOfValues.length > 0) {
+          var underlyingArray = this.peek();
+          this.valueWillMutate();
+          for (var i = 0; i < arrayOfValues.length; ++i) {
+            underlyingArray.push(arrayOfValues[i]);
+          }
+          this.valueHasMutated("extended");
+        }
+    },
+
     'destroy': function (valueOrPredicate) {
         var underlyingArray = this.peek();
         var predicate = typeof valueOrPredicate == "function" ? valueOrPredicate : function (value) { return value === valueOrPredicate; };

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -37,14 +37,24 @@ ko.subscribable['fn'] = {
     },
 
     "notifySubscribers": function (valueToNotify, event) {
-        event = event || defaultEvent;
+        var actualEvent = event;
+        if (event === "extended")
+          event = defaultEvent;
+        else
+          event = event || defaultEvent;
+
         if (this._subscriptions[event]) {
             ko.dependencyDetection.ignore(function() {
                 ko.utils.arrayForEach(this._subscriptions[event].slice(0), function (subscription) {
                     // In case a subscription was disposed during the arrayForEach cycle, check
                     // for isDisposed on each subscription before invoking its callback
-                    if (subscription && (subscription.isDisposed !== true))
-                        subscription.callback(valueToNotify);
+                    if (subscription && (subscription.isDisposed !== true)) {
+                        if (actualEvent && actualEvent !== defaultEvent) {
+                          subscription.callback(valueToNotify, actualEvent);
+                        } else {
+                          subscription.callback(valueToNotify);
+                        }
+                    }
                 });
             }, this);
         }

--- a/src/templating/native/nativeTemplateEngine.js
+++ b/src/templating/native/nativeTemplateEngine.js
@@ -14,7 +14,7 @@ ko.nativeTemplateEngine.prototype['renderTemplateSource'] = function (templateSo
         return ko.utils.makeArray(templateNodes.cloneNode(true).childNodes);
     } else {
         var id = templateSource.domElement.id;
-        var cache = this.templateCache;
+        var cache = ko.nativeTemplateEngine.prototype.templateCache || {};
 
         // If the template is not cached, parse it
         if (!cache[id]) {

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -174,7 +174,7 @@
                 options['afterRender'](addedNodesArray, arrayValue);
         };
 
-        return ko.dependentObservable(function () {
+        return ko.dependentObservable(function (changeType) {
             var unwrappedArray = ko.utils.unwrapObservable(arrayOrObservableArray) || [];
             if (typeof unwrappedArray.length == "undefined") // Coerce single value into array
                 unwrappedArray = [unwrappedArray];
@@ -186,7 +186,7 @@
 
             // Call setDomNodeChildrenFromArrayMapping, ignoring any observables unwrapped within (most likely from a callback function).
             // If the array items are observables, though, they will be unwrapped in executeTemplateForArrayItem and managed within setDomNodeChildrenFromArrayMapping.
-            ko.dependencyDetection.ignore(ko.utils.setDomNodeChildrenFromArrayMapping, null, [targetNode, filteredArray, executeTemplateForArrayItem, options, activateBindingsCallback]);
+            ko.dependencyDetection.ignore(ko.utils.setDomNodeChildrenFromArrayMapping, null, [targetNode, filteredArray, executeTemplateForArrayItem, options, activateBindingsCallback, changeType]);
 
         }, null, { disposeWhenNodeIsRemoved: targetNode });
     };


### PR DESCRIPTION
I've been running into a number of performance issues with using native templates and foreach, with a large number of items (1000s).

With this change, parsed templates are cached for 5s and the nodes are cloned instead of re-parsed. With my testbed, this gave a 17% speedup (5200ms instead of 6300) ms to render 5000 items.

I'm hoping to uncover even bigger wins, but this is some low hanging fruit for now. Please let me know if there is anything else you'd like me to do with this commit.