### PR TITLE
Export the setTextContent utility

### DIFF
--- a/spec/runner.html
+++ b/spec/runner.html
@@ -40,6 +40,7 @@
         <script type="text/javascript" src="jsonPostingBehaviors.js"></script>
         <script type="text/javascript" src="nativeTemplateEngineBehaviors.js"></script>
         <script type="text/javascript" src="utilsBehaviors.js"></script>
+        <script type="text/javascript" src="utilsDomBehaviors.js"></script>
         <script type="text/javascript" src="components/loaderRegistryBehaviors.js"></script>
         <script type="text/javascript" src="components/defaultLoaderBehaviors.js"></script>
         <script type="text/javascript" src="components/componentBindingBehaviors.js"></script>

--- a/spec/utilsDomBehaviors.js
+++ b/spec/utilsDomBehaviors.js
@@ -1,0 +1,31 @@
+describe('setTextContent', function () {
+    var element;
+
+    beforeEach(function () {
+        element = document.createElement('DIV');
+    });
+
+    // NOTE: will test innerHTML because <IE8 doesn't have textContent
+    it('defaults to empty string', function () {
+
+        ko.utils.setTextContent(element);
+        expect(element.innerHTML).toEqual('');
+    });
+
+    it('sets text from plain values or observables', function () {
+
+        ko.utils.setTextContent(element, 'test');
+        expect(element.innerHTML).toEqual('test');
+
+        ko.utils.setTextContent(element, ko.observable('change'));
+        expect(element.innerHTML).toEqual('change');
+    });
+
+    it('overwrites existing text', function () {
+
+        element.innerHTML = 'existing';
+
+        ko.utils.setTextContent(element, 'changed');
+        expect(element.innerHTML).toEqual('changed');
+    });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -545,6 +545,7 @@ ko.exportSymbol('utils.triggerEvent', ko.utils.triggerEvent);
 ko.exportSymbol('utils.unwrapObservable', ko.utils.unwrapObservable);
 ko.exportSymbol('utils.objectForEach', ko.utils.objectForEach);
 ko.exportSymbol('utils.addOrRemoveItem', ko.utils.addOrRemoveItem);
+ko.exportSymbol('utils.setTextContent', ko.utils.setTextContent);
 ko.exportSymbol('unwrap', ko.utils.unwrapObservable); // Convenient shorthand, because this is used so commonly
 
 if (!Function.prototype['bind']) {


### PR DESCRIPTION
This is an update to pull request https://github.com/knockout/knockout/pull/1441 with some tests

The issue addressed by the pull request is explained a bit here: https://github.com/knockout/knockout/issues/1528