### PR TITLE
Added deferSubscribeEvaluation option to computed observables.

### DIFF
--- a/spec/computedBehaviors.js
+++ b/spec/computedBehaviors.js
@@ -1,0 +1,53 @@
+describe('Computed', function() {
+    it('Should evaluate on subscribe', function () {
+        var evaluated = false;
+        var computed = ko.computed({
+            read: function () {
+                evaluated = true;
+            },
+            deferEvaluation: true
+        });
+
+        expect(evaluated).toEqual(false);
+
+        computed.subscribe(function() {});
+
+        expect(evaluated).toEqual(true);
+    });
+
+    it('Should not evaluate on subscribe when deferEvaluation && deferSubscribeEvaluation', function () {
+        var evaluated = false;
+
+        var dependent = ko.observable();
+
+        var computed = ko.computed({
+            read: function () {
+                evaluated = true;
+                return dependent();
+            },
+            deferEvaluation: true,
+            deferSubscribeEvaluation: true
+        });
+        expect(evaluated).toEqual(false);
+
+        var emmitedValue;
+        computed.subscribe(function(val) { emmitedValue = val; });
+
+        expect(evaluated).toEqual(false);
+
+        dependent('foo');
+
+        expect(evaluated).toEqual(false);
+
+        expect(computed()).toEqual('foo');
+        //expect(emmitedValue).toEqual('foo');
+
+        expect(evaluated).toEqual(true);
+
+        dependent('bar');
+        expect(emmitedValue).toEqual('bar');
+        expect(computed()).toEqual('bar');
+
+
+    });
+});

--- a/spec/computedBehaviors.js
+++ b/spec/computedBehaviors.js
@@ -50,4 +50,45 @@ describe('Computed', function() {
 
 
     });
+
+    it('Should not evaluate on subscribe when deferEvaluation && deferSubscribeEvaluation && trackArrayChanges', function () {
+
+        var evaluated = false;
+
+        var dependent = ko.observableArray();
+
+        var computed = ko.computed({
+            read: function () {
+                evaluated = true;
+                return dependent();
+            },
+            deferEvaluation: true,
+            deferSubscribeEvaluation: true
+        }).extend({ 'trackArrayChanges': true });
+
+        expect(evaluated).toEqual(false);
+
+        var emmitedValue;
+        computed.subscribe(function(val) {
+            emmitedValue = val;
+        }, null, 'arrayChange');
+
+        expect(evaluated).toEqual(false);
+
+        dependent.push('foo');
+
+        expect(evaluated).toEqual(false);
+
+        expect(computed()).toEqual(['foo']);
+
+        expect(evaluated).toEqual(true);
+
+        dependent.push('bar');
+        expect(emmitedValue).toEqual([
+            { status : 'added', value : 'foo', index : 0 },
+            { status : 'added', value : 'bar', index : 1 }
+        ]);
+        expect(computed()).toEqual(['foo', 'bar']);
+
+    });
 });

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -27,6 +27,7 @@
         <script type="text/javascript" src="observableArrayChangeTrackingBehaviors.js"></script>
         <script type="text/javascript" src="dependentObservableBehaviors.js"></script>
         <script type="text/javascript" src="dependentObservableDomBehaviors.js"></script>
+        <script type="text/javascript" src="computedBehaviors.js"></script>
         <script type="text/javascript" src="pureComputedBehaviors.js"></script>
         <script type="text/javascript" src="extenderBehaviors.js"></script>
         <script type="text/javascript" src="domNodeDisposalBehaviors.js"></script>

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -1,12 +1,14 @@
 ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget, options) {
     var _latestValue,
         _needsEvaluation = true,
+        _hasEvaluated = false,
         _isBeingEvaluated = false,
         _suppressDisposalUntilDisposeWhenReturnsFalse = false,
         _isDisposed = false,
         readFunction = evaluatorFunctionOrOptions,
         pure = false,
-        isSleeping = false;
+        isSleeping = false,
+        _onEvaluateImmediates = [];
 
     if (readFunction && typeof readFunction == "object") {
         // Single-parameter syntax - everything is on this "options" param
@@ -54,6 +56,16 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         }
     }
 
+    function fireOnEvaluateImmediat() {
+        ko.utils.arrayForEach(_onEvaluateImmediates, function(callback) {
+            callback();
+        });
+    }
+
+    dependentObservable.onEvaluateImmediate = function (callback) {
+        _onEvaluateImmediates.push(callback);
+    }
+
     function evaluateImmediate(suppressChangeNotification) {
         if (_isBeingEvaluated) {
             if (pure) {
@@ -83,6 +95,8 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         }
 
         _isBeingEvaluated = true;
+        _hasEvaluated = true;
+        fireOnEvaluateImmediat();
 
         // When sleeping, recalculate the value and return.
         if (isSleeping) {
@@ -227,6 +241,8 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
 
     dependentObservable.peek = peek;
     dependentObservable.getDependenciesCount = function () { return _dependenciesCount; };
+    dependentObservable.hasEvaluated = function () { return _hasEvaluated; };
+    dependentObservable.deferSubscribeEvaluation = function () { return options['deferSubscribeEvaluation']; };
     dependentObservable.hasWriteFunction = typeof writeFunction === "function";
     dependentObservable.dispose = function () { dispose(); };
     dependentObservable.isActive = isActive;
@@ -282,6 +298,9 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
     ko.exportProperty(dependentObservable, 'dispose', dependentObservable.dispose);
     ko.exportProperty(dependentObservable, 'isActive', dependentObservable.isActive);
     ko.exportProperty(dependentObservable, 'getDependenciesCount', dependentObservable.getDependenciesCount);
+    ko.exportProperty(dependentObservable, 'deferSubscribeEvaluation', dependentObservable.deferSubscribeEvaluation);
+    ko.exportProperty(dependentObservable, 'hasEvaluated', dependentObservable.hasEvaluated);
+    ko.exportProperty(dependentObservable, 'onEvaluateImmediate', dependentObservable.onEvaluateImmediate);
 
     // Add a "disposeWhen" callback that, on each evaluation, disposes if the node was removed without using ko.removeNode.
     if (disposeWhenNodeIsRemoved) {
@@ -339,6 +358,8 @@ if (ko.utils.canSetPrototype) {
 
 ko.exportSymbol('dependentObservable', ko.dependentObservable);
 ko.exportSymbol('computed', ko.dependentObservable); // Make "ko.computed" an alias for "ko.dependentObservable"
+ko.exportSymbol('isComputed', ko.isComputed);
+
 ko.exportSymbol('isComputed', ko.isComputed);
 
 ko.pureComputed = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget) {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -267,8 +267,9 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                 notify(undefined, "asleep");
             }
         }
-    } else if (options['deferEvaluation']) {
+    } else if (options['deferEvaluation'] && !options['deferSubscribeEvaluation']) {
         // This will force a computed with deferEvaluation to evaluate when the first subscriptions is registered.
+        // unless deferSubscribeEvaluation is specified.
         dependentObservable.beforeSubscriptionAdd = function (event) {
             if (event == 'change' || event == 'beforeChange') {
                 peek();

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -23,6 +23,17 @@ ko.extenders['trackArrayChanges'] = function(target) {
             return;
         }
 
+        if (ko.isComputed(target)) {
+            //dont setup change tracking yet if subsribe evaluation is defered.
+            if(target.deferSubscribeEvaluation() && !target.hasEvaluated()){
+                //setup change tracking once target is accessed for the first time.
+                target.onEvaluateImmediate(function() {
+                    trackChanges();
+                });
+                return;
+            }
+        }
+
         trackingChanges = true;
 
         // Intercept "notifySubscribers" to track how many times it was called.


### PR DESCRIPTION
Allows for completely lazy computed observables that don't evaluate until they are called.
Fixes issue #1653.