### PR TITLE
include prior value when notifying subscribers

### DIFF
--- a/spec/defaultBindings/styleBehaviors.js
+++ b/spec/defaultBindings/styleBehaviors.js
@@ -32,4 +32,24 @@ describe('Binding: CSS style', function() {
         myObservable(50);
         expect(testNode.childNodes[0].style.width).toBe("50px");
     });
+
+    it('Should convert css name to javascript name', function () {
+        var myObservable = new ko.observable("10pt");
+        testNode.innerHTML = "<div data-bind=\"style: { 'font-size': size }\">Hallo</div>";
+        ko.applyBindings({ size: myObservable }, testNode);
+
+        expect(testNode.childNodes[0].style.fontSize).toBe("10pt");
+        myObservable("12pt");
+        expect(testNode.childNodes[0].style.fontSize).toBe("12pt");
+    });
+
+    it('Should handle float correctly', function () {
+        var myObservable = new ko.observable("left");
+        testNode.innerHTML = "<div data-bind='style: { styleFloat: value }''>Hallo</div>";
+        ko.applyBindings({ value: myObservable }, testNode);
+
+        expect(testNode.childNodes[0].style.cssFloat).toBe("left");
+        myObservable("right");
+        expect(testNode.childNodes[0].style.cssFloat).toBe("right");
+    });
 });

--- a/spec/defaultBindings/styleBehaviors.js
+++ b/spec/defaultBindings/styleBehaviors.js
@@ -12,4 +12,15 @@ describe('Binding: CSS style', function() {
         myObservable(undefined);
         expect(testNode.childNodes[0].style.backgroundColor).toEqual("");
     });
+
+
+    it('Should give the element the specified CSS style value', function () {
+        var myObservable = new ko.observable(20);
+        testNode.innerHTML = "<div data-bind='style: { opacity: opacityValue }'>Hallo</div>";
+        ko.applyBindings({ opacityValue: myObservable }, testNode);
+
+        expect(+testNode.childNodes[0].style.opacity).toBe(20);
+        myObservable(0);
+        expect(+testNode.childNodes[0].style.opacity).toBe(0);
+    });
 });

--- a/spec/defaultBindings/styleBehaviors.js
+++ b/spec/defaultBindings/styleBehaviors.js
@@ -13,14 +13,23 @@ describe('Binding: CSS style', function() {
         expect(testNode.childNodes[0].style.backgroundColor).toEqual("");
     });
 
-
-    it('Should give the element the specified CSS style value', function () {
+    it('Should respect numeric 0 values', function () {
         var myObservable = new ko.observable(20);
         testNode.innerHTML = "<div data-bind='style: { opacity: opacityValue }'>Hallo</div>";
         ko.applyBindings({ opacityValue: myObservable }, testNode);
 
-        expect(+testNode.childNodes[0].style.opacity).toBe(20);
+        expect(testNode.childNodes[0].style.opacity).toBe("20");
         myObservable(0);
-        expect(+testNode.childNodes[0].style.opacity).toBe(0);
+        expect(testNode.childNodes[0].style.opacity).toBe("0");
+    });
+
+    it('Should infer numeric unit when not provided for appropriate styles', function () {
+        var myObservable = new ko.observable(200);
+        testNode.innerHTML = "<div data-bind='style: { width: widthValue }'>Hallo</div>";
+        ko.applyBindings({ widthValue: myObservable }, testNode);
+
+        expect(testNode.childNodes[0].style.width).toBe("200px");
+        myObservable(50);
+        expect(testNode.childNodes[0].style.width).toBe("50px");
     });
 });

--- a/spec/observableBehaviors.js
+++ b/spec/observableBehaviors.js
@@ -72,6 +72,21 @@ describe('Observable', function() {
         expect(notifiedValues[1]).toEqual('B');
     });
 
+    it('Should notify subscribers with the prior value', function () {
+        var instance = new ko.observable();
+        var priorValues = [];
+        instance.subscribe(function (value, priorValue) {
+            priorValues.push(priorValue);
+        });
+
+        instance('A');
+        instance('B');
+
+        expect(priorValues.length).toEqual(2);
+        expect(priorValues[0]).toEqual(undefined);
+        expect(priorValues[1]).toEqual('A');
+    });
+
     it('Should be able to tell it that its value has mutated, at which point it notifies subscribers', function () {
         var instance = new ko.observable();
         var notifiedValues = [];
@@ -130,7 +145,7 @@ describe('Observable', function() {
     it('Should ignore writes when the new value is primitive and strictly equals the old value', function() {
         var instance = new ko.observable();
         var notifiedValues = [];
-        instance.subscribe(notifiedValues.push, notifiedValues);
+        instance.subscribe(function (value) { notifiedValues.push(value); });
 
         for (var i = 0; i < 3; i++) {
             instance("A");
@@ -165,7 +180,7 @@ describe('Observable', function() {
         var constantObject = {};
         var instance = new ko.observable(constantObject);
         var notifiedValues = [];
-        instance.subscribe(notifiedValues.push, notifiedValues);
+        instance.subscribe(function (value) { notifiedValues.push(value); });
         instance(constantObject);
         expect(notifiedValues).toEqual([constantObject]);
     });
@@ -173,7 +188,7 @@ describe('Observable', function() {
     it('Should notify subscribers of a change even when an identical primitive is written if you\'ve set the equality comparer to null', function() {
         var instance = new ko.observable("A");
         var notifiedValues = [];
-        instance.subscribe(notifiedValues.push, notifiedValues);
+        instance.subscribe(function (value) { notifiedValues.push(value); });
 
         // No notification by default
         instance("A");
@@ -192,7 +207,7 @@ describe('Observable', function() {
         };
 
         var notifiedValues = [];
-        instance.subscribe(notifiedValues.push, notifiedValues);
+        instance.subscribe(function (value) { notifiedValues.push(value); });
 
         instance({ id: 1 });
         expect(notifiedValues.length).toEqual(1);
@@ -225,7 +240,7 @@ describe('Observable', function() {
     it('Should expose a "notify" extender that can configure the observable to notify on all writes, even if the value is unchanged', function() {
         var instance = new ko.observable();
         var notifiedValues = [];
-        instance.subscribe(notifiedValues.push, notifiedValues);
+        instance.subscribe(function (value) { notifiedValues.push(value); });
 
         instance(123);
         expect(notifiedValues.length).toEqual(1);

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -1,18 +1,67 @@
-var unitlessCssProperties = { columnCount: 1, fillOpacity: 1, fontWeight: 1, lineHeight: 1, opacity: 1, orphans: 1, widows: 1, zIndex: 1, zoom: 1 };
+var unitlessCssProperties = { 'columnCount': 1, 'fillOpacity': 1, 'fontWeight': 1, 'lineHeight': 1, 'opacity': 1, 'orphans': 1, 'widows': 1, 'zIndex': 1, 'zoom': 1 };
+var cssBrowserPrefixes = ['Webkit', 'O', 'Moz', 'ms'];
+var currentBrowserPrefix;
+var cssPropCache = {};
+var camelCaseRegex = /-(.)/gi;
+
+function toJavaScriptStyleName (value) {
+		return value.replace(camelCaseRegex, function () { return arguments[1].toUpperCase(); });
+}
+
+function toBrowserStyleName (style, name) {
+	if (name in style) {
+		return name;
+	}
+
+	var upperCaseName = name.charAt(0).toUpperCase() + name.substr(1);
+	var vendorSpecificName;
+
+	if (currentBrowserPrefix) {
+		vendorSpecificName = currentBrowserPrefix + upperCaseName;
+		if (vendorSpecificName in style) {
+			return vendorSpecificName;
+		}
+	}
+	else {
+		var i = cssBrowserPrefixes.length;
+		while (i--) {
+			vendorSpecificName = cssBrowserPrefixes[i] + upperCaseName;
+			if (vendorSpecificName in style) {
+				// Set the current browser prefix now that we know it
+				currentBrowserPrefix = cssBrowserPrefixes[i];
+				return vendorSpecificName;
+			}
+		}
+	}
+
+	return name;
+}
+
+// Account for discrepancies in `float`
+cssPropCache['float'] = cssPropCache['cssFloat'] = cssPropCache['styleFloat'] = document && (function() {
+	var div = document.createElement('div');
+
+	// cssFloat is standard though older IE uses styleFloat
+	 return 'styleFloat' in div.style ? 'styleFloat' : 'cssFloat';
+})();
 
 ko.bindingHandlers['style'] = {
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor() || {});
         ko.utils.objectForEach(value, function(styleName, styleValue) {
+        		styleName = toJavaScriptStyleName(styleName);
             styleValue = ko.utils.unwrapObservable(styleValue);
 
-            // Note that we don't care about zero here
-            if (styleValue && typeof(styleValue) === "number" && !(styleName in unitlessCssProperties)) {
-            	styleValue += "px";
+            // Note that we don't care about zero here - zero doesn't need a unit
+            if (styleValue && typeof(styleValue) === 'number' && !(styleName in unitlessCssProperties)) {
+            	styleValue += 'px';
             }
 
-            // Empty string removes the value, whereas null/undefined have no effect
-            element.style[styleName] = styleValue == null ? "" : styleValue;
+            // Store properties in cache to save on future lookups
+            styleName = cssPropCache[styleName] || (cssPropCache[styleName] = toBrowserStyleName(element.style, styleName));
+
+            // Empty string/null/undefined removes the value
+            element.style[styleName] = styleValue == null ? '' : styleValue;
         });
     }
 };

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -3,7 +3,8 @@ ko.bindingHandlers['style'] = {
         var value = ko.utils.unwrapObservable(valueAccessor() || {});
         ko.utils.objectForEach(value, function(styleName, styleValue) {
             styleValue = ko.utils.unwrapObservable(styleValue);
-            element.style[styleName] = styleValue || ""; // Empty string removes the value, whereas null/undefined have no effect
+            // Empty string removes the value, whereas null/undefined have no effect
+            element.style[styleName] = styleValue == null ? "" : styleValue;
         });
     }
 };

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -1,8 +1,16 @@
+var unitlessCssProperties = { columnCount: 1, fillOpacity: 1, fontWeight: 1, lineHeight: 1, opacity: 1, orphans: 1, widows: 1, zIndex: 1, zoom: 1 };
+
 ko.bindingHandlers['style'] = {
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor() || {});
         ko.utils.objectForEach(value, function(styleName, styleValue) {
             styleValue = ko.utils.unwrapObservable(styleValue);
+
+            // Note that we don't care about zero here
+            if (styleValue && typeof(styleValue) === "number" && !(styleName in unitlessCssProperties)) {
+            	styleValue += "px";
+            }
+
             // Empty string removes the value, whereas null/undefined have no effect
             element.style[styleName] = styleValue == null ? "" : styleValue;
         });

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -43,10 +43,8 @@ ko.extenders = {
     }
 };
 
-var primitiveTypes = { 'undefined':1, 'boolean':1, 'number':1, 'string':1 };
 function valuesArePrimitiveAndEqual(a, b) {
-    var oldValueIsPrimitive = (a === null) || (typeof(a) in primitiveTypes);
-    return oldValueIsPrimitive ? (a === b) : false;
+    return ko.utils.valueIsPrimitive(a) ? (a === b) : false;
 }
 
 function throttle(callback, timeout) {

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -1,4 +1,5 @@
 ko.observable = function (initialValue) {
+    var _priorValue;
     var _latestValue = initialValue;
 
     function observable() {
@@ -11,6 +12,7 @@ ko.observable = function (initialValue) {
                 _latestValue = arguments[0];
                 if (DEBUG) observable._latestValue = _latestValue;
                 observable.valueHasMutated();
+                _priorValue = _latestValue;
             }
             return this; // Permits chained assignments
         }
@@ -25,7 +27,7 @@ ko.observable = function (initialValue) {
 
     if (DEBUG) observable._latestValue = _latestValue;
     observable.peek = function() { return _latestValue };
-    observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
+    observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue, null, _priorValue); }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
 
     ko.exportProperty(observable, 'peek', observable.peek);

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -41,9 +41,8 @@ var ko_subscribable_fn = {
         return subscription;
     },
 
-    notifySubscribers: function (valueToNotify, event, priorValue) {
+    "notifySubscribers": function (valueToNotify, event) {
         event = event || defaultEvent;
-        var args = arguments.length === 3 ? [valueToNotify, priorValue] : [valueToNotify]; // Only pass prior value if provided
         if (this.hasSubscriptionsForEvent(event)) {
             try {
                 ko.dependencyDetection.begin(); // Begin suppressing dependency detection (by setting the top frame to undefined)
@@ -51,7 +50,7 @@ var ko_subscribable_fn = {
                     // In case a subscription was disposed during the arrayForEach cycle, check
                     // for isDisposed on each subscription before invoking its callback
                     if (!subscription.isDisposed)
-                        subscription.callback.apply(null, args);
+                        subscription.callback(valueToNotify);
                 }
             } finally {
                 ko.dependencyDetection.end(); // End suppressing dependency detection

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -41,8 +41,9 @@ var ko_subscribable_fn = {
         return subscription;
     },
 
-    "notifySubscribers": function (valueToNotify, event) {
+    notifySubscribers: function (valueToNotify, event, priorValue) {
         event = event || defaultEvent;
+        var args = arguments.length === 3 ? [valueToNotify, priorValue] : [valueToNotify]; // Only pass prior value if provided
         if (this.hasSubscriptionsForEvent(event)) {
             try {
                 ko.dependencyDetection.begin(); // Begin suppressing dependency detection (by setting the top frame to undefined)
@@ -50,7 +51,7 @@ var ko_subscribable_fn = {
                     // In case a subscription was disposed during the arrayForEach cycle, check
                     // for isDisposed on each subscription before invoking its callback
                     if (!subscription.isDisposed)
-                        subscription.callback(valueToNotify);
+                        subscription.callback.apply(null, args);
                 }
             } finally {
                 ko.dependencyDetection.end(); // End suppressing dependency detection

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,6 +55,8 @@ ko.utils = (function () {
     var isIe6 = ieVersion === 6,
         isIe7 = ieVersion === 7;
 
+    var primitiveTypes = { 'undefined':1, 'boolean':1, 'number':1, 'string':1 };
+
     function isClickOnCheckableElement(element, eventType) {
         if ((ko.utils.tagNameLower(element) !== "input") || !element.type) return false;
         if (eventType.toLowerCase() != "click") return false;
@@ -526,6 +528,10 @@ ko.utils = (function () {
             document.body.appendChild(form);
             options['submitter'] ? options['submitter'](form) : form.submit();
             setTimeout(function () { form.parentNode.removeChild(form); }, 0);
+        },
+
+        valueIsPrimitive: function (value) {
+            return value === null || typeof(value) in primitiveTypes;
         }
     }
 }());
@@ -553,6 +559,7 @@ ko.exportSymbol('utils.triggerEvent', ko.utils.triggerEvent);
 ko.exportSymbol('utils.unwrapObservable', ko.utils.unwrapObservable);
 ko.exportSymbol('utils.objectForEach', ko.utils.objectForEach);
 ko.exportSymbol('utils.addOrRemoveItem', ko.utils.addOrRemoveItem);
+ko.exportSymbol('utils.valueIsPrimitive', ko.utils.valueIsPrimitive);
 ko.exportSymbol('unwrap', ko.utils.unwrapObservable); // Convenient shorthand, because this is used so commonly
 
 if (!Function.prototype['bind']) {


### PR DESCRIPTION
I agree that it would be very convenient for knockout to natively support sending the prior value along with the new value when notifying subscribers. I decided to take a stab at it. 

Closes #914.
