### PR TITLE
Performance: always use for loop instead of native indexOf

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -52,9 +52,7 @@ ko.utils = (function () {
                 action(array[i]);
         },
 
-        arrayIndexOf: (typeof Array.prototype.indexOf == "function") ? function (array, item) {
-            return Array.prototype.indexOf.call(array, item);
-        } : function (array, item) {
+        arrayIndexOf: function (array, item) {
             for (var i = 0, j = array.length; i < j; i++)
                 if (array[i] === item)
                     return i;


### PR DESCRIPTION
I'd started this pull with an optimization to check once for the existance of the native indexOf function instead of checking each time arrayIndexOf was called -- that gave a very small boost to performance.

After some more trials, I found that just using a for loop was about 3-5x faster than the native method in all browsers that I tested.  See comments below for more details.
