### PR TITLE
ko.utils.postJson is truncating large values in Google Chrome

### DIFF
--- a/spec/jsonPostingBehaviors.js
+++ b/spec/jsonPostingBehaviors.js
@@ -54,7 +54,8 @@ describe('JSON posting', function() {
             submitter: function(x) { submittedForm = x; }
         });
 
-        expect(submittedForm.longString.value.length).toEqual(longStringJson.length);
-        expect(submittedForm.longString.value).toEqual(longStringJson);
+        var submittedValue = ko.utils.getFormFields(submittedForm, 'longString')[0].value;
+        expect(submittedValue.length).toEqual(longStringJson.length);
+        expect(submittedValue).toEqual(longStringJson);
     });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -513,12 +513,14 @@ ko.utils = (function () {
             for (var key in data) {
                 // Since 'data' this is a model object, we include all properties including those inherited from its prototype
                 var input = document.createElement("input");
+                input.type = "hidden";
                 input.name = key;
                 input.value = ko.utils.stringifyJson(ko.utils.unwrapObservable(data[key]));
                 form.appendChild(input);
             }
             objectForEach(params, function(key, value) {
                 var input = document.createElement("input");
+                input.type = "hidden";
                 input.name = key;
                 input.value = value;
                 form.appendChild(input);


### PR DESCRIPTION
When posting a model with the `postJson` method, each value is assigned to an input element's value and the submitted:

```
/* snip */
for (var key in data) {
   // Since 'data' this is a model object, we include all properties including those inherited from its prototype
  var input = document.createElement("input");
  input.name = key;
  input.value = ko.utils.stringifyJson(ko.utils.unwrapObservable(data[key]));
  form.appendChild(input);
}
/* snip */
```

The issue is that apparently Google Chrome truncates an input's value after 512KB, if its type is "text" (which is the default when not explicitly setting anything else).
This creates trouble if one tries to post e.g. a base64-encoded image, as the posted JSON is just truncated after 512KB.
Have confirmed this behaviour in Chrome 28 and 31.

Quick tests indicate that setting the type to "hidden" solves the problem.
Here is a fiddle which demonstrates the issue: http://jsfiddle.net/t8q7b/

EDIT: Here's another fiddle which actually involves knockout: http://jsfiddle.net/Gv7Y9/1/
