### PR TITLE
Performance improvements for named templates

### DIFF
--- a/src/templating/native/nativeTemplateEngine.js
+++ b/src/templating/native/nativeTemplateEngine.js
@@ -1,5 +1,8 @@
 ko.nativeTemplateEngine = function () {
     this['allowTemplateRewriting'] = false;
+
+    // Maps a element id to the parsed HTML for that template
+    this.namedTemplateCache = {}
 }
 
 ko.nativeTemplateEngine.prototype = new ko.templateEngine();
@@ -10,7 +13,16 @@ ko.nativeTemplateEngine.prototype['renderTemplateSource'] = function (templateSo
         templateNodes = templateNodesFunc ? templateSource['nodes']() : null;
 
     if (templateNodes) {
-        return ko.utils.makeArray(templateNodes.cloneNode(true).childNodes);
+        var nodes;
+        if (templateNodes instanceof Array) {
+            nodes = [];
+            for (var i = 0; i < templateNodes.length; ++i) {
+                nodes.push(templateNodes[i].cloneNode(true));
+            }
+        } else {
+            nodes = ko.utils.makeArray(templateNodes.cloneNode(true).childNodes);
+        }
+        return nodes;
     } else {
         var templateText = templateSource['text']();
         return ko.utils.parseHtmlFragment(templateText);

--- a/src/templating/templateEngine.js
+++ b/src/templating/templateEngine.js
@@ -39,9 +39,45 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
     if (typeof template == "string") {
         var namedTemplateCache = this.namedTemplateCache || {};
 
+        // Cache entries last for 10s after the last access
+        var cacheLifetime = 10000;
+
+        // Registers a timer to clean up stale entries from the template cache.
+        function cleanupCache() {
+            // If we do not yet have a cleanup scheduled, schedule one
+            if (!this.templateCacheCleanupTimeoutID) {
+                this.templateCacheCleanupTimeoutID = setTimeout(function() {
+                    this.templateCacheCleanupTimeoutID = null;
+
+                    var cacheEmpty = true;
+                    var currentTime = Date.now()
+
+                    // Walk through the templates, and delete all that have expired
+                    for (var templateName in namedTemplateCache) {
+                        var template = namedTemplateCache[templateName];
+                        if (currentTime - template.lastAccessed > cacheLifetime) {
+                            delete namedTemplateCache[templateName];
+                        } else {
+                            cacheEmpty = false;
+                        }
+                    }
+
+                    // If there are remaining cache entries, register a clean up timer
+                    if (!cacheEmpty) {
+                        cleanupCache();
+                    }
+              }, cacheLifetime);
+          }
+        }
+
+        // Garbage collect this template if not used within cacheLifetime (helpful for batch templating, like in a foreach)
+        cleanupCache();
+
         // See if we've already build this template
         if (namedTemplateCache[template]) {
-            return namedTemplateCache[template];
+            var cacheEntry = namedTemplateCache[template];
+            cacheEntry.lastAccessed = Date.now()
+            return cacheEntry.domElementSource;
         }
 
         templateDocument = templateDocument || document;
@@ -50,12 +86,10 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
             throw new Error("Cannot find template with ID " + template);
         var domElementSource = new ko.templateSources.domElement(elem);
 
-        namedTemplateCache[template] = domElementSource;
-
-        // Garbage collect this template if not used within 10s (helpful for batch templating, like in a foreach
-        setTimeout(function() {
-            delete namedTemplateCache[template];
-        }, 10000);
+        namedTemplateCache[template] = {
+          domElementSource: domElementSource,
+          lastAccessed: Date.now()
+        };
 
         return domElementSource;
     } else if ((template.nodeType == 1) || (template.nodeType == 8)) {

--- a/src/templating/templateEngine.js
+++ b/src/templating/templateEngine.js
@@ -54,11 +54,13 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
 
                     // Walk through the templates, and delete all that have expired
                     for (var templateName in namedTemplateCache) {
-                        var template = namedTemplateCache[templateName];
-                        if (currentTime - template.lastAccessed > cacheLifetime) {
-                            delete namedTemplateCache[templateName];
-                        } else {
-                            cacheEmpty = false;
+                        if (namedTemplateCache.hasOwnProperty(templateName)) {
+                            var template = namedTemplateCache[templateName];
+                            if (currentTime - template.lastAccessed > cacheLifetime) {
+                                delete namedTemplateCache[templateName];
+                            } else {
+                                cacheEmpty = false;
+                            }
                         }
                     }
 

--- a/src/templating/templateEngine.js
+++ b/src/templating/templateEngine.js
@@ -50,7 +50,7 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
                     this.templateCacheCleanupTimeoutID = null;
 
                     var cacheEmpty = true;
-                    var currentTime = Date.now()
+                    var currentTime = Date.now();
 
                     // Walk through the templates, and delete all that have expired
                     for (var templateName in namedTemplateCache) {

--- a/src/templating/templateEngine.js
+++ b/src/templating/templateEngine.js
@@ -50,7 +50,7 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
                     this.templateCacheCleanupTimeoutID = null;
 
                     var cacheEmpty = true;
-                    var currentTime = Date.now();
+                    var currentTime = new Date().getTime();
 
                     // Walk through the templates, and delete all that have expired
                     for (var templateName in namedTemplateCache) {
@@ -76,7 +76,7 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
         // See if we've already build this template
         if (namedTemplateCache[template]) {
             var cacheEntry = namedTemplateCache[template];
-            cacheEntry.lastAccessed = Date.now()
+            cacheEntry.lastAccessed = new Date().getTime();
             return cacheEntry.domElementSource;
         }
 
@@ -88,7 +88,7 @@ ko.templateEngine.prototype['makeTemplateSource'] = function(template, templateD
 
         namedTemplateCache[template] = {
           domElementSource: domElementSource,
-          lastAccessed: Date.now()
+          lastAccessed: new Date().getTime()
         };
 
         return domElementSource;

--- a/src/templating/templateSources.js
+++ b/src/templating/templateSources.js
@@ -29,6 +29,11 @@
 
     ko.templateSources.domElement = function(element) {
         this.domElement = element;
+
+        // Parse the template to speed up rendering of multiple instances of this template
+        if (this.domElement) {
+            this.nodeList = ko.utils.parseHtmlFragment(this.text());
+        }
     }
 
     ko.templateSources.domElement.prototype['text'] = function(/* valueToWrite */) {
@@ -81,8 +86,12 @@
     };
     ko.templateSources.domElement.prototype['nodes'] = function(/* valueToWrite */) {
         if (arguments.length == 0) {
-            var templateData = ko.utils.domData.get(this.domElement, anonymousTemplatesDomDataKey) || {};
-            return templateData.containerData;
+            if (this.nodeList) {
+                return this.nodeList;
+            } else {
+                var templateData = ko.utils.domData.get(this.domElement, anonymousTemplatesDomDataKey) || {};
+                return templateData.containerData;
+            }
         } else {
             var valueToWrite = arguments[0];
             ko.utils.domData.set(this.domElement, anonymousTemplatesDomDataKey, {containerData: valueToWrite});


### PR DESCRIPTION
I originally tried to get this performance boost in https://github.com/knockout/knockout/pull/1073, but it was not accepted. I've now re-done something similar for Knockout 3.0, and I hope it will be accepted. It provides a significant speed up when using named templates.

Extending the native template engine to cache the parsed HTML from named
templates. The cached nodes are stored for 10s, and then purged. This
greatly speeds up cases like templated foreach.

Performance comparison - On my machine there is a 400ms speed up
  Knockout 3.0.0 - http://jsfiddle.net/u6CvU/
  Knockout 3.0.0 with my changes - http://jsfiddle.net/Rmf3z/
