### PR TITLE
Use /*! … */ comment format for banner so that external minifiers know to preserve it

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,9 +7,11 @@ module.exports = function(grunt) {
         // Metadata
         pkg: grunt.file.readJSON('package.json'),
         fragments: './build/fragments/',
-        banner: '// Knockout JavaScript library v<%= pkg.version %>\n' +
-                '// (c) Steven Sanderson - <%= pkg.homepage %>\n' +
-                '// License: <%= pkg.licenses[0].type %> (<%= pkg.licenses[0].url %>)\n\n',
+        banner: '/*!\n' +
+                ' * Knockout JavaScript library v<%= pkg.version %>\n' +
+                ' * (c) Steven Sanderson - <%= pkg.homepage %>\n' +
+                ' * License: <%= pkg.licenses[0].type %> (<%= pkg.licenses[0].url %>)\n' +
+                ' */\n\n',
 
         checktrailingspaces: {
             main: {


### PR DESCRIPTION
KO ships its own pre-minified file, but nonetheless sometimes people will use their own minifier, either on the `.debug.js` file or even on the already-minified `knockout-x.y.z.js` file (perhaps because they are bundling it with other files, and then they run a minifier over the whole bundle). The most common one is uglify.js.

Currently, Uglify strips KO's license header. This pull request uses the special `/*! ... */` comment format for the license header, so that Uglify's `preserveComments: 'some'` option knows it should retain it.

Most JavaScript libraries use this format for license headers - I don't see any reason for KO not to :)
