### PR TITLE
valueAllowUnset - null selection not maintained when option items update

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -593,6 +593,36 @@ describe('Binding: Value', function() {
                 expect(testNode.childNodes[0].selectedIndex).toEqual(-1);
                 expect(observable()).toEqual("D");
             });
+
+            it('Should maintain model value and update selection when changing observable option text or value', function() {
+                var selected = ko.observable('B');
+                var people = [
+                    { name: ko.observable('Annie'), id: ko.observable('A') },
+                    { name: ko.observable('Bert'), id: ko.observable('B') }
+                ];
+                testNode.innerHTML = "<select data-bind=\"options:people, optionsText:'name', optionsValue:'id', value:selected, valueAllowUnset:true\"></select>";
+
+                ko.applyBindings({people: people, selected: selected}, testNode);
+                expect(testNode.childNodes[0].selectedIndex).toEqual(1);
+                expect(testNode.childNodes[0]).toHaveTexts(["Annie", "Bert"]);
+                expect(selected()).toEqual("B");
+
+                // Changing an option name shouldn't change selection
+                people[1].name("Charles");
+                expect(testNode.childNodes[0].selectedIndex).toEqual(1);
+                expect(testNode.childNodes[0]).toHaveTexts(["Annie", "Charles"]);
+                expect(selected()).toEqual("B");
+
+                // Changing the selected option value should clear selection
+                people[1].id("C");
+                expect(testNode.childNodes[0].selectedIndex).toEqual(-1);
+                expect(selected()).toEqual("B");
+
+                // Changing an option name while nothing is selected won't select anything
+                people[0].name("Amelia");
+                expect(testNode.childNodes[0].selectedIndex).toEqual(-1);
+                expect(selected()).toEqual("B");
+            });
         });
     });
 


### PR DESCRIPTION
When using `valueAllowUnset: true` with the `options`, `value`, and `optionsText` bindings on a `<select>` element, it is possible to get the view model's value out of sync with the `<select>` element in the user interface.

**Steps to reproduce**
1. Initially have no selection in the `<select>` element (underlying observable model property has value of `null`)
2. Make an update to an observable property of one of the items in the array that the `<select>` is bound to
3. The `<select>` then updates to automatically select the first item in the options array
4. But the underlying observable model property remains `null`

Note that if the `<select>` already contains a selection then everything works as expected.  In addition, adding/removing items seems to work correctly too.  

It is only when the `<select>` doesn't have an initial selection and a modification is made to an existing item in the bound array that this behaviour is observed.

I believe the correct behaviour should be to leave the `<select>` element as-is, without updating its selected value.  That is, the model property should always be respected when `valueAllowUnset: true` is applied.

**Example** (fiddle at http://jsfiddle.net/spoida/f8b7LL2b/)

In the following example, if you leave the selection blank and click the "Update name" button, the `<select>` element visually shows the first item in the list as selected but in fact the view model property is still `null`, which can be seen by clicking on "Alert selection".

**HTML**

``` html
<select data-bind="options: people, optionsText: 'Name', value: selectedPerson, valueAllowUnset: true"></select>
<button data-bind="click: updatePersonName">Update name</button>
<button data-bind="click: clearSelection">Clear selection</button>
<button data-bind="click: alertCurrentSelection">Alert selection</button>
```

**Javascript**

``` javascript
var demo = { };

demo.person = function(id, name) {
    var self = this;
    self.PersonID = id;
    self.Name = ko.observable(name);
};

demo.viewModel = function() {
    var self = this;

    self.people = ko.observableArray([]);
    self.people.push(new demo.person(1, 'Adam'));
    self.people.push(new demo.person(2, 'Belinda'));
    self.people.push(new demo.person(3, 'Chris'));
    self.people.push(new demo.person(4, 'Dianna'));

    self.selectedPerson = ko.observable(null);

    self.updatePersonName = function () {
        self.people()[2].Name(self.people()[2].Name() + ' abc');
    };

    self.clearSelection = function () {
        self.selectedPerson(null);
    };

    self.alertCurrentSelection = function () {
        var message = 'No person is selected';
        if (self.selectedPerson() !== null) {
            message = self.selectedPerson().Name() + ' is selected';
        }
        alert(message);
    };
};

ko.applyBindings(new demo.viewModel());
```
