### PR TITLE
Made the binding processing errors prettier

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -379,7 +379,11 @@
                         );
                     }
                 } catch (ex) {
-                    ex.message = "Unable to process binding \"" + bindingKey + ": " + bindings[bindingKey] + "\"\nMessage: " + ex.message;
+                    var bindingValue = bindings[bindingKey]+"";
+                    if(bindingValue && bindingValue.substr(0, 42) == 'function __ko__value__accessor__(){return '){
+                        bindingValue = bindingValue.substring(42, bindingValue.length - 2);
+                    }
+                    ex.message = "Unable to process binding \"" + bindingKey + ": " + bindingValue + "\"\nMessage: " + ex.message;
                     throw ex;
                 }
             });

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -121,7 +121,7 @@ ko.expressionRewriting = (function () {
             }
             // Values are wrapped in a function so that each value can be accessed independently
             if (makeValueAccessors) {
-                val = 'function(){return ' + val + ' }';
+                val = 'function __ko__value__accessor__(){return ' + val + ' }';
             }
             resultStrings.push("'" + key + "':" + val);
         }


### PR DESCRIPTION
 Made the binding processing errors prettier by removing the wrapping anonymous function. This was made possible by making the wrapping function a named function instead of an anonymous function, and then removing it only if it has the right name. This fixes #1632 
