### PR TITLE
knockout 3.2 component binding context $root

### DIFF
--- a/spec/components/customElementBehaviors.js
+++ b/spec/components/customElementBehaviors.js
@@ -409,9 +409,12 @@ describe('Components: Custom elements', function() {
 
         // First define a reusable 'special-list' component that produces a <ul> in which the <li>s have special CSS classes
         // It also injects and binds a supplied template for each list item
+        // Note: It would be even simpler to write "template: { nodes: $componentTemplateNodes }", which would also work.
+        //       However it's useful to have test coverage for the more longwinded approach of passing nodes via your
+        //       viewmodel as well, so retaining the longer syntax for this test.
         ko.components.register('special-list', {
             template: '<ul class="my-special-list" data-bind="foreach: specialListItems">'
-                    +     '<li class="special-list-item" data-bind="template: { nodes: $parent.suppliedItemTemplate }">'
+                    +     '<li class="special-list-item" data-bind="template: { nodes: $component.suppliedItemTemplate }">'
                     +     '</li>'
                     + '</ul>',
             viewModel: {
@@ -444,13 +447,13 @@ describe('Components: Custom elements', function() {
         expect(testNode.childNodes[1].childNodes[0].tagName.toLowerCase()).toEqual('ul');
         expect(testNode.childNodes[1].childNodes[0].className).toEqual('my-special-list');
         expect(testNode.childNodes[1].childNodes[0]).toContainHtml(
-            '<li class="special-list-item" data-bind="template: { nodes: $parent.supplieditemtemplate }">'
+            '<li class="special-list-item" data-bind="template: { nodes: $component.supplieditemtemplate }">'
           +     '<em data-bind="text: name">brie</em> has quality <em data-bind="text: quality">7</em>'
           + '</li>'
-          + '<li class="special-list-item" data-bind="template: { nodes: $parent.supplieditemtemplate }">'
+          + '<li class="special-list-item" data-bind="template: { nodes: $component.supplieditemtemplate }">'
           +     '<em data-bind="text: name">cheddar</em> has quality <em data-bind="text: quality">9</em>'
           + '</li>'
-          + '<li class="special-list-item" data-bind="template: { nodes: $parent.supplieditemtemplate }">'
+          + '<li class="special-list-item" data-bind="template: { nodes: $component.supplieditemtemplate }">'
           +     '<em data-bind="text: name">roquefort</em> has quality <em data-bind="text: quality">3</em>'
           + '</li>'
         );

--- a/src/components/componentBinding.js
+++ b/src/components/componentBinding.js
@@ -51,6 +51,7 @@
                     cloneTemplateIntoElement(componentName, componentDefinition, element);
                     var componentViewModel = createViewModel(componentDefinition, element, originalChildNodes, componentParams),
                         childBindingContext = bindingContext['createChildContext'](componentViewModel, /* dataItemAlias */ undefined, function(ctx) {
+                            ctx['$component'] = componentViewModel;
                             ctx['$componentTemplateNodes'] = originalChildNodes;
                         });
                     currentViewModel = componentViewModel;


### PR DESCRIPTION
In component template, the `$root` still refers to the absolute root view model of my app, instead of the top view model in my component definition. I could still use `$parents[n]` to get where I want, but this is kind of annoying.

A new binding context property like `$componentRoot` would be helpful. Any thought?
