### PR TITLE
Templates: template-name evaluation could set observable

### DIFF
--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -188,6 +188,20 @@ describe('Templating', function() {
         expect(testNode.innerHTML).toEqual("Value = A");
     });
 
+    it('Should be able to pick template via an observable', function () {
+        ko.setTemplateEngine(new dummyTemplateEngine({
+            firstTemplate: "First template output",
+            secondTemplate: "Second template output"
+        }));
+
+        var chosenTemplate = ko.observable("firstTemplate");
+        ko.renderTemplate(chosenTemplate, null, null, testNode);
+        expect(testNode.innerHTML).toEqual("First template output");
+
+        chosenTemplate("secondTemplate");
+        expect(testNode.innerHTML).toEqual("Second template output");
+    });
+
     it('Should be able to render a template using data-bind syntax', function () {
         ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "template output" }));
         testNode.innerHTML = "<div data-bind='template:\"someTemplate\"'></div>";

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -133,7 +133,8 @@
                         : new ko.bindingContext(ko.utils.unwrapObservable(dataOrBindingContext));
 
                     // Support selecting template as a function of the data being rendered
-                    var templateName = typeof(template) == 'function' ? template(bindingContext['$data'], bindingContext) : template;
+                    var templateName = ko.isObservable(template) ? template()
+                        : typeof(template) == 'function' ? template(bindingContext['$data'], bindingContext) : template;
 
                     var renderedNodesArray = executeTemplate(targetNodeOrNodeArray, renderMode, templateName, bindingContext, options);
                     if (renderMode == "replaceNode") {
@@ -215,15 +216,18 @@
             return { 'controlsDescendantBindings': true };
         },
         'update': function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-            var templateName = ko.utils.unwrapObservable(valueAccessor()),
-                options = {},
-                shouldDisplay = true,
+            var value = valueAccessor(),
                 dataValue,
-                templateComputed = null;
+                options = ko.utils.unwrapObservable(value),
+                shouldDisplay = true,
+                templateComputed = null,
+                templateName;
 
-            if (typeof templateName != "string") {
-                options = templateName;
-                templateName = ko.utils.unwrapObservable(options['name']);
+            if (typeof options == "string") {
+                templateName = value;
+                options = {};
+            } else {
+                templateName = options['name'];
 
                 // Support "if"/"ifnot" conditions
                 if ('if' in options)


### PR DESCRIPTION
I have following setup:
- knockout 2.2.1
- external knockout template engine 2.0.5

Interestingly until now it worked like a charm. But a single usecase now breaks it - I'm having an external template which uses another external template (altough from my perspective I use this setup at various other places on the same page).

If the **name option is an observable**, it **gets *set**\* with the current $data object instead of reading its value.

If I write `... template: {name: childTemplateName() } ...` instead of `template: {name: childTemplateName } ...` (note parentheses) it works **_with_ the following workaround** applied to knockout:

This line

``` javascript
var templateName = typeof(template) == 'function' ? template(bindingContext['$data'], bindingContext) : template;
```

being changed to

``` javascript
var templateName = typeof(template) == 'function' && ko.isObservable(template) == false ? template(bindingContext['$data'], bindingContext) : ko.utils.unwrapObservable(template);
```

(or 

``` javascript
var templateName = typeof (ko.utils.unwrapObservable(template)) == 'function' == true ? template(bindingContext['$data'], bindingContext) : ko.utils.unwrapObservable(template);
```

)

fixed the issue for me (note the **observable check** and the **unwrap call**).

Although I think it has something to do with the external template engine, `template` being an observable should be protected from being set.
