### PR TITLE
Track observables accessed in getBindingAccessors

### DIFF
--- a/spec/bindingDependencyBehaviors.js
+++ b/spec/bindingDependencyBehaviors.js
@@ -221,8 +221,7 @@ describe('Binding dependencies', function() {
         expect(latestValue).toEqual(2);
     });
 
-    it('Ignores observables accessed within the binding provider\'s "getBindingAccessor" function', function() {
-        // This behavior is not guaranteed and could change in the future if convenient.
+    it('Should track observables accessed within the binding provider\'s "getBindingAccessor" function', function() {
         this.restoreAfter(ko.bindingProvider, 'instance');
 
         var observable = ko.observable('substitute'),
@@ -237,38 +236,6 @@ describe('Binding dependencies', function() {
                     bindings['text'] = function () { return newValue; };
                 }
                 return bindings;
-            }
-        };
-
-        testNode.innerHTML = "<div data-bind='text: \"original\"'></div>";
-        ko.applyBindings({}, testNode);
-
-        expect(testNode).toContainText('substitute');
-        expect(observable.getSubscriptionsCount()).toEqual(0);
-
-        // uptdating observable doesn't update binding
-        observable('new value');
-        expect(testNode).toContainText('substitute');
-    });
-
-    it('Should track observables accessed within the binding provider\'s "getBindingAccessor" function when "trackObservables" is true', function() {
-        this.restoreAfter(ko.bindingProvider, 'instance');
-
-        var observable = ko.observable('substitute'),
-            originalBindingProvider = ko.bindingProvider.instance;
-
-        ko.bindingProvider.instance = {
-            nodeHasBindings: originalBindingProvider.nodeHasBindings,
-            getBindingAccessors: function(node, bindingContext) {
-                var bindings = originalBindingProvider.getBindingAccessors(node, bindingContext);
-                if (bindings && bindings['text']) {
-                    var newValue = observable();
-                    bindings['text'] = function () { return newValue; };
-                }
-                return bindings;
-            },
-            options: {
-                trackObservables: true
             }
         };
 

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -287,29 +287,23 @@
             bindings = sourceBindings;
         } else {
             var provider = ko.bindingProvider['instance'],
-                providerOptions = provider['options'] || {},
                 getBindings = provider['getBindingAccessors'] || getBindingsAndMakeAccessors;
 
-            if (sourceBindings || bindingContext._subscribable || providerOptions['trackObservables']) {
-                // When an obsevable view model is used, the binding context will expose an observable _subscribable value.
-                // Get the binding from the provider within a computed observable so that we can update the bindings whenever
-                // the binding context is updated. Also do so if the binding provider sets a "trackObservables" option.
-                var bindingsUpdater = ko.dependentObservable(
-                    function() {
-                        bindings = sourceBindings ? sourceBindings(bindingContext, node) : getBindings.call(provider, node, bindingContext);
-                        // Register a dependency on the binding context
-                        if (bindings && bindingContext._subscribable)
-                            bindingContext._subscribable();
-                        return bindings;
-                    },
-                    null, { disposeWhenNodeIsRemoved: node }
-                );
+            // Get the binding from the provider within a computed observable so that we can update the bindings whenever
+            // the binding context is updated or if the binding provider accesses observables.
+            var bindingsUpdater = ko.dependentObservable(
+                function() {
+                    bindings = sourceBindings ? sourceBindings(bindingContext, node) : getBindings.call(provider, node, bindingContext);
+                    // Register a dependency on the binding context to support obsevable view models.
+                    if (bindings && bindingContext._subscribable)
+                        bindingContext._subscribable();
+                    return bindings;
+                },
+                null, { disposeWhenNodeIsRemoved: node }
+            );
 
-                if (!bindings || !bindingsUpdater.isActive())
-                    bindingsUpdater = null;
-            } else {
-                bindings = ko.dependencyDetection.ignore(getBindings, provider, [node, bindingContext]);
-            }
+            if (!bindings || !bindingsUpdater.isActive())
+                bindingsUpdater = null;
         }
 
         var bindingHandlerThatControlsDescendantBindings;

--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -24,12 +24,6 @@
             return bindingsString ? this['parseBindingsString'](bindingsString, bindingContext, node, {'valueAccessors':true}) : null;
         },
 
-        'options': {
-            // Don't try to track observables accessed in getBindingAccessors. Note that this is just a hint
-            // to the binding processor, which may still track obsevables if it's convenient.
-            'trackObservables': false
-        },
-
         // The following function is only used internally by this default provider.
         // It's not part of the interface definition for a general binding provider.
         'getBindingsString': function(node, bindingContext) {


### PR DESCRIPTION
My original goal was that `getBindingAccessors` would never access any observables, and to help promote that, I set up the code to [ignore any observables it accessed](https://github.com/knockout/knockout/commit/32fe21095be#diff-49b895d65fb975dc8b84e3311720a326R151). Then, when we enabled support for observable view models, the code was set up so that [observables _would_ be tracked](https://github.com/knockout/knockout/commit/2273c72e83#diff-49b895d65fb975dc8b84e3311720a326L173). Later on, I changed the code to reduce the number of computed observables by checking specifically if an [observable view model was in use](https://github.com/knockout/knockout/commit/93c66c065a#diff-49b895d65fb975dc8b84e3311720a326R293).

After Knockout 3.0 was released, when I was helping @rniemeyer set up his [_class_ binding provider](https://github.com/rniemeyer/knockout-classBindingProvider) to work better with Knockout 3.0, I realized that it was useful to be able to track observables accessed in `getBindingAccessors` for backwards compatibility. For his provider, I worked around the observable view model check by adding a hack that [pretends that an observable view model is in use](https://github.com/rniemeyer/knockout-classBindingProvider/commit/d4a621b54243#diff-32fe7209b7759ca6726cf31060ee7c97R30).

So I'd like to see proper support for this in the next Knockout version. One option is to undo the change in 93c66c065a so that it works for any provider. Another option is to add some kind of flag on the provider that tells Knockout to track observables; then only binding providers that need that support will enable it.
