### PR TITLE
Added note to attribute binding page about reserved words as attrubutes breaking in ie8

### DIFF
--- a/documentation/attr-binding.md
+++ b/documentation/attr-binding.md
@@ -42,6 +42,14 @@ If you want to apply the attribute `data-something`, you *can't* write this:
 
     <div data-bind="attr: { 'data-something': someValue }">...</div>
 
+### Note: Using reserved words as attribute names in older browsers
+
+In older browsers (ie8 and below) using reserved javascript words as attribute names causes an error. You can get around this by quoting them like this:
+
+    <input data-bind="attr: { 'for': someValue }" />
+
+You can find a good list of reserved words on [Mozilla's MDN page here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords).
+
 ### Dependencies
 
 None, other than the core Knockout library.


### PR DESCRIPTION
Until I knew this it caused me a lot of irritation - debugging in ie8 isn't the best experience. There is some disparate chatter about this on some stack overflow posts but it didn't appear high up on Google search results. I stopped short of putting all the reserved words inline - and have only tested a dozen or so. 

This could perhaps be a part of the previous note - but personally I like my docs explicit.
