### PR TITLE
"arrayChange" event for splice assumes all added items are new

### DIFF
--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -189,6 +189,22 @@ describe('Observable Array change tracking', function() {
                 ]
             });
 
+            // Slice - swapping items should find moves
+            // NOTE: ko.utils.compareArrays will report the change list as
+            //     { status: 'deleted', value: 'First', index: 0, moved: 1 },
+            //     { status: 'added', value: 'First', index: 1, moved: 0 }
+            // which is also valid.
+            testKnownOperation(myArray, 'splice', {
+                args: [0, 2, 'X', 'First'],
+                result: ['X', 'First', 'Blah', 'Another', 'New2'],
+                changes: [
+                    { status: 'added', value: 'X', index: 0, moved: 1 },
+                    { status: 'deleted', value: 'First', index: 0, moved: 1 },
+                    { status: 'added', value: 'First', index: 1, moved: 0 },
+                    { status: 'deleted', value: 'X', index: 1, moved: 0 }
+                ]
+            });
+
             expect(callLog.length).toBe(0); // Never needed to run the diff algorithm
         });
     });

--- a/src/binding/editDetection/compareArrays.js
+++ b/src/binding/editDetection/compareArrays.js
@@ -1,3 +1,21 @@
+// Go through the items that have been added and deleted and try to find matches between them.
+ko.utils.findMovesInArrayComparison = function (left, right, limitFailedCompares) {
+    if (left.length && right.length) {
+        var failedCompares, l, r, leftItem, rightItem;
+        for (failedCompares = l = 0; (!limitFailedCompares || failedCompares < limitFailedCompares) && (leftItem = left[l]); ++l) {
+            for (r = 0; rightItem = right[r]; ++r) {
+                if (leftItem['value'] === rightItem['value']) {
+                    leftItem['moved'] = rightItem['index'];
+                    rightItem['moved'] = leftItem['index'];
+                    right.splice(r, 1);         // This item is marked as moved; so remove it from right list
+                    failedCompares = r = 0;     // Reset failed compares count because we're checking for consecutive failures
+                    break;
+                }
+            }
+            failedCompares += r;
+        }
+    }
+};
 
 ko.utils.compareArrays = (function () {
     var statusNotInOld = 'added', statusNotInNew = 'deleted';
@@ -71,25 +89,10 @@ ko.utils.compareArrays = (function () {
             }
         }
 
-        if (notInSml.length && notInBig.length) {
-            // Set a limit on the number of consecutive non-matching comparisons; having it a multiple of
-            // smlIndexMax keeps the time complexity of this algorithm linear.
-            var limitFailedCompares = smlIndexMax * 10, failedCompares,
-                a, d, notInSmlItem, notInBigItem;
-            // Go through the items that have been added and deleted and try to find matches between them.
-            for (failedCompares = a = 0; (options['dontLimitMoves'] || failedCompares < limitFailedCompares) && (notInSmlItem = notInSml[a]); a++) {
-                for (d = 0; notInBigItem = notInBig[d]; d++) {
-                    if (notInSmlItem['value'] === notInBigItem['value']) {
-                        notInSmlItem['moved'] = notInBigItem['index'];
-                        notInBigItem['moved'] = notInSmlItem['index'];
-                        notInBig.splice(d,1);       // This item is marked as moved; so remove it from notInBig list
-                        failedCompares = d = 0;     // Reset failed compares count because we're checking for consecutive failures
-                        break;
-                    }
-                }
-                failedCompares += d;
-            }
-        }
+        // Set a limit on the number of consecutive non-matching comparisons; having it a multiple of
+        // smlIndexMax keeps the time complexity of this algorithm linear.
+        ko.utils.findMovesInArrayComparison(notInSml, notInBig, smlIndexMax * 10);
+
         return editScript.reverse();
     }
 

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -81,7 +81,7 @@ ko.extenders['trackArrayChanges'] = function(target) {
             offset = 0;
 
         function pushDiff(status, value, index) {
-            diff.push({ 'status': status, 'value': value, 'index': index });
+            return diff[diff.length] = { 'status': status, 'value': value, 'index': index };
         }
         switch (operationName) {
             case 'push':
@@ -106,13 +106,15 @@ ko.extenders['trackArrayChanges'] = function(target) {
                 var startIndex = Math.min(Math.max(0, args[0] < 0 ? arrayLength + args[0] : args[0]), arrayLength),
                     endDeleteIndex = argsLength === 1 ? arrayLength : Math.min(startIndex + (args[1] || 0), arrayLength),
                     endAddIndex = startIndex + argsLength - 2,
-                    endIndex = Math.max(endDeleteIndex, endAddIndex);
+                    endIndex = Math.max(endDeleteIndex, endAddIndex),
+                    additions = [], deletions = [];
                 for (var index = startIndex, argsIndex = 2; index < endIndex; ++index, ++argsIndex) {
                     if (index < endDeleteIndex)
-                        pushDiff('deleted', rawArray[index], index);
+                        deletions.push(pushDiff('deleted', rawArray[index], index));
                     if (index < endAddIndex)
-                        pushDiff('added', args[argsIndex], index);
+                        additions.push(pushDiff('added', args[argsIndex], index));
                 }
+                ko.utils.findMovesInArrayComparison(deletions, additions);
                 break;
 
             default:


### PR DESCRIPTION
Given

```
var a = ko.observableArray([2,1]);
a.splice(0, 2, 1, 2);
```

The expected output should be something like this (the output of the `compareArrays` function):

```
[
    {status:"deleted", value:2, index:0, moved:1},
    {status:"added",   value:2, index:1, moved:0}
]
```

Instead, it's this:

```
[
    {status:"deleted", value:2, index:0},
    {status:"added",   value:1, index:0},
    {status:"deleted", value:1, index:1},
    {status:"added",   value:2, index:1}
]
```

http://jsfiddle.net/mbest/uWQyF/
