### PR TITLE
Improve '.toThrowContaining' matcher error message

### DIFF
--- a/spec/lib/jasmine.extensions.js
+++ b/spec/lib/jasmine.extensions.js
@@ -72,8 +72,16 @@ jasmine.Matchers.prototype.toThrowContaining = function(expected) {
     } catch (e) {
         exception = e;
     }
-    this.actual = exception && (exception.message || exception);   // Fix explanatory message
-    return exception ? this.env.contains_(exception.message || exception, expected) : false;
+    var exceptionMessage = exception && (exception.message || exception);
+
+    this.message = function () {
+        var notText = this.isNot ? " not" : "";
+        var expectation = "Expected " + this.actual.toString() + notText + " to throw exception containing '" + expected + "'";
+        var result = exception ? (", but it threw '" + exceptionMessage + "'") : ", but it did not throw anything";
+        return expectation + result;
+    }
+
+    return exception ? this.env.contains_(exceptionMessage, expected) : false;
 };
 
 jasmine.addScriptReference = function(scriptUrl) {


### PR DESCRIPTION
Currently the toThrowContaining matcher returns very unhelpful error messages in tests. This patch makes it wildly more informative.

If the function does not throw an exception, it used to return:

`Expected undefined to throw containing 'qwe'.`

it now returns;

`Expected function () { } to throw exception containing 'qwe', but it did not throw anything`.

If the function throws the wrong exceptions, it used to return:

`Expected 'asd' to throw containing 'qwe'.`

it now returns:

`Expected function () { throw new Error("asd"); } to throw exception containing 'qwe', but it threw 'asd'`.
