### PR TITLE
Initialization of observableArray with Null in 2.3.0/3.0 is not backward compatible with 2.2.1 and lower

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -1,5 +1,7 @@
 
 describe('Observable Array', function() {
+    var testObservableArray, notifiedValues, beforeNotifiedValues;
+
     beforeEach(function () {
         testObservableArray = new ko.observableArray([1, 2, 3]);
         notifiedValues = [];
@@ -37,6 +39,21 @@ describe('Observable Array', function() {
         expect(notifiedValues.length).toEqual(1);
         expect(notifiedValues[0][0]).toEqual('X');
         expect(notifiedValues[0][1]).toEqual('Y');
+    });
+
+    it('Should require written value to be array-like or null or undefined', function() {
+        var observableArray = ko.observableArray();
+        // Try non-array-like args
+        expect(function () { observableArray(1); }).toThrow();
+        expect(function () { observableArray({}); }).toThrow();
+
+        // Try allowed args
+        observableArray([1,2,3]);
+        expect(observableArray().length).toEqual(3);
+        observableArray(null);
+        expect(observableArray().length).toEqual(0);
+        observableArray(undefined);
+        expect(observableArray().length).toEqual(0);
     });
 
     it('Should be able to mark single items as destroyed', function() {

--- a/spec/observableBehaviors.js
+++ b/spec/observableBehaviors.js
@@ -142,12 +142,12 @@ describe('Observable', function() {
         expect(notifiedValues).toEqual([]);
     });
 
-    it('Should notify subscribers of a change when both the old and new values are strictly undefined', function() {
+    it('Should ignore writes when both the old and new values are strictly undefined', function() {
         var instance = new ko.observable(undefined);
         var notifiedValues = [];
         instance.subscribe(notifiedValues.push, notifiedValues);
         instance(undefined);
-        expect(notifiedValues).toEqual([undefined]);
+        expect(notifiedValues).toEqual([]);
     });
 
     it('Should notify subscribers of a change when an object value is written, even if it is identical to the old value', function() {
@@ -253,18 +253,25 @@ describe('Observable', function() {
     });
 
     it('Should write values returned by "validateInput" filter function', function() {
-        var observable = ko.observable();
-        observable.validateInput = function(newValue, oldValue) {
-            return isNaN(newValue) ? 0 : parseFloat(+newValue);
-        };
+        var observable = ko.observable(undefined, {
+            validateInput: function(newValue, oldValue) {
+                return isNaN(newValue) ? 0 : parseFloat(+newValue);
+            }});
         var notifiedValues = [];
         observable.subscribe(notifiedValues.push, notifiedValues);
 
-        // undefined becomes 0 (even though observable was initially undefined [being unset])
+        // initial value is 0 (converted from undefined)
+        expect(observable()).toEqual(0);
+
+        // Setting to undefined becomes 0 (even though observable was initially undefined)
         observable(undefined);
         expect(notifiedValues).toEqual([0]);
 
         // Numeric 1 is unchanged
+        observable(1);
+        expect(notifiedValues).toEqual([0,1]);
+
+        // Setting to 1 again doesn't notify
         observable(1);
         expect(notifiedValues).toEqual([0,1]);
 

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -27,7 +27,8 @@ ko.extenders = {
     }
 };
 
-var primitiveTypes = { 'undefined':1, 'boolean':1, 'number':1, 'string':1 };
+// 'undefined' specifically isn't included because two "un-set" values are not considered equal
+var primitiveTypes = { 'boolean':1, 'number':1, 'string':1 };
 function valuesArePrimitiveAndEqual(a, b) {
     var oldValueIsPrimitive = (a === null) || (typeof(a) in primitiveTypes);
     return oldValueIsPrimitive ? (a === b) : false;

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -27,8 +27,7 @@ ko.extenders = {
     }
 };
 
-// 'undefined' specifically isn't included because two "un-set" values are not considered equal
-var primitiveTypes = { 'boolean':1, 'number':1, 'string':1 };
+var primitiveTypes = { 'undefined':1, 'boolean':1, 'number':1, 'string':1 };
 function valuesArePrimitiveAndEqual(a, b) {
     var oldValueIsPrimitive = (a === null) || (typeof(a) in primitiveTypes);
     return oldValueIsPrimitive ? (a === b) : false;

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -4,11 +4,13 @@ ko.observable = function (initialValue) {
     function observable() {
         if (arguments.length > 0) {
             // Write
+            var newValue = arguments[0];
 
             // Ignore writes if the value hasn't changed
-            if (!observable['equalityComparer'] || !observable['equalityComparer'](_latestValue, arguments[0])) {
+            if (!observable['equalityComparer'] || !observable['equalityComparer'](_latestValue, newValue)) {
                 observable.valueWillMutate();
-                _latestValue = arguments[0];
+                // Filter/validate incoming value if function is set
+                _latestValue = observable['validateInput'] ? observable['validateInput'](newValue, _latestValue) : newValue;
                 if (DEBUG) observable._latestValue = _latestValue;
                 observable.valueHasMutated();
             }

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -1,5 +1,7 @@
-ko.observable = function (initialValue) {
-    var _latestValue = initialValue;
+ko.observable = function (initialValue, options) {
+    options = options || {};
+    var validateInput = options['validateInput'];
+    var _latestValue = validateInput ? validateInput(initialValue) : initialValue;
 
     function observable() {
         if (arguments.length > 0) {
@@ -10,7 +12,7 @@ ko.observable = function (initialValue) {
             if (!observable['equalityComparer'] || !observable['equalityComparer'](_latestValue, newValue)) {
                 observable.valueWillMutate();
                 // Filter/validate incoming value if function is set
-                _latestValue = observable['validateInput'] ? observable['validateInput'](newValue, _latestValue) : newValue;
+                _latestValue = validateInput ? validateInput(newValue, _latestValue) : newValue;
                 if (DEBUG) observable._latestValue = _latestValue;
                 observable.valueHasMutated();
             }

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -1,7 +1,6 @@
 ko.observableArray = function (initialValues) {
-    var result = ko.utils.extend(ko.observable([]), ko.observableArray['fn']).extend({'trackArrayChanges':true});
-    result(initialValues);
-    return result;
+    var result = ko.observable(initialValues, {'validateInput': ko.observableArray['fn']['validateInput']});
+    return ko.utils.extend(result, ko.observableArray['fn']).extend({'trackArrayChanges':true});
 };
 
 ko.observableArray['fn'] = {

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -1,15 +1,16 @@
 ko.observableArray = function (initialValues) {
-    var result = ko.observable(initialValues, {'validateInput': ko.observableArray['fn']['validateInput']});
-    return ko.utils.extend(result, ko.observableArray['fn']).extend({'trackArrayChanges':true});
-};
-
-ko.observableArray['fn'] = {
-    'validateInput': function(value) {
+    var options = {};
+    options['validateInput'] = function(value) {
         value = value || [];
         if (typeof value != 'object' || !('length' in value))
             throw new Error("The argument passed when setting an observable array must be an array, null, or undefined.");
         return value;
-    },
+    };
+    var result = ko.observable(initialValues, options);
+    return ko.utils.extend(result, ko.observableArray['fn']).extend({'trackArrayChanges':true});
+};
+
+ko.observableArray['fn'] = {
     'remove': function (valueOrPredicate) {
         var underlyingArray = this.peek();
         var removedValues = [];

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -1,15 +1,16 @@
 ko.observableArray = function (initialValues) {
-    initialValues = initialValues || [];
-
-    if (typeof initialValues != 'object' || !('length' in initialValues))
-        throw new Error("The argument passed when initializing an observable array must be an array, or null, or undefined.");
-
-    var result = ko.observable(initialValues);
-    ko.utils.extend(result, ko.observableArray['fn']);
-    return result.extend({'trackArrayChanges':true});
+    var result = ko.utils.extend(ko.observable([]), ko.observableArray['fn']).extend({'trackArrayChanges':true});
+    result(initialValues);
+    return result;
 };
 
 ko.observableArray['fn'] = {
+    'validateInput': function(value) {
+        value = value || [];
+        if (typeof value != 'object' || !('length' in value))
+            throw new Error("The argument passed when setting an observable array must be an array, null, or undefined.");
+        return value;
+    },
     'remove': function (valueOrPredicate) {
         var underlyingArray = this.peek();
         var removedValues = [];


### PR DESCRIPTION
I think this change probably falls under the release note "Observable arrays have better handling of unexpected parameters (for example, when initialized with non-array values)", but here's the issue

The old code:
```javascript
ko.observableArray = function (initialValues) {
    if (arguments.length == 0) {
        // Zero-parameter constructor initializes to empty array
        initialValues = [];
    }
 //...code removed
    var result = ko.observable(initialValues);
//...code removed
```
Will allow the observableArray to initialize to Null whereas the new code:

```javascript
ko.observableArray = function (initialValues) {
    initialValues = initialValues || [];
//...code removed
    var result = ko.observable(initialValues);
//...code removed
```

The problem as I see it is this:
```javascript
var x = ko.observableArray(null);
//x == [] 
x(null);
//x == null  
```
Since null is falsy, when x is initialized, it is set to empty array in 2.3/3.0.
If x is set to null after initialization, it returns null until it reset since it is just an observable under the hood.

We implemented a workaround in our application, but we had valid circumstances where the observable array would be initialized with or reset to null and then tested for such. 

I would consider the inconsistency in behavior between the init and setter to be a bug in 2.3/3.0.