### PR TITLE
Clean up subscription to arrayChange when there are no subscribers

### DIFF
--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -261,6 +261,15 @@ describe('Observable Array change tracking', function() {
         expect(changelist2).toBe(changelist);
     });
 
+    // Per: https://github.com/knockout/knockout/issues/1503
+    it('Should cleanup a single arrayChange dependency', function() {
+        var source = ko.observableArray();
+        var arrayChange = source.subscribe(function() {}, null, "arrayChange");
+        expect(source.getSubscriptionsCount("arrayChange")).toBe(1);
+        arrayChange.dispose();
+        expect(source.getSubscriptionsCount()).toBe(0);
+    });
+
     it('Should support tracking of a computed observable using extender', function() {
         var myArray = ko.observable(['Alpha', 'Beta', 'Gamma']),
             myComputed = ko.computed(function() {
@@ -270,7 +279,7 @@ describe('Observable Array change tracking', function() {
 
         expect(myComputed()).toEqual(['Beta', 'Gamma']);
 
-        myComputed.subscribe(function(changes) {
+        var arrayChange = myComputed.subscribe(function(changes) {
             changelist = changes;
         }, null, 'arrayChange');
 
@@ -280,6 +289,38 @@ describe('Observable Array change tracking', function() {
             { status : 'deleted', value : 'Beta', index : 0 },
             { status : 'added', value : 'Delta', index : 1 }
         ]);
+
+        // Should clean up all subscriptions when arrayChange subscription is disposed
+        arrayChange.dispose();
+        expect(myComputed.getSubscriptionsCount()).toBe(0);
+    });
+
+    it('Should support tracking of a pure computed observable using extender', function() {
+        var myArray = ko.observable(['Alpha', 'Beta', 'Gamma']),
+            myComputed = ko.pureComputed(function() {
+                return myArray().slice(-2);
+            }).extend({trackArrayChanges:true}),
+            changelist;
+
+        expect(myComputed()).toEqual(['Beta', 'Gamma']);
+        // The pure computed doesn't yet subscribe to the observable (it's still sleeping)
+        expect(myArray.getSubscriptionsCount()).toBe(0);
+
+        var arrayChange = myComputed.subscribe(function(changes) {
+            changelist = changes;
+        }, null, 'arrayChange');
+        expect(myArray.getSubscriptionsCount()).toBe(1);
+
+        myArray(['Alpha', 'Beta', 'Gamma', 'Delta']);
+        expect(myComputed()).toEqual(['Gamma', 'Delta']);
+        expect(changelist).toEqual([
+            { status : 'deleted', value : 'Beta', index : 0 },
+            { status : 'added', value : 'Delta', index : 1 }
+        ]);
+
+        // It releases subscriptions when the arrayChange subscription is disposed
+        arrayChange.dispose();
+        expect(myArray.getSubscriptionsCount()).toBe(0);
     });
 
     it('Should support recursive updates (modify array within arrayChange callback)', function() {
@@ -311,24 +352,6 @@ describe('Observable Array change tracking', function() {
         list.push(toAdd);
         // See that descendent nodes are also added
         expect(list()).toEqual([ toAdd, toAdd.nodes[0], toAdd.nodes[1], toAdd.nodes[2], toAdd.nodes[0].nodes[0] ]);
-    });
-
-    // Per: https://github.com/knockout/knockout/issues/1503
-    it("Should cleanup a single arrayChange dependency", function() {
-        var source = ko.observableArray();
-        var arrayChange = source.subscribe(function() {}, null, "arrayChange");
-        expect(source.hasSubscriptionsForEvent("arrayChange")).toBe(1);
-        arrayChange.dispose();
-        expect(source.getSubscriptionsCount()).toBe(0);
-    });
-
-    it('Should have the same arrayChange subscriptions for computed observables', function () {
-        var source = ko.computed(function () {}).extend({trackArrayChanges: true});
-        var arrayChange = source.subscribe(function() {}, null, "arrayChange");
-        expect(source.hasSubscriptionsForEvent("arrayChange")).toBe(1);
-        arrayChange.dispose();
-        // Note: It would make sense if source.dispose() called arrayChange.dispose.
-        expect(source.getSubscriptionsCount()).toBe(0);
     });
 
     function testKnownOperation(array, operationName, options) {

--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -88,7 +88,7 @@ describe('Observable Array change tracking', function() {
         captureCompareArraysCalls(function(callLog) {
             var myArray = ko.observableArray(['Alpha', 'Beta', 'Gamma']),
                 browserSupportsSpliceWithoutDeletionCount = [1, 2].splice(1).length === 1;
-            
+
             // Make sure there is one subscription, or we short-circuit cacheDiffForKnownOperation.
             myArray.subscribe(function () {}, null, 'arrayChange');
 

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -272,7 +272,6 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         dependentObservable.beforeSubscriptionAdd = function (event) {
             if (event == 'change' || event == 'beforeChange') {
                 peek();
-                delete dependentObservable.beforeSubscriptionAdd;
             }
         }
     }


### PR DESCRIPTION
Re. #1503 

Note that this should also speed up changes to observables since `cacheDiffForKnownOperation` will not be executed when there are no subscribers (is this any concern?)