### PR TITLE
External templates with default templating engine

### DIFF
--- a/src/templating/templateSources.js
+++ b/src/templating/templateSources.js
@@ -37,8 +37,24 @@
                                  : tagNameLower === "textarea" ? "value"
                                  : "innerHTML";
 
-        if (arguments.length == 0) {
-            return this.domElement[elemContentsProperty];
+       if (arguments.length == 0) {
+            var el = this.domElement;
+            var val = el[elemContentsProperty];
+            if (tagNameLower === "script" && !val && el['src']) {
+                val = ko.observable("Loading...<br/>");
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', this.domElement['src'], true);
+                xhr.setRequestHeader('Content-Type', 'text/html; charset=utf-8');
+                xhr.onreadystatechange = function() {
+                    if (xhr.readyState !== 4) return;
+                    val(el[elemContentsProperty] = xhr.response || xhr.responseText);
+                };
+                xhr.onerror = function (e) {
+                    val(el[elemContentsProperty] = 'Cannot load: ' + e);
+                };
+                xhr.send();
+            }
+            return ko.utils.unwrapObservable(val);
         } else {
             var valueToWrite = arguments[0];
             if (elemContentsProperty === "innerHTML")


### PR DESCRIPTION
I was searching for a way to define template via
```html
<script type="text/html" id="templateId">
template text
</script>
```
but with the ''template text'' being in a separate file. I have not found the exact solution, the closest one being [this tutorial](http://www.knockmeout.net/2011/10/ko-13-preview-part-3-template-sources.html). Based on it I figured out I can redefine behavior of ko.templateSources.domElement.prototype['text'] to do what I need. I think the solution could be generally useful and I am proposing to include it in the nativeTemplatingEngine itself.

With my change one can define a template via 
```html
<script src="your.template.html" type="text/html"></script> 
```
and once the template is needed the nativeTemplatingEngine will asynchronously load it from given source (in this case your.template.html).

If you find the overall direction of my pull request sane, let me know what else should be polished, so the request is mergeable.