### PR TITLE
Change makeArray to just wrap arrayPushAll

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -442,11 +442,7 @@ ko.utils = (function () {
         },
 
         makeArray: function(arrayLikeObject) {
-            var result = [];
-            for (var i = 0, j = arrayLikeObject.length; i < j; i++) {
-                result.push(arrayLikeObject[i]);
-            };
-            return result;
+            return ko.utils.arrayPushAll([], arrayLikeObject);
         },
 
         isIe6 : isIe6,


### PR DESCRIPTION
The code in makeArray and arrayPushAll does almost exactly the same thing, with the caveat that arrayPushAll has an optimization if the object being passed in is already an array.  This just puts everything through the same code path.

Originally part of #1199, separated out since it's just simple refactoring and not really related to the other changes there.
