### PR TITLE
test and implementation checkedValue+value throws error 

### DIFF
--- a/spec/defaultBindings/checkedBehaviors.js
+++ b/spec/defaultBindings/checkedBehaviors.js
@@ -339,4 +339,14 @@ describe('Binding: Checked', function() {
         ko.utils.triggerEvent(testNode.childNodes[2], "click");
         expect(testNode.childNodes[0].checked).toEqual(true);
     });
+
+    it('When checkbox has a value attribute and a checkedValue property throw error', function() {
+        var prevCheckSetting = ko.bindingHandlers['disallow-value-and-checkedValue'];
+        ko.bindingHandlers['checkedValue']['disallow-value-and-checkedValue'] = true;
+        testNode.innerHTML = '<input type="radio" value="1" data-bind="checkedValue: 1" />';
+        expect(function(){
+            ko.applyBindings({}, testNode);
+        }).toThrow();
+        ko.bindingHandlers['checkedValue']['disallow-value-and-checkedValue'] = prevCheckSetting;
+    })
 });

--- a/src/binding/defaultBindings/checked.js
+++ b/src/binding/defaultBindings/checked.js
@@ -94,6 +94,11 @@ ko.bindingHandlers['checked'] = {
 ko.expressionRewriting.twoWayBindings['checked'] = true;
 
 ko.bindingHandlers['checkedValue'] = {
+    'disallow-value-and-checkedValue': false,
+    'init': function(element) {
+        if(ko.bindingHandlers['checkedValue']['disallow-value-and-checkedValue'] && element.hasAttribute('value'))
+            throw Error("The checkedValue binding will always overwrite the value binding. You should avoid using both.");
+    },
     'update': function (element, valueAccessor) {
         element.value = ko.utils.unwrapObservable(valueAccessor());
     }


### PR DESCRIPTION
[Fix for #1146](https://github.com/knockout/knockout/issues/1146).

Not sure if this is exactly what you guys had in mind (I would think by default the `disallow-value-and-checkedValue` should be set to `true`) but doing this causes other tests to fail.
