### PR TITLE
nativeTemplateEngine: Multi-node template

### DIFF
--- a/src/templating/native/nativeTemplateEngine.js
+++ b/src/templating/native/nativeTemplateEngine.js
@@ -10,7 +10,7 @@ ko.nativeTemplateEngine.prototype['renderTemplateSource'] = function (templateSo
         templateNodes = templateNodesFunc ? templateSource['nodes']() : null;
 
     if (templateNodes) {
-        return ko.utils.makeArray(templateNodes.cloneNode(true).childNodes);
+        return ko.utils.makeArray(templateNodes.length ? ko.utils.cloneNodes(templateNodes, false) : templateNodes.cloneNode(true).childNodes);
     } else {
         var templateText = templateSource['text']();
         return ko.utils.parseHtmlFragment(templateText, templateDocument);


### PR DESCRIPTION
Allow creating templates from multiple nodes directly (without "root" node)