### PR TITLE
Release cached arrayItemContext after it has been used

### DIFF
--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -186,6 +186,10 @@
             activateBindingsOnContinuousNodeArray(addedNodesArray, arrayItemContext);
             if (options['afterRender'])
                 options['afterRender'](addedNodesArray, arrayValue);
+                
+            // release the "cache" variable, so that it can be collected by 
+            // the GC when its value isn't used from within the bindings anymore.
+            arrayItemContext = null;
         };
 
         return ko.dependentObservable(function () {


### PR DESCRIPTION
arrayItemContext was cached between two closures. Hence initiated by the first, but not released by the latter.
