### PR TITLE
remove use of instanceof

### DIFF
--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -28,7 +28,7 @@
         if (!canHaveProperties)
             return rootObject;
 
-        var outputProperties = toString.call(rootObject) === "[object Array]" ? [] : {};
+        var outputProperties = ko.utils.isArray(rootObject) ? [] : {};
         visitedObjects.save(rootObject, outputProperties);
 
         visitPropertiesOrArrayEntries(rootObject, function(indexer) {


### PR DESCRIPTION
Using ko.utils.isArray instead of instanceof Array - it's a better fix than in https://github.com/knockout/knockout/pull/1465
