### PR TITLE
simplify isWritableObservable, hasPrototype

### DIFF
--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -42,7 +42,7 @@ var protoProperty = ko.observable.protoProperty = "__ko_proto__";
 ko.observable['fn'][protoProperty] = ko.observable;
 
 ko.hasPrototype = function(instance, prototype) {
-    if ((instance === null) || (instance === undefined) || (instance[protoProperty] === undefined)) return false;
+    if ((typeof instance != "function") || (instance[protoProperty] === undefined)) return false;
     if (instance[protoProperty] === prototype) return true;
     return ko.hasPrototype(instance[protoProperty], prototype); // Walk the prototype chain
 };
@@ -51,14 +51,8 @@ ko.isObservable = function (instance) {
     return ko.hasPrototype(instance, ko.observable);
 }
 ko.isWriteableObservable = function (instance) {
-    // Observable
-    if ((typeof instance == "function") && instance[protoProperty] === ko.observable)
-        return true;
-    // Writeable dependent observable
-    if ((typeof instance == "function") && (instance[protoProperty] === ko.dependentObservable) && (instance.hasWriteFunction))
-        return true;
-    // Anything else
-    return false;
+    // Observable or Writeable dependent observable
+    return (ko.isObservable(instance) || (ko.isComputed(instance) && instance.hasWriteFunction));
 }
 
 

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -23,6 +23,7 @@ ko.observable = function (initialValue) {
     if (DEBUG) observable._latestValue = _latestValue;
     ko.subscribable.call(observable);
     observable.peek = function() { return _latestValue };
+    observable.hasWriteFunction = true;
     observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
     ko.utils.extend(observable, ko.observable['fn']);
@@ -52,7 +53,7 @@ ko.isObservable = function (instance) {
 }
 ko.isWriteableObservable = function (instance) {
     // Observable or Writeable dependent observable
-    return (ko.isObservable(instance) || (ko.isComputed(instance) && instance.hasWriteFunction));
+    return ko.isObservable(instance) && instance.hasWriteFunction;
 }
 
 


### PR DESCRIPTION
Simplify isWritableObservable by using existing methods for isObservable and isComputed.

Since the only uses of ko.hasPrototype are in ko.isObservable and ko.isComputed and doesn't seem to be used, I went ahead and simplified the null / undefined checks with a check to see if the instance has a typeof "function".  (Arguably the function might be more clearly named "ko.hasFunctionPrototype" with the new behavior)
