### PR TITLE
Check for existance of array instead of reassigning

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -48,23 +48,29 @@ ko.utils = (function () {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
 
         arrayForEach: function (array, action) {
-            for (var i = 0, j = array.length; i < j; i++)
-                action(array[i]);
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++)
+                    action(array[i]);                
+            }
         },
 
         arrayIndexOf: function (array, item) {
             if (typeof Array.prototype.indexOf == "function")
                 return Array.prototype.indexOf.call(array, item);
-            for (var i = 0, j = array.length; i < j; i++)
-                if (array[i] === item)
-                    return i;
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++)
+                    if (array[i] === item)
+                        return i;
+            }
             return -1;
         },
 
         arrayFirst: function (array, predicate, predicateOwner) {
-            for (var i = 0, j = array.length; i < j; i++)
-                if (predicate.call(predicateOwner, array[i]))
-                    return array[i];
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++)
+                    if (predicate.call(predicateOwner, array[i]))
+                        return array[i];
+            }
             return null;
         },
 
@@ -75,29 +81,32 @@ ko.utils = (function () {
         },
 
         arrayGetDistinctValues: function (array) {
-            array = array || [];
             var result = [];
-            for (var i = 0, j = array.length; i < j; i++) {
-                if (ko.utils.arrayIndexOf(result, array[i]) < 0)
-                    result.push(array[i]);
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++) {
+                    if (ko.utils.arrayIndexOf(result, array[i]) < 0)
+                        result.push(array[i]);
+                }
             }
             return result;
         },
 
         arrayMap: function (array, mapping) {
-            array = array || [];
             var result = [];
-            for (var i = 0, j = array.length; i < j; i++)
-                result.push(mapping(array[i]));
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++)
+                    result.push(mapping(array[i]));
+            }
             return result;
         },
 
         arrayFilter: function (array, predicate) {
-            array = array || [];
             var result = [];
-            for (var i = 0, j = array.length; i < j; i++)
-                if (predicate(array[i]))
-                    result.push(array[i]);
+            if (array) {
+                for (var i = 0, j = array.length; i < j; i++)
+                    if (predicate(array[i]))
+                        result.push(array[i]);
+            }
             return result;
         },
 


### PR DESCRIPTION
Seems to be somewhat faster for null / undefined values: http://jsperf.com/exists-vs-reassignment

Also applied the same method to arrayForEach, arrayIndexOf, arrayFirst so that null / undefined inputs don't result in errors.
