### PR TITLE
ko.utils.array: consistency of passing the context as a parameter. #1482

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -65,9 +65,9 @@ ko.utils = (function () {
     return {
         fieldsIncludedWithJsonPost: ['authenticity_token', /^__RequestVerificationToken(_.*)?$/],
 
-        arrayForEach: function (array, action) {
+        arrayForEach: function (array, action, actionOwner) {
             for (var i = 0, j = array.length; i < j; i++)
-                action(array[i], i);
+                action.call(actionOwner, array[i], i);
         },
 
         arrayIndexOf: function (array, item) {
@@ -106,19 +106,19 @@ ko.utils = (function () {
             return result;
         },
 
-        arrayMap: function (array, mapping) {
+        arrayMap: function (array, mapping, mappingOwner) {
             array = array || [];
             var result = [];
             for (var i = 0, j = array.length; i < j; i++)
-                result.push(mapping(array[i], i));
+                result.push(mapping.call(mappingOwner, array[i], i));
             return result;
         },
 
-        arrayFilter: function (array, predicate) {
+        arrayFilter: function (array, predicate, predicateOwner) {
             array = array || [];
             var result = [];
             for (var i = 0, j = array.length; i < j; i++)
-                if (predicate(array[i], i))
+                if (predicate.call(predicateOwner, array[i], i))
                     result.push(array[i]);
             return result;
         },


### PR DESCRIPTION
It's for this issue https://github.com/knockout/knockout/issues/1482

I copied the behaviour of arrayFirst into arrayForEach, arrayMap and arrayFilter.
The other array functions don't take functions as parameters but objects or values.
