### PR TITLE
Add hook for ko.onBindingError

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -472,6 +472,19 @@ describe('Binding attribute syntax', function() {
         }).toThrow("You cannot apply bindings multiple times to the same element.");
     });
 
+    it("Should call ko.onBindingError when applyBindings is called multiple times for the same element", function () {
+        var obe_calls = 0;
+        this.restoreAfter(ko, 'onBindingError');
+        testNode.innerHTML = "<div data-bind='text: \"Some Text\"'></div>";
+        ko.applyBindings({}, testNode);
+        ko.onBindingError = function (spec) {
+            obe_calls++;
+            expect(spec.during).toEqual('apply');
+        };
+        ko.applyBindings({}, testNode);
+        expect(obe_calls).toEqual(1);
+    });
+
     it('Should allow multiple applyBindings calls for the same element if cleanNode is used', function() {
         testNode.innerHTML = "<div data-bind='text: \"Some Text\"'></div>";
 


### PR DESCRIPTION
This PR should exposes a function (`ko.onBindingError`) to hook into binding errors.

This should give greater control to users handling cases such as #1626 

The `function onBindingError(spec)` takes one object, `spec` containing the following properties:

| Property | Meaning |
| --- | --- |
| during | (string) The binding function name (`init` or `update` or `apply`) |
| errorCaptured | (Error) The error that was thrown by the binding function |
| element | (HTML Node) The node the binding was being applied to |
| bindingKey | (string) The name of the binding (`init` or `update` only) |
| valueAccessor | (function) As passed to the binding function (`init` or `update` only) |
| allBindings | (function) As passed to the binding function (`init` or `update` only) |
| bindingContext | (object) As passed to the binding function (contains `$data`, `$rawData`, `$root`, ...) |

Tested on PhantomJS, Chrome, Safari, and Firefox.
