### PR TITLE
Fix missing favicon on non-root pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
         {% if page.canonicalUrl %}<link rel="canonical" href="{{ page.canonicalUrl }}" />{% endif %}
         <link rel="stylesheet" type="text/css" href="{{ page.pathprefix }}css/styles.css" />
         <link rel="stylesheet" type="text/css" href="{{ page.pathprefix }}css/smallScreen.css" media="only screen and (max-device-width: 800px)" />
-        <link rel="shortcut icon" href="img/favicon.ico" />
+        <link rel="shortcut icon" href="{{ page.pathprefix }}img/favicon.ico" />
         <!--[if IE]><link rel="stylesheet" type="text/css" href="{{ page.pathprefix }}css/tripoli.simple.ie.css" /><![endif]-->
         <!--[if lte IE 7]><link rel="stylesheet" type="text/css" href="{{ page.pathprefix }}css/ie6ie7.css" /><![endif]-->
         <!--[if lte IE 6]><link rel="stylesheet" type="text/css" href="{{ page.pathprefix }}css/ie6.css" /><![endif]-->


### PR DESCRIPTION
The Knockout documentation keeps "disappearing" in the huge number of open tabs in my browser because there is no favicon.
