### PR TITLE
Fix error in fixUpContinuousNodeArray when using jquery.tmpl

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -232,7 +232,7 @@ ko.utils = (function () {
 
                 // Rule [A]
                 while (continuousNodeArray.length && continuousNodeArray[0].parentNode !== parentNode)
-                    continuousNodeArray.shift();
+                    continuousNodeArray.splice(0, 1);
 
                 // Rule [B]
                 if (continuousNodeArray.length > 1) {


### PR DESCRIPTION
The `shift` method does not exist on jQuery objects. However, the `splice` method does exist. Previously, `splice(0,1)` was used as of #144 but was replaced with `shift()` in [this commit](https://github.com/knockout/knockout/commit/7c99a942d0befbf2294a8f45d6a7a5cc2e7ac194#diff-2b4ca49d4bb0a774c4d4c1672d7aa781R235).

A workaround can be found [on StackOverflow:](http://stackoverflow.com/questions/6515544/how-to-pop-or-shift-from-jquery-set)

``` js
(function( $ ) {
    $.fn.pop = function() {
        var top = this.get(-1);
        this.splice(this.length-1,1);
        return top;
    };

    $.fn.shift = function() {
        var bottom = this.get(0);
        this.splice(0,1);
        return bottom;
    };
})( jQuery );
```
