### PR TITLE
Allow `ko.applyBindings` to accept ´#document-fragment´s

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -430,7 +430,7 @@
             jQueryInstance = window['jQuery'];
         }
 
-        if (rootNode && (rootNode.nodeType !== 1) && (rootNode.nodeType !== 8))
+        if (rootNode && (rootNode.nodeType !== 1) && (rootNode.nodeType !== 8) && (rootNode.nodeType !== 11))
             throw new Error("ko.applyBindings: first parameter should be your view model; second parameter should be a DOM node");
         rootNode = rootNode || window.document.body; // Make "rootNode" parameter optional
 


### PR DESCRIPTION
Adding HTML nodeType 11 (Document Fragment) to the allowed node types for `ko.applyBindings` allows knockout to operate on Shadow DOM Root nodes
