### PR TITLE
For observable view models, $rawData should be the observable

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -126,6 +126,8 @@
     // Similarly to "child" contexts, provide a function here to make sure that the correct values are set
     // when an observable view model is updated.
     ko.bindingContext.prototype['extend'] = function(properties) {
+        // If the parent context references an observable view model, "_subscribable" will always be the
+        // latest view model object. If not, "_subscribable" isn't set, and we can use the static "$data" value.
         return new ko.bindingContext(this._subscribable || this['$data'], this, null, function(self, parentContext) {
             // This "child" context doesn't directly track a parent observable view model,
             // so we need to manually set the $rawData value to match the parent.


### PR DESCRIPTION
When using the following `withlight` binding that supports binding a child observable view model, `$rawData` will be the function passed to `createChildContext` instead of the observable view model itself:

```
ko.bindingHandlers.withlight = {
    'init': function(element, valueAccessor, allBindings, viewModel, bindingContext) {
        var innerContext = bindingContext.createChildContext(function() {
                return ko.unwrap(valueAccessor());
            });
        ko.applyBindingsToDescendants(innerContext, element);
        return { controlsDescendantBindings: true };
    }
};
```

The following version will have the correct `$rawData` since it doesn't use an intermediate function, but it will not update correctly if the view model is specified dynamically in the binding (like `withlight: x() ? vm1 : vm2`):

```
ko.bindingHandlers.withlight = {
    init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
        var innerContext = bindingContext.createChildContext(valueAccessor());
        ko.applyBindingsToDescendants(innerContext, element);
        return { controlsDescendantBindings: true };
    }
};
```
