### PR TITLE
ko.renderTemplate doesn't work with documentFragments in ko 3.0.0rc in IE8 anymore, throws 'SCRIPT16386 no such interface supported' in new version of domNodeIsContainedBy method

### DIFF
--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -986,4 +986,20 @@ describe('Templating', function() {
         // Since the actual template markup was invalid, we don't really care what the
         // resulting DOM looks like. We are only verifying there were no exceptions.
     });
+
+    it('Should be possible to render a template to a document fragment', function() {
+        // Represents https://github.com/knockout/knockout/issues/1162
+        // This was failing on IE8
+        ko.setTemplateEngine(new dummyTemplateEngine({
+            myTemplate: "<p>myval: [js: myVal]</p>" // The whitespace after the closing span is what triggers the strange HTML parsing
+        }));
+
+        var testDocFrag = document.createDocumentFragment();
+        ko.renderTemplate("myTemplate", { myVal: 123 }, null, testDocFrag);
+
+        // Can't use .toContainHtml directly on doc frags, so check DOM structure manually
+        expect(testDocFrag.childNodes.length).toEqual(1);
+        expect(testDocFrag.childNodes[0].tagName).toEqual("P");
+        expect(testDocFrag.childNodes[0]).toContainHtml("myval: 123");
+    });
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -268,6 +268,8 @@ ko.utils = (function () {
         domNodeIsContainedBy: function (node, containedByNode) {
             if (node === containedByNode)
                 return true;
+            if (node.nodeType === 11)
+                return false; // Fixes issue #1162 - can't use node.contains for document fragments on IE8
             if (containedByNode.contains)
                 return containedByNode.contains(node.nodeType === 3 ? node.parentNode : node);
             if (containedByNode.compareDocumentPosition)


### PR DESCRIPTION
after updating to knockout 3.0.0rc, I can't use `js ko.renderTemplate(name, bindingContext, {}, element)` with element being a documentFragment created by `document.createDocumentFragment()` anymore in IE8, because an exception 'SCRIPT16386 no such interface supported' is thrown within domNodeIsContainedBy() on the line `return containedByNode.contains(node.nodeType === 3 ? node.parentNode : node);`` since 3.0.0rc.

This problem doesn't exist in ko 2.3.0.

Either
- commenting out the newly introduced

```
 if (containedByNode.contains)
                return containedByNode.contains(node.nodeType === 3 ? node.parentNode : node);
```

from domNodeIsContainedBy(), or
- adding another case

``````
if (node.nodeType === 11) return false;``` before ``` if (containedByNode.contains)...```
(nodeType 11 means 'documentFragment', which is never inserted into a document and therefore can be considered "floating-free", see http://stackoverflow.com/a/2620223)

solved the problem. I don't know the details of domNodeIsContainedBy() or why it has been extended with the ```if (containedByNode.contains)...``` case, but either one or the other of the above two solutions are needed to support rendering to documentFragments in IE8 again.
``````
