### PR TITLE
Creates ko.onError handler

### DIFF
--- a/spec/onErrorBehaviors.js
+++ b/spec/onErrorBehaviors.js
@@ -1,0 +1,93 @@
+describe('onError handler', function () {
+    var koOnErrorCount = 0;
+    var windowOnErrorCount = 0;
+    var windowOnErrorOrginal;
+
+    beforeEach(function () {
+        ko.onError = function (error) {
+            koOnErrorCount++;
+        };
+
+        function ensureNodeExistsAndIsEmpty(id, tagName, type) {
+            var existingNode = document.getElementById(id);
+            if (existingNode != null)
+                existingNode.parentNode.removeChild(existingNode);
+            var resultNode = document.createElement(tagName || "div");
+            resultNode.id = id;
+            if (type)
+                resultNode.setAttribute("type", type);
+            document.body.appendChild(resultNode);
+            return resultNode;
+        }
+
+        window.testDivTemplate = ensureNodeExistsAndIsEmpty("testDivTemplate");
+        window.templateOutput = ensureNodeExistsAndIsEmpty("templateOutput");
+
+        koOnErrorCount = 0;
+        windowOnErrorCount = 0;
+
+        windowOnErrorOrginal = window.onerror;
+
+        window.onerror = function () {
+            windowOnErrorCount++;
+        };
+    });
+
+    afterEach(function () {
+        window.onerror = windowOnErrorOrginal;
+        ko.onError = null;
+    });
+
+    it('does not fire on sync errors', function () {
+        window.testDivTemplate.innerHTML = "name: <div data-bind='text: name'></div>";
+
+        var syncError = false;
+
+        try {
+            ko.renderTemplate("testDivTemplate", {
+                name: ko.computed(function () {
+                    return ERRORS_ON_PURPOSE = ERRORS_ON_PURPOSE2;
+                })
+            }, null, window.templateOutput);
+        }
+        catch (e) {
+            syncError = true;
+        }
+
+        expect(syncError).toBe(true);
+
+        expect(koOnErrorCount).toBe(0);
+        expect(windowOnErrorCount).toBe(0);
+    });
+
+    it('fires on async component errors', function () {
+        runs(function () {
+            var component = {
+                tagName: 'test-onerror',
+                template: "<div data-bind='text: name'></div>",
+                viewModel: function () {
+                    this.name = ko.computed(function () {
+                        return ERRORS_ON_PURPOSE = ERRORS_ON_PURPOSE2;
+                    });
+                }
+            };
+
+            if (!ko.components.isRegistered(component.tagName)) {
+                ko.components.register(component.tagName, component);
+            }
+
+            window.testDivTemplate.innerHTML = "<test-onerror></test-onerror>";
+            ko.renderTemplate("testDivTemplate", {
+            }, null, window.templateOutput);
+        });
+
+        waitsFor(function () {
+            return koOnErrorCount > 0 && windowOnErrorCount > 0;
+        }, 'Error counts were not updated', 500);
+
+        runs(function () {
+            expect(koOnErrorCount).toBe(1);
+            expect(windowOnErrorCount).toBe(1);
+        });
+    });
+});

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -40,6 +40,7 @@
         <script type="text/javascript" src="jsonPostingBehaviors.js"></script>
         <script type="text/javascript" src="nativeTemplateEngineBehaviors.js"></script>
         <script type="text/javascript" src="utilsBehaviors.js"></script>
+        <script type="text/javascript" src="onErrorBehaviors.js"></script>
         <script type="text/javascript" src="components/loaderRegistryBehaviors.js"></script>
         <script type="text/javascript" src="components/defaultLoaderBehaviors.js"></script>
         <script type="text/javascript" src="components/componentBindingBehaviors.js"></script>

--- a/src/binding/defaultBindings/textInput.js
+++ b/src/binding/defaultBindings/textInput.js
@@ -68,7 +68,7 @@ ko.bindingHandlers['textInput'] = {
                 // such as rateLimit. Such updates, if not ignored, can cause keystrokes to be lost.
                 elementValueBeforeEvent = element.value;
                 var handler = DEBUG ? updateModel.bind(element, {type: event.type}) : updateModel;
-                timeoutHandle = setTimeout(handler, 4);
+                timeoutHandle = ko.utils.setTimeout(handler, 4);
             }
         };
 
@@ -80,7 +80,7 @@ ko.bindingHandlers['textInput'] = {
             }
 
             if (elementValueBeforeEvent !== undefined && modelValue === elementValueBeforeEvent) {
-                setTimeout(updateView, 4);
+                ko.utils.setTimeout(updateView, 4);
                 return;
             }
 

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -57,7 +57,7 @@ ko.bindingHandlers['value'] = {
                     // techniques like rateLimit can trigger model changes at critical moments that will
                     // override the user's inputs, causing keystrokes to be lost.
                     elementValueBeforeEvent = ko.selectExtensions.readValue(element);
-                    setTimeout(valueUpdateHandler, 0);
+                    ko.utils.setTimeout(valueUpdateHandler, 0);
                 };
                 eventName = eventName.substring("after".length);
             }
@@ -69,7 +69,7 @@ ko.bindingHandlers['value'] = {
             var elementValue = ko.selectExtensions.readValue(element);
 
             if (elementValueBeforeEvent !== null && newValue === elementValueBeforeEvent) {
-                setTimeout(updateFromModel, 0);
+                ko.utils.setTimeout(updateFromModel, 0);
                 return;
             }
 
@@ -91,7 +91,7 @@ ko.bindingHandlers['value'] = {
                         // Workaround for IE6 bug: It won't reliably apply values to SELECT nodes during the same execution thread
                         // right after you've changed the set of OPTION nodes on it. So for that node type, we'll schedule a second thread
                         // to apply the value as well.
-                        setTimeout(applyValueAction, 0);
+                        ko.utils.setTimeout(applyValueAction, 0);
                     }
                 } else {
                     ko.selectExtensions.writeValue(element, newValue);

--- a/src/components/loaderRegistry.js
+++ b/src/components/loaderRegistry.js
@@ -14,7 +14,7 @@
                         callback(cachedDefinition.definition);
                     });
                 } else {
-                    setTimeout(function() { callback(cachedDefinition.definition); }, 0);
+                    ko.utils.setTimeout(function () { callback(cachedDefinition.definition); }, 0);
                 }
             } else {
                 // Join the loading process that is already underway, or start a new one.
@@ -57,7 +57,7 @@
                     // See comment in loaderRegistryBehaviors.js for reasoning
                     subscribable['notifySubscribers'](definition);
                 } else {
-                    setTimeout(function() {
+                    ko.utils.setTimeout(function () {
                         subscribable['notifySubscribers'](definition);
                     }, 0);
                 }

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -46,7 +46,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         var throttleEvaluationTimeout = dependentObservable['throttleEvaluation'];
         if (throttleEvaluationTimeout && throttleEvaluationTimeout >= 0) {
             clearTimeout(evaluationTimeoutInstance);
-            evaluationTimeoutInstance = setTimeout(evaluateImmediate, throttleEvaluationTimeout);
+            evaluationTimeoutInstance = ko.utils.setTimeout(evaluateImmediate, throttleEvaluationTimeout);
         } else if (dependentObservable._evalRateLimited) {
             dependentObservable._evalRateLimited();
         } else {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -38,7 +38,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                 dependency = dependencyTracking[id];
                 if (dependency._target.hasChanged(dependency._version)) {
                     return true;
-    }
+                }
             }
         }
     }
@@ -98,72 +98,72 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
 
         _isBeingEvaluated = true;
 
-            try {
-                // Initially, we assume that none of the subscriptions are still being used (i.e., all are candidates for disposal).
-                // Then, during evaluation, we cross off any that are in fact still being used.
+        try {
+            // Initially, we assume that none of the subscriptions are still being used (i.e., all are candidates for disposal).
+            // Then, during evaluation, we cross off any that are in fact still being used.
             var disposalCandidates = dependencyTracking,
                     disposalCount = _dependenciesCount,
                     isInitial = pure ? undefined : !_dependenciesCount;   // If we're evaluating when there are no previous dependencies, it must be the first time
 
-                ko.dependencyDetection.begin({
-                    callback: function(subscribable, id) {
-                        if (!_isDisposed) {
-                            if (disposalCount && disposalCandidates[id]) {
-                                // Don't want to dispose this subscription, as it's still being used
+            ko.dependencyDetection.begin({
+                callback: function (subscribable, id) {
+                    if (!_isDisposed) {
+                        if (disposalCount && disposalCandidates[id]) {
+                            // Don't want to dispose this subscription, as it's still being used
                             addDependencyTracking(id, subscribable, disposalCandidates[id]);
-                                delete disposalCandidates[id];
-                                --disposalCount;
+                            delete disposalCandidates[id];
+                            --disposalCount;
                         } else if (!dependencyTracking[id]) {
-                                // Brand new subscription - add it
+                            // Brand new subscription - add it
                             addDependencyTracking(id, subscribable, isSleeping ? { _target: subscribable } : subscribable.subscribe(evaluatePossiblyAsync));
-                            }
                         }
-                    },
-                    computed: dependentObservable,
-                    isInitial: isInitial
-                });
+                    }
+                },
+                computed: dependentObservable,
+                isInitial: isInitial
+            });
 
             dependencyTracking = {};
-                _dependenciesCount = 0;
+            _dependenciesCount = 0;
 
-                try {
-                    var newValue = evaluatorFunctionTarget ? readFunction.call(evaluatorFunctionTarget) : readFunction();
+            try {
+                var newValue = evaluatorFunctionTarget ? readFunction.call(evaluatorFunctionTarget) : readFunction();
 
-                } finally {
-                    ko.dependencyDetection.end();
+            } finally {
+                ko.dependencyDetection.end();
 
-                    // For each subscription no longer being used, remove it from the active subscriptions list and dispose it
+                // For each subscription no longer being used, remove it from the active subscriptions list and dispose it
                 if (disposalCount && !isSleeping) {
-                        ko.utils.objectForEach(disposalCandidates, function(id, toDispose) {
+                    ko.utils.objectForEach(disposalCandidates, function (id, toDispose) {
                         if (toDispose.dispose)
                             toDispose.dispose();
-                        });
-                    }
-
-                    _needsEvaluation = false;
+                    });
                 }
 
-                if (dependentObservable.isDifferent(_latestValue, newValue)) {
+                _needsEvaluation = false;
+            }
+
+            if (dependentObservable.isDifferent(_latestValue, newValue)) {
                 if (!isSleeping) {
                     notify(_latestValue, "beforeChange");
                 }
 
-                    _latestValue = newValue;
-                    if (DEBUG) dependentObservable._latestValue = _latestValue;
+                _latestValue = newValue;
+                if (DEBUG) dependentObservable._latestValue = _latestValue;
 
                 if (isSleeping) {
                     dependentObservable.updateVersion();
                 } else if (notifyChange) {
-                        notify(_latestValue);
-                    }
+                    notify(_latestValue);
                 }
-
-                if (isInitial) {
-                    notify(_latestValue, "awake");
-                }
-            } finally {
-                _isBeingEvaluated = false;
             }
+
+            if (isInitial) {
+                notify(_latestValue, "awake");
+            }
+        } finally {
+            _isBeingEvaluated = false;
+        }
 
         if (!_dependenciesCount)
             dispose();
@@ -228,9 +228,9 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
 
     // Replace the limit function with one that delays evaluation as well.
     var originalLimit = dependentObservable.limit;
-    dependentObservable.limit = function(limitFunction) {
+    dependentObservable.limit = function (limitFunction) {
         originalLimit.call(dependentObservable, limitFunction);
-        dependentObservable._evalRateLimited = function() {
+        dependentObservable._evalRateLimited = function () {
             dependentObservable._rateLimitedBeforeChange(_latestValue);
 
             _needsEvaluation = true;    // Mark as dirty
@@ -251,7 +251,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                 if (_needsEvaluation || haveDependenciesChanged()) {
                     dependencyTracking = null;
                     _dependenciesCount = 0;
-                _needsEvaluation = true;
+                    _needsEvaluation = true;
                     evaluateImmediate();
                 } else {
                     // First put the dependencies in order
@@ -260,7 +260,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                         dependeciesOrder[dependency._order] = id;
                     });
                     // Next, subscribe to each one
-                    ko.utils.arrayForEach(dependeciesOrder, function(id, order) {
+                    ko.utils.arrayForEach(dependeciesOrder, function (id, order) {
                         var dependency = dependencyTracking[id],
                             subscription = dependency._target.subscribe(evaluatePossiblyAsync);
                         subscription._order = order;
@@ -298,7 +298,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         dependentObservable.getVersion = function () {
             if (isSleeping && (_needsEvaluation || haveDependenciesChanged())) {
                 evaluateImmediate();
-        }
+            }
             return dependentObservable._originalGetVersion();
         };
     } else if (options['deferEvaluation']) {
@@ -341,7 +341,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
     // Attach a DOM node disposal callback so that the computed will be proactively disposed as soon as the node is
     // removed using ko.removeNode. But skip if isActive is false (there will never be any dependencies to dispose).
     if (disposeWhenNodeIsRemoved && isActive() && disposeWhenNodeIsRemoved.nodeType) {
-        dispose = function() {
+        dispose = function () {
             ko.utils.domNodeDisposal.removeDisposeCallback(disposeWhenNodeIsRemoved, dispose);
             disposeComputed();
         };
@@ -351,7 +351,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
     return dependentObservable;
 };
 
-ko.isComputed = function(instance) {
+ko.isComputed = function (instance) {
     return ko.hasPrototype(instance, ko.dependentObservable);
 };
 
@@ -375,7 +375,7 @@ ko.exportSymbol('isComputed', ko.isComputed);
 
 ko.pureComputed = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget) {
     if (typeof evaluatorFunctionOrOptions === 'function') {
-        return ko.computed(evaluatorFunctionOrOptions, evaluatorFunctionTarget, {'pure':true});
+        return ko.computed(evaluatorFunctionOrOptions, evaluatorFunctionTarget, { 'pure': true });
     } else {
         evaluatorFunctionOrOptions = ko.utils.extend({}, evaluatorFunctionOrOptions);   // make a copy of the parameter object
         evaluatorFunctionOrOptions['pure'] = true;

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -13,7 +13,7 @@ ko.extenders = {
             'read': target,
             'write': function(value) {
                 clearTimeout(writeTimeoutInstance);
-                writeTimeoutInstance = setTimeout(function() {
+                writeTimeoutInstance = ko.utils.setTimeout(function() {
                     target(value);
                 }, timeout);
             }
@@ -53,7 +53,7 @@ function throttle(callback, timeout) {
     var timeoutInstance;
     return function () {
         if (!timeoutInstance) {
-            timeoutInstance = setTimeout(function() {
+            timeoutInstance = ko.utils.setTimeout(function () {
                 timeoutInstance = undefined;
                 callback();
             }, timeout);
@@ -65,7 +65,7 @@ function debounce(callback, timeout) {
     var timeoutInstance;
     return function () {
         clearTimeout(timeoutInstance);
-        timeoutInstance = setTimeout(callback, timeout);
+        timeoutInstance = ko.utils.setTimeout(callback, timeout);
     };
 }
 


### PR DESCRIPTION
This creates a optional ko.onError callback property that will be called on new async callstacks when errors are hit. This allows us to get usable callstacks in browsers that do not have the stack param on the window.onerror event (e.g. IE 11 and lower).