### PR TITLE
Make ko.dependencyDetection.ignore exported outside

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -138,6 +138,17 @@ describe('Dependent Observable', function() {
         expect(computed()).toEqual(2);    // value wasn't changed
     });
 
+    it('Should be able to use \'ko.ignoreDependencies\' within a computed to avoid dependencies', function() {
+        var observable = ko.observable(1),
+            computed = ko.dependentObservable(function () {
+                return ko.ignoreDependencies(function() { return observable() + 1 } );
+            });
+        expect(computed()).toEqual(2);
+
+        observable(50);
+        expect(computed()).toEqual(2);    // value wasn't changed
+    });
+
     it('Should unsubscribe from previous dependencies each time a dependency changes', function () {
         var observableA = new ko.observable("A");
         var observableB = new ko.observable("B");

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -61,3 +61,5 @@ ko.exportSymbol('computedContext', ko.computedContext);
 ko.exportSymbol('computedContext.getDependenciesCount', ko.computedContext.getDependenciesCount);
 ko.exportSymbol('computedContext.isInitial', ko.computedContext.isInitial);
 ko.exportSymbol('computedContext.isSleeping', ko.computedContext.isSleeping);
+
+ko.exportSymbol('ignoreDependencies', ko.ignoreDependencies = ko.dependencyDetection.ignore);


### PR DESCRIPTION
Here is oversimplified custom binding to highlight next problem.
```
// valueChanged: {value: visible, valueChanged: function(){ /* callback code */ }}
ko.bindingHandlers['valueChanged'] = {
    'init': function (element, valueAccessor) {
        ko.computed({
            read: function () {
                var value = ko.unwrap(valueAccessor().value);

                //ko.dependencyDetection.ignore(function () {
                    valueAccessor().valueChanged(value);
                //});
            },
            disposeWhenNodeIsRemoved: element
        });
    }
};
```
If inside callback code (which set in valueChanged binding option) another observable fields will be read knockout will subscribe on them also, so valueChanged callback will be triggered when:
* valueAccessor().value changed
* another observable fields changed (we should remove this side effect!)

This behavior is not suitable for the valueChanged binding, to fix ko.dependencyDetection.ignore will help.
To use ko.dependencyDetection.ignore it should be exported outside, for now we can use it ONLY in debug version of knockout not in minimized.
I don't like next solution, it looks like a hack.
```
ko.computed(function() {
    valueAccessor().valueChanged(value);
 }).dispose();
```