### PR TITLE
options placeholder always re-added when update binding fires

### DIFF
--- a/spec/defaultBindings/optionsBehaviors.js
+++ b/spec/defaultBindings/optionsBehaviors.js
@@ -118,10 +118,14 @@ describe('Binding: Options', function() {
         };
         ko.applyBindings(viewModel, testNode);
         expect(testNode.childNodes[0]).toHaveSelectedValues([undefined]);
+        var captionElement = testNode.childNodes[0].options[0];
 
         viewModel.filterValues.push("1");
         viewModel.filterValues.push("2");
         expect(testNode.childNodes[0]).toHaveSelectedValues([undefined]);
+
+        // The option element for the caption is retained
+        expect(testNode.childNodes[0].options[0]).toBe(captionElement);
     });
 
     it('Should trigger a change event when the options selection is populated or changed by modifying the options data (single select)', function() {
@@ -233,8 +237,8 @@ describe('Binding: Options', function() {
         var myCaption = ko.observable("Initial caption");
         testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], optionsCaption: myCaption'></select>";
         ko.applyBindings({ myCaption: myCaption }, testNode);
-        testNode.childNodes[0].options[2].selected = true;
 
+        testNode.childNodes[0].options[2].selected = true;
         expect(testNode.childNodes[0].selectedIndex).toEqual(2);
         expect(testNode.childNodes[0]).toHaveTexts(["Initial caption", "A", "B"]);
 

--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -1,3 +1,4 @@
+var captionPlaceholder = {};
 ko.bindingHandlers['options'] = {
     'init': function(element) {
         if (ko.utils.tagNameLower(element) !== "select")
@@ -18,14 +19,13 @@ ko.bindingHandlers['options'] = {
 
         var selectWasPreviouslyEmpty = element.length == 0;
         var previousScrollTop = (!selectWasPreviouslyEmpty && element.multiple) ? element.scrollTop : null;
-
         var unwrappedArray = ko.utils.unwrapObservable(valueAccessor());
         var includeDestroyed = allBindings.get('optionsIncludeDestroyed');
         var arrayToDomNodeChildrenOptions = {};
-        var captionPlaceholder = {};
         var captionValue;
-
+        var filteredArray;
         var previousSelectedValues;
+
         if (element.multiple) {
             previousSelectedValues = ko.utils.arrayMap(selectedOptions(), ko.selectExtensions.readValue);
         } else {
@@ -37,7 +37,7 @@ ko.bindingHandlers['options'] = {
                 unwrappedArray = [unwrappedArray];
 
             // Filter out any entries marked as destroyed
-            var filteredArray = ko.utils.arrayFilter(unwrappedArray, function(item) {
+            filteredArray = ko.utils.arrayFilter(unwrappedArray, function(item) {
                 return includeDestroyed || item === undefined || item === null || !ko.utils.unwrapObservable(item['_destroy']);
             });
 
@@ -51,7 +51,6 @@ ko.bindingHandlers['options'] = {
             }
         } else {
             // If a falsy value is provided (e.g. null), we'll simply empty the select element
-            unwrappedArray = [];
         }
 
         function applyToObject(object, predicate, defaultValue) {


### PR DESCRIPTION
In the options update function, the captionPlaceholder variable is always assigned a new instance of an empty object.

This instance is then unshifted to the start of the filteredArray.

However when the array are compared ( from setDomNodeChildrenFromArrayMapping ), the old placeholder and the new placeholder objects are different instances of an empty objects

This caused the array comparer to delete the old placeholder and add a new placeholder, ultimately removing the old option element and adding a new option element.

This is un-necessary and can easily be eliminated by always using the same instance of the empty object ( whether globally or per DOM element ).

What triggered this investigation and finding is that we use Select2 to wrap the select element and we have element focus issues as it rebuilds the droplist if you immediately leave an element that (ultimately) causes a options binding update.  I'm raising an issue with them as well as the problem still existing if the options legitimately change.
