### PR TITLE
Fix : do not bind contents of <textarea> elements

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -5,9 +5,10 @@
     // may consider adding <template> to this list, because such elements' contents are always
     // intended to be bound in a different context from where they appear in the document.
     var bindingDoesNotRecurseIntoElementTypes = {
-        // Don't want bindings that operate on text nodes to mutate <script> contents,
+        // Don't want bindings that operate on text nodes to mutate <script> and <textarea> contents,
         // because it's unexpected and a potential XSS issue
-        'script': true
+        'script': true,
+        'textarea': true
     };
 
     // Use an overridable method for retrieving binding handlers so that a plugins may support dynamically created handlers


### PR DESCRIPTION
Added `<textarea>` to `bindingDoesNotRecurseIntoElementTypes` in bindingAttributeSyntax.js  and added a test for this also.

Refer to:
https://github.com/knockout/knockout/issues/1534
