### PR TITLE
IE8 throws errors when calling apply with second argument undefined

### DIFF
--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -88,7 +88,7 @@
                             mapData.dependentObservable.dispose();
 
                         // Queue these nodes for later removal
-                        nodesToDelete.push.apply(nodesToDelete, ko.utils.fixUpContinuousNodeArray(mapData.mappedNodes, domNode));
+                        nodesToDelete.push.apply(nodesToDelete, ko.utils.fixUpContinuousNodeArray(mapData.mappedNodes, domNode) || []);
                         if (options['beforeRemove']) {
                             itemsForBeforeRemoveCallbacks[i] = mapData;
                             itemsToProcess.push(mapData);


### PR DESCRIPTION
IE8 (and possibly earlier, I haven't tested), isn't able to handle calling apply with undefined for the parameters array. It instead must be called with an empty array. I haven't combed through the entire codebase to see if this is a problem elsewhere, but this is one spot that has caused problems for me in IE8. See http://stackoverflow.com/questions/20432707/knockout-removing-item-from-observablearray-throwing-error-in-ie8 for some more context to the issue. This JSFiddle demonstrates the behavior: http://jsfiddle.net/klinden/3sj2dkzj/3/