### PR TITLE
Update submit.js

### DIFF
--- a/src/binding/defaultBindings/submit.js
+++ b/src/binding/defaultBindings/submit.js
@@ -8,10 +8,7 @@ ko.bindingHandlers['submit'] = {
             try { handlerReturnValue = value.call(bindingContext['$data'], element); }
             finally {
                 if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
-                    if (event.preventDefault)
-                        event.preventDefault();
-                    else
-                        event.returnValue = false;
+                    event.returnValue = false;
                 }
             }
         });


### PR DESCRIPTION
I put `data-bind="submit: doingSomething"`.
But it does not prevent default submitting behavior.

`preventDefault` call in submit event handler does not seems to be working.
Submit event handler prevent submitting when just returns false value.

(I tried this with GoogleChrome 35.0.1916.153 / OS X 10.9.3)
