### PR TITLE
Detect and reject (probably accidental) empty anonymous templates

### DIFF
--- a/spec/defaultBindings/foreachBehaviors.js
+++ b/spec/defaultBindings/foreachBehaviors.js
@@ -25,6 +25,13 @@ describe('Binding: Foreach', function() {
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span>');
     });
 
+    it('Should reject bindings where no template content is specified', function () {
+        testNode.innerHTML = "<div data-bind='foreach: [1, 2, 3]'></div>";
+        expect(function () {
+            ko.applyBindings({}, testNode);
+        }).toThrowContaining("no template content");
+    });
+
     it('Should clean away any data values attached to the original template nodes before use', function() {
         // Represents issue https://github.com/SteveSanderson/knockout/pull/420
         testNode.innerHTML = "<div data-bind='foreach: [1, 2]'><span></span></div>";

--- a/spec/nativeTemplateEngineBehaviors.js
+++ b/spec/nativeTemplateEngineBehaviors.js
@@ -70,6 +70,17 @@ describe('Native template engine', function() {
         expect(window.testDivTemplate.childNodes[0]).toContainText("Value: abc");
     });
 
+    it('Anonymous templates with no content should be rejected', function () {
+        window.testDivTemplate.innerHTML = "<div data-bind='template: { data: someItem }'></div>"
+
+        var viewModel = {
+            someItem: { val: 'abc' }
+        };
+        expect(function () {
+            ko.applyBindings(viewModel, window.testDivTemplate);
+        }).toThrowContaining("no template content");
+    });
+
     it('Anonymous templates work in conjunction with foreach', function() {
         window.testDivTemplate.innerHTML = "<div data-bind='template: { foreach: myItems }'><b>Item: <span data-bind='text: itemProp'></span></b></div>";
         var myItems = ko.observableArray([{ itemProp: 'Alpha' }, { itemProp: 'Beta' }, { itemProp: 'Gamma' }]);

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -208,9 +208,13 @@
                 ko.virtualElements.emptyNode(element);
             } else {
                 // It's an anonymous template - store the element contents, then clear the element
-                var templateNodes = ko.virtualElements.childNodes(element),
-                    container = ko.utils.moveCleanedNodesToContainerElement(templateNodes); // This also removes the nodes from their current parent
-                new ko.templateSources.anonymousTemplate(element)['nodes'](container);
+                var templateNodes = ko.virtualElements.childNodes(element);
+                if (templateNodes.length > 0) {
+                    var container = ko.utils.moveCleanedNodesToContainerElement(templateNodes); // This also removes the nodes from their current parent
+                    new ko.templateSources.anonymousTemplate(element)['nodes'](container);
+                } else {
+                    throw new Error("Anonymous template defined, but no template content was provided");
+                }
             }
             return { 'controlsDescendantBindings': true };
         },


### PR DESCRIPTION
It's very easy to accidentally define your template or foreach binding incorrectly and end up building an anonymous template from your empty element, rather than using the named template you intended to (I personally have done `data-bind="template: { templateName: 'xyz' }"` for example quite a few times). It can be non-trivial to debug this (particularly if the template isn't supposed to end up showing anything, to start with), and it'd be much better if Knockout caught it for you.

This patch solves that. As far as I know there's no good reason whatsoever to define an empty anonymous template otherwise; it's a binding that can never do anything, and it seems like a clear place where Knockout could usefully point out that you've probably made a mistake.
