### PR TITLE
For value binding, when model rejects change, update view to match

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -75,18 +75,23 @@ describe('Binding: Value', function() {
         ko.utils.triggerEvent(testNode.childNodes[0], "change");
         expect(validValue()).toEqual("1234");
         expect(isValid()).toEqual(true);
+        expect(testNode.childNodes[0].value).toEqual("1234");
 
         //set to an invalid value
         testNode.childNodes[0].value = "1234a";
         ko.utils.triggerEvent(testNode.childNodes[0], "change");
         expect(validValue()).toEqual("1234");
         expect(isValid()).toEqual(false);
+        
+        // binding should revert element value since the change was rejected by the computed observable 
+        expect(testNode.childNodes[0].value).toEqual("1234");
 
         //set to a valid value where the current value of the writeable computed is the same as the written value
         testNode.childNodes[0].value = "1234";
         ko.utils.triggerEvent(testNode.childNodes[0], "change");
         expect(validValue()).toEqual("1234");
         expect(isValid()).toEqual(true);
+        expect(testNode.childNodes[0].value).toEqual("1234");
     });
 
     it('Should ignore node changes when bound to a read-only observable', function() {

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -17,6 +17,11 @@ ko.bindingHandlers['value'] = {
             var modelValue = valueAccessor();
             var elementValue = ko.selectExtensions.readValue(element);
             ko.expressionRewriting.writeValueToProperty(modelValue, allBindings, 'value', elementValue);
+            
+            // Sometimes, the model property will reject the update. In that case, the model and element
+            // will be out-of-sync. The update function checks if this is the case (values are different) 
+            // and updates the element to match.
+            ko.bindingHandlers['value']['update'](element, valueAccessor);
         }
 
         // Workaround for https://github.com/SteveSanderson/knockout/issues/122


### PR DESCRIPTION
The documentation includes an example of a computed observable that will "reject" certain updates: http://knockoutjs.com/documentation/extenders.html#live_example_1_forcing_input_to_be_numeric

This example includes code to update the input when the value is rejected: 

``` javascript
//if the rounded value is the same, but a different value was written, force a notification for the current field
if (newValue !== current) {
    target.notifySubscribers(valueToWrite);
}
```

In Knockout 3.0.0, even this code won't be sufficient because the computed observable will also ignore the change. See 78442f90df5a.

A small change to the value binding that checks if the model property has rejected a change can solve this problem without having to complicate the issue for the user.
