### PR TITLE
Pass bindingContext as a parameter to the viewModel constructor

### DIFF
--- a/src/components/componentBinding.js
+++ b/src/components/componentBinding.js
@@ -49,7 +49,7 @@
                         throw new Error('Unknown component \'' + componentName + '\'');
                     }
                     cloneTemplateIntoElement(componentName, componentDefinition, element);
-                    var componentViewModel = createViewModel(componentDefinition, element, originalChildNodes, componentParams),
+                    var componentViewModel = createViewModel(componentDefinition, element, originalChildNodes, componentParams, bindingContext),
                         childBindingContext = bindingContext['createChildContext'](componentViewModel, /* dataItemAlias */ undefined, function(ctx) {
                             ctx['$component'] = componentViewModel;
                             ctx['$componentTemplateNodes'] = originalChildNodes;
@@ -75,10 +75,10 @@
         ko.virtualElements.setDomNodeChildren(element, clonedNodesArray);
     }
 
-    function createViewModel(componentDefinition, element, originalChildNodes, componentParams) {
+    function createViewModel(componentDefinition, element, originalChildNodes, componentParams, bindingContext) {
         var componentViewModelFactory = componentDefinition['createViewModel'];
         return componentViewModelFactory
-            ? componentViewModelFactory.call(componentDefinition, componentParams, { 'element': element, 'templateNodes': originalChildNodes })
+            ? componentViewModelFactory.call(componentDefinition, componentParams, { 'element': element, 'templateNodes': originalChildNodes }, bindingContext)
             : componentParams; // Template-only component
     }
 

--- a/src/components/defaultLoader.js
+++ b/src/components/defaultLoader.js
@@ -136,8 +136,8 @@
             // By design, this does *not* supply componentInfo to the constructor, as the intent is that
             // componentInfo contains non-viewmodel data (e.g., the component's element) that should only
             // be used in factory functions, not viewmodel constructors.
-            callback(function (params /*, componentInfo */) {
-                return new viewModelConfig(params);
+            callback(function (params, componentInfo, bindingContext) {
+                return new viewModelConfig(params, bindingContext);
             });
         } else if (typeof viewModelConfig[createViewModelKey] === 'function') {
             // Already a factory function - use it as-is


### PR DESCRIPTION
By providing the bindingContext to the viewModel constructor, we are able to create sub-components with less boilerplate code.

For example the live example 2, from page: http://knockoutjs.com/documentation/extenders.html could be done with components like this:

First register an auxiliar component, which assumes the model has a observable called value
```
    ko.components.register('required-text', {
      viewModel: function(params, bindingContext) {
        this.visible = ko.pureComputed(function(){
          return bindingContext.$rawData.value() == ""
        })
      },
      template: '<span data-bind="visible: visible">This field is required</span>'
    });
```

Bind the context:
```
var appModel = {
  firstName: {value: ko.observable("John")}, 
  lastName: {value: ko.observable("Doe")}
}
 
ko.applyBindings(appModel);
```

With markup:
```
            <div data-bind="with: firstName">
              <input type="text" data-bind="value: value, valueUpdate: 'afterkeydown'" />
              <required-text></required-text>
            </div>
            <div data-bind="with: lastName">
              <input type="text" data-bind="value: value, valueUpdate: 'afterkeydown'" />
              <required-text></required-text>
            </div>
```

Currently the required-text -component would require passing parameters in the markup like:
```
            <div data-bind="with: firstName">
              <input type="text" data-bind="value: value, valueUpdate: 'afterkeydown'" />
              <required-text params="value: value"></required-text>
            </div>
            <div data-bind="with: lastName">
              <input type="text" data-bind="value: value, valueUpdate: 'afterkeydown'" />
              <required-text params="value: value"></required-text>
            </div>
```

