### PR TITLE
Binding errors in 3.0 are less informative

### DIFF
--- a/spec/bindingDependencyBehaviors.js
+++ b/spec/bindingDependencyBehaviors.js
@@ -402,10 +402,9 @@ describe('Binding dependencies', function() {
             ko.bindingHandlers.test4.after = [];
             testNode.innerHTML = "<div data-bind='test1, unknownBinding, test2, test4, test3'></div>";
 
-            var didThrow = false;
-            try { ko.applyBindings(null, testNode) }
-            catch(ex) { didThrow = true; expect(ex.message).toContain('Cannot combine the following bindings, because they have a cyclic dependency: test1, test3, test2') }
-            expect(didThrow).toEqual(true);
+            expect(function () {
+                ko.applyBindings(null, testNode);
+            }).toThrow("Cannot combine the following bindings, because they have a cyclic dependency: test1, test3, test2");
         })
     });
 });

--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -378,14 +378,11 @@ describe('Dependent Observable', function() {
         // Initially the computed value is true (executed sucessfully -> same value as observable)
         expect(computed()).toEqual(true);
 
-        var didThrow = false;
-        try {
+        expect(function () {
             // Update observable to cause computed to throw an exception
             observable(false);
-        } catch(e) {
-            didThrow = true;
-        }
-        expect(didThrow).toEqual(true);
+        }).toThrow();
+
         // The value of the computed is now undefined, although currently it keeps the previous value
         expect(computed()).toEqual(true);
 

--- a/spec/lib/jasmine.extensions.js
+++ b/spec/lib/jasmine.extensions.js
@@ -58,6 +58,17 @@ jasmine.Matchers.prototype.toHaveSelectedValues = function (expectedValues) {
     return this.env.equals_(selectedValues, expectedValues);
 };
 
+jasmine.Matchers.prototype.toThrowContaining = function(expected) {
+    var exception;
+    try {
+        this.actual();
+    } catch (e) {
+        exception = e;
+    }
+    this.actual = exception && (exception.message || exception);   // Fix explanatory message
+    return exception ? this.env.contains_(exception.message || exception, expected) : false;
+};
+
 jasmine.addScriptReference = function(scriptUrl) {
     if (window.console)
         console.log("Loading " + scriptUrl + "...");

--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -1,10 +1,9 @@
 
 describe('Mapping helpers', function() {
     it('ko.toJS should require a parameter', function() {
-        var didThrow = false;
-        try { ko.toJS() }
-        catch(ex) { didThow = true }
-        expect(didThow).toEqual(true);
+        expect(function () {
+            ko.toJS();
+        }).toThrow();
     });
 
     it('ko.toJS should unwrap observable values', function() {

--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -23,11 +23,8 @@ describe('Observable Array', function() {
 
     it('Should require constructor arg, if given, to be array-like or null or undefined', function() {
         // Try non-array-like args
-        var threw;
-        try { threw = false; new ko.observableArray(1); } catch(ex) { threw = true }
-        expect(threw).toEqual(true);
-        try { threw = false; new ko.observableArray({}); } catch(ex) { threw = true }
-        expect(threw).toEqual(true);
+        expect(function () { ko.observableArray(1); }).toThrow();
+        expect(function () { ko.observableArray({}); }).toThrow();
 
         // Try allowed args
         expect((new ko.observableArray([1,2,3]))().length).toEqual(3);

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -93,11 +93,10 @@ describe('Templating', function() {
     });
 
     it('Should not be able to render a template until a template engine is provided', function () {
-        var threw = false;
-        ko.setTemplateEngine(undefined);
-        try { ko.renderTemplate("someTemplate", {}) }
-        catch (ex) { threw = true }
-        expect(threw).toEqual(true);
+        expect(function () {
+            ko.setTemplateEngine(undefined);
+            ko.renderTemplate("someTemplate", {});
+        }).toThrow();
     });
 
     it('Should be able to render a template into a given DOM element', function () {
@@ -870,14 +869,9 @@ describe('Templating', function() {
         }));
         testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
 
-        var didThrow = false;
-        try {
+        expect(function () {
             ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
-        } catch(ex) {
-            didThrow = true;
-            expect(ex.message).toEqual("This template engine does not support anonymous templates nested within its templates");
-        }
-        expect(didThrow).toEqual(true);
+        }).toThrowContaining("This template engine does not support anonymous templates nested within its templates");
     });
 
     it('Should not be allowed to rewrite templates that embed control flow bindings', function() {
@@ -886,15 +880,10 @@ describe('Templating', function() {
             ko.setTemplateEngine(new dummyTemplateEngine({ myTemplate: "<div data-bind='" + bindingName + ": \"SomeValue\"'>Hello</div>" }));
             testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
 
-            var didThrow = false;
             ko.utils.domData.clear(testNode);
-            try { ko.applyBindings({ someData: { childProp: 'abc' } }, testNode) }
-            catch (ex) {
-                didThrow = true;
-                expect(ex.message).toMatch("This template engine does not support");
-            }
-            if (!didThrow)
-                throw new Error("Did not prevent use of " + bindingName);
+            expect(function () {
+                ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
+            }).toThrowContaining("This template engine does not support");
         });
     });
 


### PR DESCRIPTION
2.3.0:

```
Uncaught ReferenceError: Unable to parse bindings.
Bindings value: text: dummy
Message: dummy is not defined 
```

3.0.0:

```
Uncaught ReferenceError: dummy is not defined 
```

http://jsfiddle.net/mbest/QFQkb/
