### PR TITLE
bug in 'style'-binding

### DIFF
--- a/spec/defaultBindings/styleBehaviors.js
+++ b/spec/defaultBindings/styleBehaviors.js
@@ -12,4 +12,18 @@ describe('Binding: CSS style', function() {
         myObservable(undefined);
         expect(testNode.childNodes[0].style.backgroundColor).toEqual("");
     });
+
+    it('Should be able to apply the numeric value zero to a style', function() {
+        // Represents https://github.com/knockout/knockout/issues/972
+        testNode.innerHTML = "<div data-bind='style: { width: 0 }'></div>";
+        ko.applyBindings(null, testNode);
+        expect(testNode.childNodes[0].style.width).toBe("0px");
+    });
+
+    it('Should be able to use "false" to remove a style', function() {
+        // Verifying that the fix for 972 doesn't break this existing behaviour
+        testNode.innerHTML = "<div style='width: 100px' data-bind='style: { width: false }'></div>";
+        ko.applyBindings(null, testNode);
+        expect(testNode.childNodes[0].style.width).toBe("");
+    });
 });

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -3,7 +3,13 @@ ko.bindingHandlers['style'] = {
         var value = ko.utils.unwrapObservable(valueAccessor() || {});
         ko.utils.objectForEach(value, function(styleName, styleValue) {
             styleValue = ko.utils.unwrapObservable(styleValue);
-            element.style[styleName] = styleValue || ""; // Empty string removes the value, whereas null/undefined have no effect
+
+            if (styleValue === null || styleValue === undefined || styleValue === false) {
+                // Empty string removes the value, whereas null/undefined have no effect
+                styleValue = "";
+            }
+
+            element.style[styleName] = styleValue;
         });
     }
 };


### PR DESCRIPTION
Hi,

we use knockout a lot in our Project, and have noticed that when you try to update css properties, which have no unit, you can end up that knockout removes the property, because the value you want to set is `0`. (like setting `"opacity: 0"`)

``` javascript
ko.bindingHandlers['style'] = {
    'update': function (element, valueAccessor) {
        var value = ko.utils.unwrapObservable(valueAccessor() || {});
        for (var styleName in value) {
            if (typeof styleName == "string") {
                var styleValue = ko.utils.unwrapObservable(value[styleName]);
                element.style[styleName] = styleValue || ""; // Empty string removes the value, whereas null/undefined have no effect
            }
        }
    }
};
```

The problem lies on the folowing line

``` javascript
 element.style[styleName] = styleValue || "";
```

since `styleValue` is `0` it will default to `""`.

we overwrote the 'style'-binding with the following code:

``` javascript
var cssNumberTest = /columnCount|fillOpacity|fontWeight|lineHeight|opacity|orphans|widows|zIndex|zoom/;
ko.bindingHandlers['style'] = {
    'update': function (element, valueAccessor) {
        var value = ko.utils.unwrapObservable(valueAccessor() || {});
        for (var styleName in value) {
            if (typeof styleName == "string") {
                var styleValue = ko.utils.unwrapObservable(value[styleName]);
                if(!cssNumberTest.test(styleName)){
                    styleValue = styleValue || ""; // Empty string removes the value, whereas null/undefined have no effect
                }
                element.style[styleName] = styleValue;
            }
        }
    }
};
```

Please consider updating knockout.js to make it an even greater, more stable library!

Thanks
