### PR TITLE
Publish a "cache" event on latestValue change

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -150,6 +150,8 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
 
                 _latestValue = newValue;
                 if (DEBUG) dependentObservable._latestValue = _latestValue;
+                
+                notify(_latestValue, "cache");
 
                 if (isSleeping) {
                     dependentObservable.updateVersion();


### PR DESCRIPTION
For pure computeds the "change"-event does not actually fire on every change, but only for changes on active observables. (not on awake and peek) Also, the subscriptions to "change" lead to computation.

This is a necessary hook for #1511.
