### PR TITLE
arrayChange can notify with empty change list

### DIFF
--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -100,7 +100,7 @@ describe('Observable Array change tracking', function() {
 
             // Pop empty array
             testKnownOperation(ko.observableArray([]), 'pop', {
-                args: [], result: [], changes: []
+                args: [], result: [], changes: undefined
             });
 
             // Shift
@@ -114,7 +114,7 @@ describe('Observable Array change tracking', function() {
 
             // Shift empty array
             testKnownOperation(ko.observableArray([]), 'shift', {
-                args: [], result: [], changes: []
+                args: [], result: [], changes: undefined
             });
 
             // Unshift
@@ -264,7 +264,8 @@ describe('Observable Array change tracking', function() {
 
         // The ordering of added/deleted items for replaced entries isn't defined, so
         // we'll sort by index and then status just so the tests can get consistent results
-        changeList.sort(compareChangeListItems);
+        if (changeList && changeList.sort)
+            changeList.sort(compareChangeListItems);
         expect(changeList).toEqual(options.changes);
     }
 

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -45,7 +45,9 @@ ko.extenders['trackArrayChanges'] = function(target) {
             // Compute the diff and issue notifications, but only if someone is listening
             if (target.hasSubscriptionsForEvent(arrayChangeEventName)) {
                 var changes = getChanges(previousContents, currentContents);
-                target['notifySubscribers'](changes, arrayChangeEventName);
+                if (changes.length) {
+                    target['notifySubscribers'](changes, arrayChangeEventName);
+                }
             }
 
             // Eliminate references to the old, removed items, so they can be GCed


### PR DESCRIPTION
Currently, if you update an array with the same value, the `arrayChange` event will notify with an empty change-list: `[]`. It seems to me that it should not notify at all. Since this is a new feature in 3.0, I think we should resolve this before the release.
