### PR TITLE
Convert output toString() before calling replace()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
                 done(false);
             } else {
                 grunt.log.ok();
-                grunt.file.write(output, (grunt.config('banner') + stdout).replace(/\r\n/g, '\n'));
+                grunt.file.write(output, (grunt.config('banner') + stdout).toString().replace(/\r\n/g, '\n'));
                 done(true);
             }
         });


### PR DESCRIPTION
I'm not sure if this is a necessary pull request, but it doesn't hurt submitting it anyway.

When trying to build Knockout on an Ubuntu 13.10 x64 instance I got the following error at the end of the process:

```
Fatal error: Object true has no method 'replace'
```

I fixed the issue by converting the output to a string before calling replace() on it. This fixed my issue, but if anyone has any suggestions so I can build Knockout without this modification, it'd be greatly appreciated.
