### PR TITLE
optionsCaption using setHtml() instead of setTextContent()

### DIFF
--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -74,7 +74,7 @@ ko.bindingHandlers['options'] = {
             }
             var option = document.createElement("option");
             if (arrayEntry === captionPlaceholder) {
-                ko.utils.setHtml(option, allBindings.get('optionsCaption'));
+                ko.utils.setTextContent(option, allBindings.get('optionsCaption'));
                 ko.selectExtensions.writeValue(option, undefined);
             } else {
                 // Apply a value to the option element


### PR DESCRIPTION
The optionsCaption binding should set the text content of the option element, rather than setting child html.  If it set optionsCaption: '<Select your flavor>', I get no text for the undefined option in most browsers due to invalid markup.

[The html option element has a text content model](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#the-option-element).  This means that it cannot have child elements, and therefore there is no reason to support optionsCaption with actual html. This means that correctly using optionsCaption today requires html escaping of the input before passing it in.  

The code fix is simple, though I realize there may be issues with fixing this breaking "bug-compatibility" in the case where people have already done html escaping to work around this.

At line 2284 (in my 2.1.0-debug.js)

``` javascript
            if (allBindings['optionsCaption']) {
                var option = document.createElement("option");
                ko.utils.setHtml(option, allBindings['optionsCaption']);
                ko.selectExtensions.writeValue(option, undefined);
                element.appendChild(option);
            }
```

The line:

``` javascript
        ko.utils.setHtml(option, allBindings['optionsCaption']);
```

should be replaced with:

``` javascript
        ko.utils.setTextContent(option, allBindings['optionsCaption']);
```
