### PR TITLE
Fix $rawData within 'with' bindings and rendered templates

### DIFF
--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -176,4 +176,20 @@ describe('Binding: With', function() {
         viewModel.topitem(null);
         expect(testNode).toContainHtml("hello <!-- ko with: topitem --><!-- /ko -->");
     });
+
+    it('Should provide access to an observable viewModel through $rawData', function() {
+        testNode.innerHTML = "<div data-bind='with: item'><input data-bind='value: $rawData'/></div>";
+        var item = ko.observable('one');
+        ko.applyBindings({ item: item }, testNode);
+        expect(testNode.childNodes[0]).toHaveValues(['one']);
+
+        // Should update observable when input is changed
+        testNode.childNodes[0].childNodes[0].value = 'two';
+        ko.utils.triggerEvent(testNode.childNodes[0].childNodes[0], "change");
+        expect(item()).toEqual('two');
+
+        // Should update the input when the observable changes
+        item('three');
+        expect(testNode.childNodes[0]).toHaveValues(['three']);
+    });
 });

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -384,6 +384,22 @@ describe('Templating', function() {
         expect(testNode.childNodes[0]).toContainText("true");
     });
 
+    it('Data binding syntax should be able to use $rawData in binding value to refer to a top level template\'s view model observable', function() {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
+        ko.renderTemplate("someTemplate", ko.observable('value'), null, testNode);
+        expect(testNode.childNodes[0]).toContainText("true");
+    });
+
+    it('Data binding syntax should be able to use $rawData in binding value to refer to a data-bound template\'s view model observable', function() {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
+        testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+
+        viewModel = { someProp: ko.observable('value') };
+        ko.applyBindings(viewModel, testNode);
+
+        expect(testNode.childNodes[0].childNodes[0]).toContainText("true");
+    });
+
     it('Data binding syntax should defer evaluation of variables until the end of template rendering (so bindings can take independent subscriptions to them)', function () {
         ko.setTemplateEngine(new dummyTemplateEngine({
             someTemplate: "<input data-bind='value:message' />[js: message = 'goodbye'; undefined; ]"

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -20,7 +20,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
                         if (!isFirstRender) {
                             ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
                         }
-                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, dataValue) : bindingContext, element);
+                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, valueAccessor) : bindingContext, element);
                     } else {
                         ko.virtualElements.emptyNode(element);
                     }


### PR DESCRIPTION
Make $rawData correctly refer to the local view model observable inside a 'with' binding.