### PR TITLE
Lodash _.where style removeAll and destroyAll syntax for observable arrays

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -143,6 +143,14 @@ describe('Observable Array', function() {
         expect(notifiedValues).toEqual([[]]);
     });
 
+    it('Should notify subscribers on removeAll with object argument', function () {
+        testObservableArray(["Alpha", "Beta", "Gamma"]);
+        notifiedValues = [];
+        var removed = testObservableArray.removeAll({length: 5});
+        expect(removed).toEqual(["Alpha", "Gamma"]);
+        expect(notifiedValues).toEqual([["Beta"]]);
+    });
+
     it('Should notify "beforeChange" subscribers before remove', function () {
         testObservableArray(["Alpha", "Beta", "Gamma"]);
         beforeNotifiedValues = [];

--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -58,6 +58,16 @@ describe('Observable Array', function() {
         expect(z._destroy).toEqual(true);
     });
 
+    it('Should be able to mark multiple items as destroyed with an object argument', function () {
+        var x = {id: "x", val: 1}, y = {id: "y", val: 2}, z = {id: "z", val: 1};
+        testObservableArray([x, y, z]);
+        testObservableArray.destroyAll({val: 1});
+        expect(testObservableArray().length).toEqual(3);
+        expect(x._destroy).toEqual(true);
+        expect(y._destroy).toEqual(undefined);
+        expect(z._destroy).toEqual(true);
+    });
+
     it('Should be able to mark observable items as destroyed', function() {
         var x = ko.observable(), y = ko.observable();
         testObservableArray([x, y]);

--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -154,11 +154,11 @@ describe('Observable Array', function() {
     });
 
     it('Should notify subscribers on removeAll with object argument', function () {
-        testObservableArray(["Alpha", "Beta", "Gamma"]);
+        testObservableArray(["Alpha", "Beta", "Gamma", null]);
         notifiedValues = [];
         var removed = testObservableArray.removeAll({length: 5});
         expect(removed).toEqual(["Alpha", "Gamma"]);
-        expect(notifiedValues).toEqual([["Beta"]]);
+        expect(notifiedValues).toEqual([["Beta", null]]);
     });
 
     it('Should notify "beforeChange" subscribers before remove', function () {

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -51,6 +51,7 @@ ko.observableArray['fn'] = {
         // Otherwise remove all objects with values matching properties of the passed object
         var props = Object.keys(arrayOfValuesOrObject);
         return this['remove'](function (value) {
+            if(!value) return false;
             //Return true if value matches all properties specified on arrayOfValuesOrObject
             for (var i = 0; i < props.length ; i++) {
                 var prop = props[i];
@@ -89,6 +90,7 @@ ko.observableArray['fn'] = {
         // Otherwise destroy all objects with values matching properties of the passed object
         var props = Object.keys(arrayOfValuesOrObject);
         return this['destroy'](function (value) {
+            if(!value) return false;
             //Return true if value matches all properties specified on arrayOfValuesOrObject
             for (var i = 0; i < props.length ; i++) {
                 var prop = props[i];

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -31,9 +31,9 @@ ko.observableArray['fn'] = {
         return removedValues;
     },
 
-    'removeAll': function (arrayOfValues) {
+    'removeAll': function (arrayOfValuesOrObject) {
         // If you passed zero args, we remove everything
-        if (arrayOfValues === undefined) {
+        if (arrayOfValuesOrObject === undefined) {
             var underlyingArray = this.peek();
             var allValues = underlyingArray.slice(0);
             this.valueWillMutate();
@@ -41,11 +41,24 @@ ko.observableArray['fn'] = {
             this.valueHasMutated();
             return allValues;
         }
-        // If you passed an arg, we interpret it as an array of entries to remove
-        if (!arrayOfValues)
-            return [];
+        arrayOfValuesOrObject = arrayOfValuesOrObject || [];
+        // If you passed an array, we interpret it as an array of entries to remove
+        if (arrayOfValuesOrObject instanceof Array) {
+            return this['remove'](function (value) {
+                return ko.utils.arrayIndexOf(arrayOfValuesOrObject, value) >= 0;
+            });
+        }
+        // Otherwise remove all objects with values matching properties of the passed object
+        var props = Object.keys(arrayOfValuesOrObject);
         return this['remove'](function (value) {
-            return ko.utils.arrayIndexOf(arrayOfValues, value) >= 0;
+            //Return true if value matches all properties specified on arrayOfValuesOrObject
+            for (var i = 0; i < props.length ; i++) {
+                var prop = props[i];
+                if ( value[prop] !== arrayOfValuesOrObject[prop] ) {
+                    return false;
+                }
+            }
+            return true;
         });
     },
 

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -74,16 +74,29 @@ ko.observableArray['fn'] = {
         this.valueHasMutated();
     },
 
-    'destroyAll': function (arrayOfValues) {
+    'destroyAll': function (arrayOfValuesOrObject) {
         // If you passed zero args, we destroy everything
-        if (arrayOfValues === undefined)
+        if (arrayOfValuesOrObject === undefined)
             return this['destroy'](function() { return true });
 
-        // If you passed an arg, we interpret it as an array of entries to destroy
-        if (!arrayOfValues)
-            return [];
+        arrayOfValuesOrObject = arrayOfValuesOrObject || [];
+        // If you passed an array, we interpret it as an array of entries to destroy
+        if (arrayOfValuesOrObject instanceof Array) {
+            return this['destroy'](function (value) {
+                return ko.utils.arrayIndexOf(arrayOfValuesOrObject, value) >= 0;
+            });
+        }
+        // Otherwise destroy all objects with values matching properties of the passed object
+        var props = Object.keys(arrayOfValuesOrObject);
         return this['destroy'](function (value) {
-            return ko.utils.arrayIndexOf(arrayOfValues, value) >= 0;
+            //Return true if value matches all properties specified on arrayOfValuesOrObject
+            for (var i = 0; i < props.length ; i++) {
+                var prop = props[i];
+                if (value[prop] !== arrayOfValuesOrObject[prop] ) {
+                    return false;
+                }
+            }
+            return true;
         });
     },
 


### PR DESCRIPTION
Allows the argument to `observableArray.removeAll` and observableArray.destroyAll` to be an object.  In that case, objects will be removed/destroyed if their properties match all properties specified on the provided object.

So these two lines would be equivalent: 

```
array.removeAll({foo: x, bar: y});
array.removeAll(function (value) { return value.foo === x && value.bar === y });
```
