### PR TITLE
Update the array utilities to use the native methods

### DIFF
--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -74,6 +74,32 @@ describe('Observable Array change tracking', function() {
         });
     });
 
+    it('Converts a non array to an array', function() {
+        captureCompareArraysCalls(function(callLog) {
+            var myArray = ko.observable('hello').extend({'trackArrayChanges':true}),
+                changelist1;
+
+            myArray.subscribe(function(changes) { changelist1 = changes; }, null, 'arrayChange');
+            myArray(1);
+
+            // See that, not only did it invoke compareArrays only once, but the
+            // return values from getChanges are the same array instances
+            expect(callLog.length).toBe(1);
+            expect(changelist1).toEqual([
+                { status: 'deleted', value: 'hello', index: 0 },
+                { status: 'added', value: 1, index: 0 }
+            ]);
+
+            // Objects get converted to Array
+            myArray({a: 1});
+            expect(callLog.length).toBe(2);
+            expect(changelist1).toEqual([
+                { status: 'deleted', value: 1, index: 0 },
+                { status: 'added', value: {a: 1}, index: 0 }
+            ]);
+        });
+    });
+
     it('Skips the diff algorithm when the array mutation is a known operation', function() {
         captureCompareArraysCalls(function(callLog) {
             var myArray = ko.observableArray(['Alpha', 'Beta', 'Gamma']),

--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -36,9 +36,9 @@ describe('arrayForEach', function () {
         ko.utils.arrayForEach(["a", "b", "c"], callback);
 
         expect(callback.calls.length).toBe(3);
-        expect(callback.calls[0].args).toEqual(["a", 0]);
-        expect(callback.calls[1].args).toEqual(["b", 1]);
-        expect(callback.calls[2].args).toEqual(["c", 2]);
+        expect(callback.calls[0].args).toEqual(["a", 0, ["a", "b", "c"]]);
+        expect(callback.calls[1].args).toEqual(["b", 1, ["a", "b", "c"]]);
+        expect(callback.calls[2].args).toEqual(["c", 2, ["a", "b", "c"]]);
     });
 
     it('Should do nothing with empty arrays', function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,13 +66,17 @@ ko.utils = (function () {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
 
         arrayForEach: function (array, action) {
+            if (array && typeof array.forEach == 'function') {
+                return array.forEach(action);
+            }
             for (var i = 0, j = array.length; i < j; i++)
-                action(array[i], i);
+                action(array[i], i, array);
         },
 
         arrayIndexOf: function (array, item) {
-            if (typeof Array.prototype.indexOf == "function")
-                return Array.prototype.indexOf.call(array, item);
+            if (array && typeof array.indexOf == 'function') {
+                return array.indexOf(item);
+            }
             for (var i = 0, j = array.length; i < j; i++)
                 if (array[i] === item)
                     return i;
@@ -80,6 +84,9 @@ ko.utils = (function () {
         },
 
         arrayFirst: function (array, predicate, predicateOwner) {
+            if (array && typeof array.find == 'function') {
+                return array.find(predicate, predicateOwner);
+            }
             for (var i = 0, j = array.length; i < j; i++)
                 if (predicate.call(predicateOwner, array[i], i))
                     return array[i];
@@ -99,14 +106,18 @@ ko.utils = (function () {
         arrayGetDistinctValues: function (array) {
             array = array || [];
             var result = [];
-            for (var i = 0, j = array.length; i < j; i++) {
-                if (ko.utils.arrayIndexOf(result, array[i]) < 0)
-                    result.push(array[i]);
-            }
+            ko.utils.arrayForEach(array, function(item) {
+                if (ko.utils.arrayIndexOf(result, item) < 0)
+                    result.push(item);
+            });
+
             return result;
         },
 
         arrayMap: function (array, mapping) {
+            if (array && typeof array.map == 'function') {
+                return array.map(mapping);
+            }
             array = array || [];
             var result = [];
             for (var i = 0, j = array.length; i < j; i++)
@@ -115,6 +126,9 @@ ko.utils = (function () {
         },
 
         arrayFilter: function (array, predicate) {
+            if (array && typeof array.filter == 'function') {
+                return array.filter(predicate);
+            }
             array = array || [];
             var result = [];
             for (var i = 0, j = array.length; i < j; i++)


### PR DESCRIPTION
By using the native methods this opens up an interesting usecase. I was playing around with the component flow and was having a hard time because my View Models are created by the template engine. What I needed was a way for my Backbone collections and models to get passed in as parameters into my View Models. 

viewmodel.js

```
var viewModel = {collection: ko.observable(new Backbone.Collection())}
```

template.html

```
<!-- ko foreach: collection -->  
  <custom-component params="model: $data"></repository-card>
<!-- /ko -->
```

After some digging around I found that if I just use the _native_ methods in the array helpers everything else just works.

The last step was to hook onto the collections events so I wrote a quick extender that will do just that. https://gist.github.com/ismell/d4f977f2d7a4a86b9cb1

So now if I just extend my observable with trackCollectionChanges my views will correctly update whenever my backbone collection changes.

viewmodel.js

```
var viewModel = {
    collection: ko.observable(new Backbone.Collection()).extend({'trackCollectionChanges': true})
}
```

Sorry for the long story...
