### PR TITLE
Make stacktrace visible in console on binding processing error

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -379,7 +379,8 @@
                         );
                     }
                 } catch (ex) {
-                    throw new Error("Unable to process binding \"" + bindingKey + ": " + bindings[bindingKey] + "\"\nMessage: " + ex.message);
+                    // stack trace is appended to the message to avoid it being lost
+                    throw new Error("Unable to process binding \"" + bindingKey + ": " + bindings[bindingKey] + "\"\nMessage: " + ex.message + "\n" + ex.stack);
                 }
             });
         }


### PR DESCRIPTION
When there is a binding processing error, the stack trace of the original exception seems to be lost (in Chrome, at least). Using new Error() fixed this.
