### PR TITLE
Spectator-mode subscriptions OR "side-effect-free" subscriptions

### DIFF
--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -10,8 +10,8 @@ ko.extenders['trackArrayChanges'] = function(target) {
         underlyingSubscribeFunction = target.subscribe;
 
     // Intercept "subscribe" calls, and for array change events, ensure change tracking is enabled
-    target.subscribe = target['subscribe'] = function(callback, callbackTarget, event) {
-        if (event === arrayChangeEventName) {
+    target.subscribe = target['subscribe'] = function(callback, callbackTarget, eventOrOptions) {
+        if (eventOrOptions === arrayChangeEventName || (eventOrOptions && (eventOrOptions.event == arrayChangeEventName))) {
             trackChanges();
         }
         return underlyingSubscribeFunction.apply(this, arguments);


### PR DESCRIPTION
In #855 knockout "fixed" the flaw that a subscribe on a deferredComputed wouldn't lead to it's computation.

However, in some cases it is still desired to subscribe to a deferred or pure computed without beeing counted as an active subscriber.

This could be solved by adding an option to subscriptions, that could be called `spectatorMode` (`true` /`false`). Subscriptions in spectatorMode would behave differently in a couple of ways:

*For deferred computed observables:*
(same as before the #855 fix)

* they would not lead to computation
* when the computed is evaluated after subscribe, the subscription would be informed about the initial computed value

*For pure computed observables:*

* They would not awaken a sleeping pure computed
* The pure computed would fall asleep, if all "normal" subscriptions are disposed
* On awake, they would get triggered with the computed value.
* On falling asleep, they would get triggered with an "undefined" value.

It would also make sence to introduce a mode for pureComputed, stating, if the computed value should be cached, although the computed falls asleep. Then on awake it can compare the values and only notify the spectatorMode-subscriptions, if the value has changed since when it was awake last time.

We have already coded this in a patch, since we need it. But we'd like to discuss it before integrating it into knockout, submitting a pull request and implementing (more) tests.

This is a very important feature for us, since we have designed our api around it. And we would be very happy, if we didn't need to maintain our own fork, but find a solution together instead.
