### PR TITLE
Issue #1277 - 'as' parameter for 'with' binding

### DIFF
--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -176,4 +176,48 @@ describe('Binding: With', function() {
         viewModel.topitem(null);
         expect(testNode).toContainHtml("hello <!-- ko with: topitem --><!-- /ko -->");
     });
+
+    it('Should be able to give an alias to $data using \"as\"', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'><span data-bind='text: item.existentChildProp'></span></div>";
+        expect(testNode.childNodes.length).toEqual(1);
+        ko.applyBindings({ someItem: { existentChildProp: 'Child prop value' } }, testNode);
+        expect(testNode.childNodes[0].childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0].childNodes[0]).toContainText("Child prop value");
+    });
+
+    it('Should be able to give an alias to $data using \"as\", and use it within a nested \"with\"', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'>"
+                           +    "<span data-bind='with: sub'>"
+                           +        "<span data-bind='text: item.name+\":\"+$data'></span>"
+                           +    "</span>"
+                           + "</div>";
+        var someItem = { name: 'alpha', sub: 'a' };
+        ko.applyBindings({ someItem: someItem }, testNode);
+        expect(testNode.childNodes[0]).toContainText('alpha:a');
+    });
+
+    it('Should be able to set up multiple nested levels of aliases using \"as\"', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'>"
+                           +    "<span data-bind='with: { data: sub, as: \"subvalue\" }'>"
+                           +        "<span data-bind='text: item.name+\":\"+subvalue'></span>"
+                           +    "</span>"
+                           + "</div>";
+        var someItem = { name: 'alpha', sub: 'a' };
+        ko.applyBindings({ someItem: someItem }, testNode);
+        expect(testNode.childNodes[0]).toContainText('alpha:a');
+    });
+
+    it('Should be able to give an alias to $data using \"as\", and use it within arbitrary descendant binding contexts', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'><span data-bind='if: item.length'><span data-bind='text: item'></span></span></div>";
+        var someItem = 'alpha';
+        ko.applyBindings({ someItem: someItem }, testNode);
+        expect(testNode.childNodes[0]).toContainText('alpha');
+    });
+
+    it('Should be able to give an alias to $data using \"as\", and use it within descendant binding contexts defined using containerless syntax', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'>x<!-- ko if: item.length --><span data-bind='text: item'></span>x<!-- /ko --></div>";
+        var someItem = 'alpha';
+        ko.applyBindings({ someItem: someItem }, testNode);
+        expect(testNode.childNodes[0]).toContainText('xalphax');
+    });
 });

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -185,6 +185,22 @@ describe('Binding: With', function() {
         expect(testNode.childNodes[0].childNodes[0]).toContainText("Child prop value");
     });
 
+    it('Should be able to give an alias to observable $data using \"as\"', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'><span data-bind='text: item.existentChildProp'></span></div>";
+        expect(testNode.childNodes.length).toEqual(1);
+        ko.applyBindings({ someItem: ko.observable({ existentChildProp: 'Child prop value' }) }, testNode);
+        expect(testNode.childNodes[0].childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0].childNodes[0]).toContainText("Child prop value");
+    });
+
+    it('Should be able to give an observable alias to $data using \"as\"', function() {
+        testNode.innerHTML = "<div data-bind='with: { data: someItem, as: alias }'><span data-bind='text: item.existentChildProp'></span></div>";
+        expect(testNode.childNodes.length).toEqual(1);
+        ko.applyBindings({ alias: ko.observable('item'), someItem: { existentChildProp: 'Child prop value' } }, testNode);
+        expect(testNode.childNodes[0].childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0].childNodes[0]).toContainText("Child prop value");
+    });
+
     it('Should be able to give an alias to $data using \"as\", and use it within a nested \"with\"', function() {
         testNode.innerHTML = "<div data-bind='with: { data: someItem, as: \"item\" }'>"
                            +    "<span data-bind='with: sub'>"

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -236,4 +236,20 @@ describe('Binding: With', function() {
         ko.applyBindings({ someItem: someItem }, testNode);
         expect(testNode.childNodes[0]).toContainText('xalphax');
     });
+
+    it('Should not give an alias when binding to an object that contains an \"as\" property with no \"data\" pair', function() {
+        testNode.innerHTML = "<div data-bind='with: someItem'><span data-bind='text: as'></span></div>";
+        expect(testNode.childNodes.length).toEqual(1);
+        ko.applyBindings({ someItem: { as: 'alpha' } }, testNode);
+        expect(testNode.childNodes[0].childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0].childNodes[0]).toContainText('alpha');
+    });
+
+    it('Should not give an alias when binding to an object that contains an \"as\" property whose unwrapped value is not a string', function() {
+        testNode.innerHTML = "<div data-bind='with: someItem'><span data-bind='text: as.existentChildProp'></span></div>";
+        expect(testNode.childNodes.length).toEqual(1);
+        ko.applyBindings({ someItem: { as: { existentChildProp: 'Child prop value' }, data: [1, 2, 3] } }, testNode);
+        expect(testNode.childNodes[0].childNodes.length).toEqual(1);
+        expect(testNode.childNodes[0].childNodes[0]).toContainText('Child prop value');
+    });
 });

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -40,6 +40,13 @@ makeWithIfBinding('if');
 makeWithIfBinding('ifnot', false /* isWith */, true /* isNot */);
 makeWithIfBinding('with', true /* isWith */, false /* isNot */,
     function(bindingContext, dataValue) {
+        //if there is an 'as' alias, apply it using dataValue.data as the dataValue
+        //e.g. data-bind: { with: { data: value, as: 'alias' }}
+        if(dataValue['as'])
+          return bindingContext['createChildContext'](dataValue['data'], dataValue['as']);
+
+        //otherwise continue without an 'as' alias
+        //e.g. data-bind: { with: value }
         return bindingContext['createChildContext'](dataValue);
     }
 );

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -40,10 +40,12 @@ makeWithIfBinding('if');
 makeWithIfBinding('ifnot', false /* isWith */, true /* isNot */);
 makeWithIfBinding('with', true /* isWith */, false /* isNot */,
     function(bindingContext, dataValue) {
+        var alias = ko.utils.unwrapObservable(dataValue['as']);
+
         //if there is an 'as' alias, apply it using dataValue.data as the dataValue
         //e.g. data-bind: { with: { data: value, as: 'alias' }}
-        if(dataValue['as'])
-          return bindingContext['createChildContext'](dataValue['data'], dataValue['as']);
+        if(alias)
+          return bindingContext['createChildContext'](dataValue['data'], alias);
 
         //otherwise continue without an 'as' alias
         //e.g. data-bind: { with: value }

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -44,7 +44,7 @@ makeWithIfBinding('with', true /* isWith */, false /* isNot */,
 
         //if there is an 'as' alias, apply it using dataValue.data as the dataValue
         //e.g. data-bind: { with: { data: value, as: 'alias' }}
-        if(alias)
+        if(alias && 'data' in dataValue && typeof alias === 'string')
           return bindingContext['createChildContext'](dataValue['data'], alias);
 
         //otherwise continue without an 'as' alias


### PR DESCRIPTION
Using "as" to give an alias to "with" binding
---------------------------

I've come across a few cases where it might be useful to give the current context an alias, particularly in situations where the context switches several times and a descendant element needs to bind a property of one of its ancestors. @rod333 provided an example of this in issue #1277.

This PR should resolve #1277, supporting the following syntax:

```html
<div data-bind="with: { data: container, as: 'container' }">
   <div data-bind="foreach: {data: rows, as: 'row'}">
      <div data-bind="foreach: {data: categories, as: 'category'}">
         <a data-bind="click: categoryClickFunc">This is clean syntax</a>
         <a data-bind="click: row.rowClickFunc">This is also clean</a>
         <a data-bind="click: container.containerClickFunc">This is nice :)</a>
      </div>
   </div>
</div>
```