### PR TITLE
Component API should not directly use require

### DIFF
--- a/build/fragments/amd-pre.js
+++ b/build/fragments/amd-pre.js
@@ -1,14 +1,13 @@
 (function(factory) {
     // Support three module loading scenarios
-    if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-        // [1] CommonJS/Node.js
-        var target = module['exports'] || exports; // module.exports is for Node.js
-        factory(target, require);
-    } else if (typeof define === 'function' && define['amd']) {
-        // [2] AMD anonymous module
+    if (typeof define === 'function' && define['amd']) {
+        // [1] AMD anonymous module
         define(['exports', 'require'], factory);
+    } else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+        // [2] CommonJS/Node.js
+        factory(module['exports'] || exports);  // module.exports is for Node.js
     } else {
         // [3] No module loader (plain <script> tag) - put directly in global namespace
         factory(window['ko'] = {});
     }
-}(function(koExports, require){
+}(function(koExports, amdRequire){

--- a/src/components/defaultLoader.js
+++ b/src/components/defaultLoader.js
@@ -194,8 +194,8 @@
     function possiblyGetConfigFromAmd(errorCallback, config, callback) {
         if (typeof config['require'] === 'string') {
             // The config is the value of an AMD module
-            if (require || window['require']) {
-                (require || window['require'])([config['require']], callback);
+            if (amdRequire || window['require']) {
+                (amdRequire || window['require'])([config['require']], callback);
             } else {
                 errorCallback('Uses require, but no AMD loader is present');
             }


### PR DESCRIPTION
Regarding https://github.com/knockout/knockout/issues/1517, the component API should be updated to remove directly using require so that static analysis works by build systems: https://github.com/webpack/webpack/issues/424.

Alternatively, you could move the components module into its own separate module: https://github.com/knockout/knockout/issues/1525
