### PR TITLE
fixes issue where comment elements cause " "Not enough storage is available to complete this operation" in IE9

### DIFF
--- a/src/memoization.js
+++ b/src/memoization.js
@@ -8,11 +8,15 @@ ko.memoization = (function () {
     function generateRandomId() {
         return randomMax8HexChars() + randomMax8HexChars();
     }
+	var commentNodesHaveTextProperty = document.createComment("test").text === "<!--test-->";
+	function getNodeValue(node){
+		return commentNodesHaveTextProperty ? node.text: node.nodeValue;
+	}
     function findMemoNodes(rootNode, appendToArray) {
         if (!rootNode)
             return;
         if (rootNode.nodeType == 8) {
-            var memoId = ko.memoization.parseMemoText(rootNode.nodeValue);
+            var memoId = ko.memoization.parseMemoText(getNodeValue(rootNode));
             if (memoId != null)
                 appendToArray.push({ domNode: rootNode, memoId: memoId });
         } else if (rootNode.nodeType == 1) {


### PR DESCRIPTION
see #186 which doesn't seem to have fixed the problem at least for us

get the error "Not enough storage is available to complete this operation" in IE 9

Have attached a patch that works for us in 2.2.1.
