### PR TITLE
ko.toJS() in 3.0.0beta omit toJSON function from output

### DIFF
--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -112,6 +112,21 @@ describe('Mapping helpers', function() {
         expect(parsedResult[2].someProp).toEqual('Hey');
     });
 
+    it('ko.toJSON should respect .toJSON functions on objects', function() {
+        var data = {
+            a: { one: "one", two: "two"},
+            b: ko.observable({ one: "one", two: "two" })
+        };
+        data.a.toJSON = function() { return "a-mapped" };
+        data.b().toJSON = function() { return "b-mapped" };
+        var result = ko.toJSON(data);
+
+        // Check via parsing so the specs are independent of browser-specific JSON string formatting
+        expect(typeof result).toEqual("string");
+        var parsedResult = ko.utils.parseJson(result);
+        expect(parsedResult).toEqual({ a: "a-mapped", b: "b-mapped" });
+    });
+
     it('ko.toJSON should respect .toJSON functions on arrays', function() {
         var data = {
             a: [1, 2],

--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -64,7 +64,7 @@
                 visitorCallback('toJSON');
         } else {
             for (var propertyName in rootObject) {
-                if ( !(typeof rootObject[propertyName] === 'function') || ko.isObservable(rootObject[propertyName]) )
+                if (propertyName === 'toJSON' || typeof rootObject[propertyName] !== 'function' || ko.isObservable(rootObject[propertyName]))
                     visitorCallback(propertyName);
             }
         }


### PR DESCRIPTION
In 3.0.0beta, ko.toJS was omitting toJSON function defined in the model from its output. This causes ko.JSON to failed to pickup custom serialization of the model.

``` javascript
var model = function() {
    var self = this;

    self.firstName = "Bob";
    self.lastName = "Person";

    self.toJSON = function() {
        var copy = {
            firstName: self.firstName,
            lastName: self.lastName.toUpperCase()
        };
        return copy;
    }
  }

ko.applyBindings(new model);
```

``` html
<div data-bind="text: ko.toJSON($data)"></div>
```

Output in 2.3.0 (as expected)

``` javascript
{"firstName":"Bob","lastName":"PERSON"}
```

Output in 3.0.0beta

``` javascript
{"firstName":"Bob","lastName":"Person"}
```
