### PR TITLE
Remove jQuery workaround that's no longer needed

### DIFF
--- a/spec/defaultBindings/checkedBehaviors.js
+++ b/spec/defaultBindings/checkedBehaviors.js
@@ -318,4 +318,25 @@ describe('Binding: Checked', function() {
         expect(testNode.childNodes[0].childNodes[1].checked).toEqual(true);
     });
 
+    it('When the bound observable is updated in a subscription in response to a radio click, view and model should stay in sync', function() {
+        // This test failed when jQuery was included before the changes made in #1191
+        testNode.innerHTML = '<input type="radio" value="1" name="x" data-bind="checked: choice" />' +
+            '<input type="radio" value="2" name="x" data-bind="checked: choice" />' +
+            '<input type="radio" value="3" name="x" data-bind="checked: choice" />';
+        var choice = ko.observable('1');
+        choice.subscribe(function(newValue) {
+            if (newValue == '3')        // don't allow item 3 to be selected; revert to item 1
+                choice('1');
+        });
+        ko.applyBindings({choice: choice}, testNode);
+        expect(testNode.childNodes[0].checked).toEqual(true);
+
+        // Click on item 2; verify it's selected
+        ko.utils.triggerEvent(testNode.childNodes[1], "click");
+        expect(testNode.childNodes[1].checked).toEqual(true);
+
+        // Click on item 3; verify item 1 is selected
+        ko.utils.triggerEvent(testNode.childNodes[2], "click");
+        expect(testNode.childNodes[0].checked).toEqual(true);
+    });
 });


### PR DESCRIPTION
Code in question: https://github.com/knockout/knockout/blob/1f0e337f84f694d4f7eb17c8b90bee06064f4645/src/utils.js#L301

jQuery 1.9 upgrade notes: http://jquery.com/upgrade-guide/1.9/#checkbox-radio-state-in-a-trigger-ed-quot-click-quot-event

jQuery bug ticket: http://bugs.jquery.com/ticket/3827
