### PR TITLE
Add check that optionsAfterRender binding was provided a function

### DIFF
--- a/spec/defaultBindings/optionsBehaviors.js
+++ b/spec/defaultBindings/optionsBehaviors.js
@@ -290,4 +290,13 @@ describe('Binding: Options', function() {
         expect(testNode.childNodes[0]).toContainText('first childhidden child');
         expect(callbacks).toEqual(2);
     });
+
+    it('Should ignore the optionsAfterRender binding if the callback was not provided or not a function', function () {
+        testNode.innerHTML = "<select data-bind=\"options: someItems, optionsText: 'childprop', optionsAfterRender: callback\"></select>";
+        var someItems = ko.observableArray([{ childprop: 'first child' }]);
+
+        ko.applyBindings({ someItems: someItems, callback: null }, testNode);
+        // Ensure bindings were applied normally
+        expect(testNode.childNodes[0]).toContainText('first child');
+    });
 });

--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -110,7 +110,7 @@ ko.bindingHandlers['options'] = {
         }
 
         var callback = setSelectionCallback;
-        if (allBindings['has']('optionsAfterRender')) {
+        if (allBindings['has']('optionsAfterRender') && typeof allBindings.get('optionsAfterRender') == "function") {
             callback = function(arrayEntry, newOptions) {
                 setSelectionCallback(arrayEntry, newOptions);
                 ko.dependencyDetection.ignore(allBindings.get('optionsAfterRender'), null, [newOptions[0], arrayEntry !== captionPlaceholder ? arrayEntry : undefined]);


### PR DESCRIPTION
Resolves #1555 by checking that the optionsAfterRender function was provided a function and adding a test for the case.
