### PR TITLE
addDisposeCallback to "not nodes"

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -223,7 +223,7 @@ ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunction
 
     // Attach a DOM node disposal callback so that the computed will be proactively disposed as soon as the node is
     // removed using ko.removeNode. But skip if isActive is false (there will never be any dependencies to dispose).
-    if (disposeWhenNodeIsRemoved && isActive()) {
+    if (disposeWhenNodeIsRemoved && isActive() && disposeWhenNodeIsRemoved.nodeType) {
         dispose = function() {
             ko.utils.domNodeDisposal.removeDisposeCallback(disposeWhenNodeIsRemoved, dispose);
             disposeAllSubscriptionsToDependencies();


### PR DESCRIPTION
https://github.com/knockout/knockout/blob/master/src/subscribables/dependentObservable.js#L231

Can not applied to not-nodes...  call from this line:
https://github.com/knockout/knockout/blob/master/src/binding/bindingAttributeSyntax.js#L75

before applying need to be validated, like
`if (disposeWhenNodeIsRemoved.nodeType)`
