### PR TITLE
overwrite toString method of observable

### DIFF
--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -20,8 +20,14 @@ ko.observable = function (initialValue) {
             return _latestValue;
         }
     }
+    
     ko.subscribable.call(observable);
     ko.utils.setPrototypeOfOrExtend(observable, ko.observable['fn']);
+    
+    observable.toString = function(){
+   		ko.dependencyDetection.registerDependency(observable);
+   		return _latestValue;
+   	}
 
     if (DEBUG) observable._latestValue = _latestValue;
     observable.peek = function() { return _latestValue };


### PR DESCRIPTION
overwrite toString method of observable,to make the getting obj's value more like a variable,following is code

``` javascript
this.selectedIndex = ko.observable(-1);
console.log(this.selectedIndex());//before overwriting 
console.log(this.selectedIndex(), this.selectedIndex); // after overwriting
```
