### PR TITLE
Backwards compatibility of 3.0.0beta with ko.toJSON

### DIFF
--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -85,17 +85,15 @@ describe('Mapping helpers', function() {
         expect(result.booleanValue).toEqual(booleanValue);
     });
 
-    it('ko.toJS shouldn\'t serialize functions', function() {
+    it('ko.toJS should serialize functions', function() {
         var obj = {
-            include: ko.observable("I should be serialized"),
-            exclude: function(){
-                return "I shouldn't be serialized"
-            }
+            include: ko.observable("test"),
+            exclude: function(){}
         };
 
         var result = ko.toJS(obj);
-        expect(result.include).toEqual("I should be serialized");
-        expect(result.exclude).toEqual(undefined);
+        expect(result.include).toEqual("test");
+        expect(result.exclude).toEqual(obj.exclude);
     });
 
     it('ko.toJSON should unwrap everything and then stringify', function() {

--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -64,8 +64,7 @@
                 visitorCallback('toJSON');
         } else {
             for (var propertyName in rootObject) {
-                if (propertyName === 'toJSON' || typeof rootObject[propertyName] !== 'function' || ko.isObservable(rootObject[propertyName]))
-                    visitorCallback(propertyName);
+                visitorCallback(propertyName);
             }
         }
     };


### PR DESCRIPTION
Hi,

I'm currently in the process of upgrading to 3.0.0beta and have found a breaking change in the way ko.toJSON now works.

As it now strips out functions (from within ko.toJS) any custom formatters that would rely on those functions will begin to fail.

In my specific example this happens if a value in an observable is a moment (http://momentjs.com/) and to toJSON function looks like:

```
moment.fn.toJSON = function () {
    return this.format('YYYY-MM-DDT00:00:00ZZ');
};
```

By stripping out the functions attached to the object format is undefined. From memory I believe you made this change to fix another bug. I do not know which way makes most sense with regards to this, but at a minimum this probably needs calling out in the release notes.

Thanks,
Adam
