### PR TITLE
package.json: change url into homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knockout",
   "description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
-  "url": "http://knockoutjs.com/",
+  "homepage": "http://knockoutjs.com/",
   "version": "3.0.0beta",
   "license": "MIT",
   "author": "The Knockout.js team",


### PR DESCRIPTION
If you don't want that npm will spit at you this field should be homepage instead of url:

https://npmjs.org/doc/files/package.json.html#homepage

best regards
