### PR TITLE
KO 3.0.0 error with jquery templates containing any 'value' bindings

### DIFF
--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -138,7 +138,7 @@ ko.expressionRewriting = (function () {
         });
 
         if (propertyAccessorResultStrings.length)
-            processKeyValue('_ko_property_writers', "{" + propertyAccessorResultStrings.join(",") + "}");
+            processKeyValue('_ko_property_writers', "{" + propertyAccessorResultStrings.join(",") + " }");
 
         return resultStrings.join(",");
     }


### PR DESCRIPTION
Mailing List Discussion: https://groups.google.com/forum/#!topic/knockoutjs/VHcuc0L2BhE

JSFiddle illustrating the issue: http://jsfiddle.net/joshSzep/KNELY/1/

In Knockout 3.0.0 'value' bindings within a jquery template cause the error:

```
Uncaught SyntaxError: Unable to process binding "template: function (){return 'brokenTemplate' }"
Message: Unexpected token ) 
```

In the Mailing List Discussion Michael Best's suggestion of using 

```
ko.expressionRewriting._twoWayBindings.value = false;
```

works, so long as no non-observable values are used.

This is a breaking change in 3.0.0; it was not misbehaving in 2.3.0.

Test Browser: Chrome Version 31.0.1650.57 m, Windows 8
