### PR TITLE
Remove use of instanceof

### DIFF
--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -28,7 +28,7 @@
         if (!canHaveProperties)
             return rootObject;
 
-        var outputProperties = rootObject instanceof Array ? [] : {};
+        var outputProperties = toString.call(rootObject) === "[object Array]" ? [] : {};
         visitedObjects.save(rootObject, outputProperties);
 
         visitPropertiesOrArrayEntries(rootObject, function(indexer) {


### PR DESCRIPTION
instanceof does not work correctly for cross frame code.  Removed it's use in mapJsObjectGraph to fix ko.toJS on cross-frame objects.

See here for example of problem caused:
http://stackoverflow.com/questions/24890168/ko-tojs-converting-array-to-object/

And here for a bug report for using instanceof in general:
https://github.com/knockout/knockout/issues/1307
