### PR TITLE
Throw errors if virtual tree traversal finds an unmatched ko closing comment

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -266,15 +266,22 @@ describe('Binding attribute syntax', function() {
         expect(testNode).toContainText('Hello Bert, Goodbye');
     });
 
-    it('Should reject closing virtual bindings, when found as first child', function() {
-        testNode.innerHTML = "<!-- /ko -->";
+    it('Should reject closing virtual bindings without matching open, when found as a sibling', function() {
+        testNode.innerHTML = "<div></div><!-- /ko -->";
         expect(function() {
             ko.applyBindings(null, testNode);
         }).toThrow();
     });
 
-    it('Should reject closing virtual bindings without matching open, when found as a sibling', function() {
-        testNode.innerHTML = "<div></div><!-- /ko -->";
+    it('Should reject closing virtual bindings without matching open, when found as a a first child', function() {
+        testNode.innerHTML = "<div><!-- /ko --></div>";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
+    it('Should reject closing virtual bindings, when found as first child at the top level', function() {
+        testNode.innerHTML = "<!-- /ko -->";
         expect(function() {
             ko.applyBindings(null, testNode);
         }).toThrow();
@@ -286,7 +293,6 @@ describe('Binding attribute syntax', function() {
             ko.applyBindings(null, testNode);
         }).toThrow();
     });
-
 
     it('Should reject opening virtual bindings that are not closed', function() {
         testNode.innerHTML = "<!-- ko if: true -->";

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -266,6 +266,42 @@ describe('Binding attribute syntax', function() {
         expect(testNode).toContainText('Hello Bert, Goodbye');
     });
 
+    it('Should reject closing virtual bindings, when found as first child', function() {
+        testNode.innerHTML = "<!-- /ko -->";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
+    it('Should reject closing virtual bindings without matching open, when found as a sibling', function() {
+        testNode.innerHTML = "<div></div><!-- /ko -->";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
+    it('Should reject duplicated closing virtual bindings', function() {
+        testNode.innerHTML = "<!-- ko if: true --><div></div><!-- /ko --><!-- /ko -->";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
+
+    it('Should reject opening virtual bindings that are not closed', function() {
+        testNode.innerHTML = "<!-- ko if: true -->";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
+    it('Should reject virtual bindings that are nested incorrectly', function() {
+        testNode.innerHTML = "<!-- ko if: true --><div><!-- /ko --></div>";
+        expect(function() {
+            ko.applyBindings(null, testNode);
+        }).toThrow();
+    });
+
     it('Should be able to access virtual children in custom containerless binding', function() {
         var countNodes = 0;
         ko.bindingHandlers.test = {

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -141,8 +141,8 @@
 
         firstChild: function(node) {
             if (!isStartComment(node)) {
-                if (node.firstChild && isUnmatchedEndComment(node.firstChild)) {
-                    throw new Error("Found end comment without opening comment, as first child of " + node);
+                if (node.firstChild && isEndComment(node.firstChild)) {
+                    throw new Error("Found invalid end comment, as the first child of " + node);
                 }
                 return node.firstChild;
             } else if (!node.nextSibling || isEndComment(node.nextSibling)) {

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -145,6 +145,8 @@
                     throw new Error("Found end comment without opening comment, as first child of " + node);
                 }
                 return node.firstChild;
+            } else if (!node.nextSibling || isEndComment(node.nextSibling)) {
+                return null;
             } else {
                 return node.nextSibling;
             }

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -142,7 +142,7 @@
         firstChild: function(node) {
             if (!isStartComment(node)) {
                 if (node.firstChild && isUnmatchedEndComment(node.firstChild)) {
-                    throw new Error("Found end comment without opening comment, as first child of " + node.outerHTML);
+                    throw new Error("Found end comment without opening comment, as first child of " + node);
                 }
                 return node.firstChild;
             } else {
@@ -157,7 +157,7 @@
 
             if (node.nextSibling && isEndComment(node.nextSibling)) {
                 if (isUnmatchedEndComment(node.nextSibling)) {
-                    throw Error("Found end comment without a matching opening comment, as next sibling of " + node.outerHTML);
+                    throw Error("Found end comment without a matching opening comment, as child of " + node);
                 } else {
                     return null;
                 }


### PR DESCRIPTION
Currently Knockout will throw an error if you use a opening virtual element with no closing element, but will otherwise completely ignore extra closing comments. It's extremely easy to accidentally use too many closing elements or incorrect nesting and end up with all sorts of problems, particularly with 'with' bindings which will then leave you with slightly wrong contexts applied in the wrong places.

This patch fixes that. It hooks into the virtual tree traversal and loudly fails if at any point you attempt to traverse to a tree node that hasn't previously been matched by a starting node. End comments that are matched are tracked by tagging with ko.domData. This gets done when starting nodes are about to be included in the traversal route; they're found via virtualElements.nextSibling, which calls getMatchingEndComment, which calls getVirtualChildren, which _now_ adds a marker to correctly matching end comments as they're found.

One contentious bit that's worth thinking about is the error messages: I did this with outerHTML initially, so it gave you the relevant chunk of the page as part of the error message. That was useful, but a potentially bit long-winded, and doesn't work in FF < 4. I've pulled that out, and it now gives errors along the lines of 'Found end comment without opening comment, as first child of [object HTMLDivElement]'. Gives you the parent element type, and makes the situation fairly clear if you debug into it, but otherwise not too great.
