### PR TITLE
jQuery in sources

### DIFF
--- a/build/knockout-raw.js
+++ b/build/knockout-raw.js
@@ -1,4 +1,6 @@
-var DEBUG=true;
+var DEBUG = true,
+    jQuery = window.jQuery,
+    JSON = window.JSON;
 
 // This script adds <script> tags referencing each of the knockout.js source files in the correct order
 // It uses JSONP to fetch the list of source files from source-references.js

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -3,10 +3,8 @@
     <head>
 
         <!-- All specs should pass with or without jQuery+Modernizr being referenced -->
-        <!--
-        <script type="text/javascript" src="http://code.jquery.com/jquery-1.8.2.js"></script>
-        <script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/modernizr/modernizr-1.7-development-only.js"></script>
-        -->
+        <!--<script type="text/javascript" src="http://code.jquery.com/jquery-1.10.1.js"></script>-->
+        <!--<script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/modernizr/modernizr-1.7-development-only.js"></script>-->
 
         <!-- jasmine -->
         <link rel="stylesheet" type="text/css" href="lib/jasmine-1.2.0/jasmine.css" />

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -423,6 +423,11 @@
     };
 
     ko.applyBindings = function (viewModelOrBindingContext, rootNode) {
+        // If jQuery is loaded after Knockout, we won't initially have access to it. So save it here.
+        if (!jQuery && window['jQuery']) {
+            jQuery = window['jQuery'];
+        }
+
         if (rootNode && (rootNode.nodeType !== 1) && (rootNode.nodeType !== 8))
             throw new Error("ko.applyBindings: first parameter should be your view model; second parameter should be a DOM node");
         rootNode = rootNode || window.document.body; // Make "rootNode" parameter optional

--- a/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
+++ b/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
@@ -5,7 +5,7 @@
         // Note that as of Knockout 1.3, we only support jQuery.tmpl 1.0.0pre and later,
         // which KO internally refers to as version "2", so older versions are no longer detected.
         var jQueryTmplVersion = this.jQueryTmplVersion = (function() {
-            if ((typeof(jQuery) == "undefined") || !(jQuery['tmpl']))
+            if (!jQuery || !(jQuery['tmpl']))
                 return 0;
             // Since it exposes no official version number, we use our own numbering system. To be updated as jquery-tmpl evolves.
             try {

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -61,8 +61,8 @@
     }
 
     ko.utils.parseHtmlFragment = function(html) {
-        return typeof jQuery != 'undefined' ? jQueryHtmlParse(html)   // As below, benefit from jQuery's optimisations where possible
-                                            : simpleHtmlParse(html);  // ... otherwise, this simple logic will do in most common cases.
+        return jQuery ? jQueryHtmlParse(html)   // As below, benefit from jQuery's optimisations where possible
+                      : simpleHtmlParse(html);  // ... otherwise, this simple logic will do in most common cases.
     };
 
     ko.utils.setHtml = function(node, html) {
@@ -78,7 +78,7 @@
             // jQuery contains a lot of sophisticated code to parse arbitrary HTML fragments,
             // for example <tr> elements which are not normally allowed to exist on their own.
             // If you've referenced jQuery we'll use that rather than duplicating its code.
-            if (typeof jQuery != 'undefined') {
+            if (jQuery) {
                 jQuery(node)['html'](html);
             } else {
                 // ... otherwise, use KO's own parsing logic.

--- a/src/utils.domNodeDisposal.js
+++ b/src/utils.domNodeDisposal.js
@@ -31,7 +31,7 @@ ko.utils.domNodeDisposal = new (function () {
         // Special support for jQuery here because it's so commonly used.
         // Many jQuery plugins (including jquery.tmpl) store data using jQuery's equivalent of domData
         // so notify it to tear down any resources associated with the node & descendants here.
-        if ((typeof jQuery == "function") && (typeof jQuery['cleanData'] == "function"))
+        if (jQuery && (typeof jQuery['cleanData'] == "function"))
             jQuery['cleanData']([node]);
 
         // Also clear any immediate-child comment nodes, as these wouldn't have been found by

--- a/src/utils.js
+++ b/src/utils.js
@@ -297,7 +297,7 @@ ko.utils = (function () {
 
         registerEventHandler: function (element, eventType, handler) {
             var mustUseAttachEvent = ieVersion && eventsThatMustBeRegisteredUsingAttachEvent[eventType];
-            if (!mustUseAttachEvent && typeof jQuery != "undefined") {
+            if (!mustUseAttachEvent && jQuery) {
                 if (isClickOnCheckableElement(element, eventType)) {
                     // For click events on checkboxes, jQuery interferes with the event handling in an awkward way:
                     // it toggles the element checked state *after* the click event handlers run, whereas native
@@ -333,7 +333,7 @@ ko.utils = (function () {
             if (!(element && element.nodeType))
                 throw new Error("element must be a DOM node when calling triggerEvent");
 
-            if (typeof jQuery != "undefined") {
+            if (jQuery) {
                 var eventData = [];
                 if (isClickOnCheckableElement(element, eventType)) {
                     // Work around the jQuery "click events on checkboxes" issue described above by storing the original checked state before triggering the handler


### PR DESCRIPTION
as knockout captures jQuery:

```
jQuery = window["jQuery"]
```

there is no way to pass jQuery into knockout and lines, such as

```
typeof jQuery !== "undefined"
```

(checking jQuery state each call of function) looks unnecessary
