### PR TITLE
Add missing update of exposed dependendObservable._latestValue (DEBUG only)

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -100,6 +100,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                 });
                 _dependenciesCount = 0;
                 _latestValue = readFunction.call(evaluatorFunctionTarget);
+                if (DEBUG) dependentObservable._latestValue = _latestValue;
             } finally {
                 ko.dependencyDetection.end();
                 _isBeingEvaluated = false;


### PR DESCRIPTION
Looks like the author forgot to update the exposed _latestValue (if DEBUG) when implementing pureComputeds awake.

The pair of setting _latestValue and dependendObservable._latestValue should rather be grouped into a method `setLatestValue`.
