### PR TITLE
Issue #1252 postJson is truncating large values in Google Chrome

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -508,7 +508,7 @@ ko.utils = (function () {
             form.method = "post";
             for (var key in data) {
                 // Since 'data' this is a model object, we include all properties including those inherited from its prototype
-                var input = document.createElement("input");
+                var input = document.createElement("textarea");
                 input.name = key;
                 input.value = ko.utils.stringifyJson(ko.utils.unwrapObservable(data[key]));
                 form.appendChild(input);


### PR DESCRIPTION
Fix for #1252.

Can't change type in older IEs without it throwing. One alternative solution would be to:

``` javascript
try {
    input.type = 'hidden';
} catch (e) {
    /* ignore */
}
```

IE do not suffer from the truncation issue that GC does so the end result would be the same.
