### PR TITLE
Memory leak in ko.computed

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -34,6 +34,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         _subscriptionsToDependencies = {};
         _dependenciesCount = 0;
         _needsEvaluation = false;
+        readFunction = null;
     }
 
     function evaluatePossiblyAsync() {


### PR DESCRIPTION
Hi,

I think ko.computed is holding onto a reference to readFunction even after it gets disposed.

This pastebin demonstrates the leak: http://pastebin.com/Ub0Ef6LY

Let me know if there are any issues!

Thanks,
Justin
