### PR TITLE
Binding parser skips all colons between the name and value

### DIFF
--- a/spec/expressionRewritingBehaviors.js
+++ b/spec/expressionRewritingBehaviors.js
@@ -55,16 +55,24 @@ describe('Expression Rewriting', function() {
         expect(result[1].value).toEqual("function(){var regex=/{/g;return/123/;}");
     });
 
+    it('Should parse a value that begins with a colon', function() {
+        var result = ko.expressionRewriting.parseObjectLiteral("a: :-)");
+        expect(result.length).toEqual(1);
+        expect(result[0].key).toEqual("a");
+        expect(result[0].value).toEqual(":-)");
+    });
+
     it('Should be able to cope with malformed syntax (things that aren\'t key-value pairs)', function() {
-        var result = ko.expressionRewriting.parseObjectLiteral("malformed1, 'mal:formed2', good:3, { malformed: 4 }, good5:5");
-        expect(result.length).toEqual(4);
+        var result = ko.expressionRewriting.parseObjectLiteral("malformed1, 'mal:formed2', good:3, {malformed:4}, good5:5, keyonly:");
+        expect(result.length).toEqual(6);
         expect(result[0].unknown).toEqual("malformed1");
         expect(result[1].unknown).toEqual("mal:formed2");
         expect(result[2].key).toEqual("good");
         expect(result[2].value).toEqual("3");
-        // "{ malformed: 4 }" gets skipped because there's no valid key value
-        expect(result[3].key).toEqual("good5");
-        expect(result[3].value).toEqual("5");
+        expect(result[3].unknown).toEqual("{malformed:4}");
+        expect(result[4].key).toEqual("good5");
+        expect(result[4].value).toEqual("5");
+        expect(result[5].unknown).toEqual("keyonly");
     });
 
     it('Should ensure all keys are wrapped in quotes', function() {

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -48,7 +48,7 @@ ko.expressionRewriting = (function () {
         if (str.charCodeAt(0) === 123) str = str.slice(1, -1);
 
         // Split into tokens
-        var result = [], toks = str.match(bindingToken), key, values, depth = 0;
+        var result = [], toks = str.match(bindingToken), key, values = [], depth = 0;
 
         if (toks) {
             // Append a comma so that we don't need a separate code block to deal with the last item
@@ -59,15 +59,17 @@ ko.expressionRewriting = (function () {
                 // A comma signals the end of a key/value pair if depth is zero
                 if (c === 44) { // ","
                     if (depth <= 0) {
-                        if (key)
-                            result.push(values ? {key: key, value: values.join('')} : {'unknown': key});
-                        key = values = depth = 0;
+                        result.push((key && values.length) ? {key: key, value: values.join('')} : {'unknown': key || values.join('')});
+                        key = depth = 0;
+                        values = [];
                         continue;
                     }
                 // Simply skip the colon that separates the name and value
                 } else if (c === 58) { // ":"
-                    if (!values)
+                    if (!depth && !key && values.length === 1) {
+                        key = values.pop();
                         continue;
+                    }
                 // A set of slashes is initially matched as a regular expression, but could be division
                 } else if (c === 47 && i && tok.length > 1) {  // "/"
                     // Look at the end of the previous token to determine if the slash is actually division
@@ -86,15 +88,11 @@ ko.expressionRewriting = (function () {
                     ++depth;
                 } else if (c === 41 || c === 125 || c === 93) { // ')', '}', ']'
                     --depth;
-                // The key must be a single token; if it's a string, trim the quotes
-                } else if (!key && !values) {
-                    key = (c === 34 || c === 39) /* '"', "'" */ ? tok.slice(1, -1) : tok;
-                    continue;
+                // The key will be the first token; if it's a string, trim the quotes
+                } else if (!key && !values.length && (c === 34 || c === 39)) { // '"', "'"
+                    tok = tok.slice(1, -1);
                 }
-                if (values)
-                    values.push(tok);
-                else
-                    values = [tok];
+                values.push(tok);
             }
         }
         return result;


### PR DESCRIPTION
I wanted to see if I could have a binding with a `preprocess` method that accepted emoticons like `emoticon: :-)`. But with `:-)`, the colon is lost. The fix for this should be pretty  simple.
