### PR TITLE
Deferred updates, part 2: default option

### DIFF
--- a/build/fragments/source-references.js
+++ b/build/fragments/source-references.js
@@ -2,6 +2,7 @@ knockoutDebugCallback([
     'src/namespace.js',
     'src/google-closure-compiler-utils.js',
     'src/version.js',
+    'src/options.js',
     'src/utils.js',
     'src/utils.domData.js',
     'src/utils.domNodeDisposal.js',

--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -619,7 +619,7 @@ describe('Deferred', function() {
     });
 
     afterEach(function() {
-        expect(ko.tasks.reset()).toEqual(0);
+        expect(ko.tasks.resetForTesting()).toEqual(0);
         jasmine.Clock.reset();
     });
 

--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -736,7 +736,7 @@ describe('Deferred', function() {
             myArray.push('Epsilon');
             myArray.pop();
             jasmine.Clock.tick(1);
-            expect(changelist).toEqualOneOf([[], undefined]);
+            expect(changelist).toEqual(undefined);
         });
     });
 

--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -618,6 +618,11 @@ describe('Deferred', function() {
         jasmine.Clock.useMockForTasks();
     });
 
+    afterEach(function() {
+        expect(ko.tasks.reset()).toEqual(0);
+        jasmine.Clock.reset();
+    });
+
     describe('Observable', function() {
         it('Should delay notifications', function() {
             var observable = ko.observable().extend({deferred:true});
@@ -683,6 +688,21 @@ describe('Deferred', function() {
             // Now, they are synchronous
             observable('B');
             expect(notifySpy.argsForCall).toEqual([ ['B'] ]);
+        });
+
+        it('Is default behavior when "ko.options.deferUpdates" is "true"', function() {
+            this.restoreAfter(ko.options, 'deferUpdates');
+            ko.options.deferUpdates = true;
+
+            var observable = ko.observable();
+            var notifySpy = jasmine.createSpy('notifySpy');
+            observable.subscribe(notifySpy);
+
+            observable('A');
+            expect(notifySpy).not.toHaveBeenCalled();
+
+            jasmine.Clock.tick(1);
+            expect(notifySpy.argsForCall).toEqual([ ['A'] ]);
         });
     });
 
@@ -784,6 +804,23 @@ describe('Deferred', function() {
             data('B');
             expect(computed()).toEqual('B');
             expect(notifySpy).not.toHaveBeenCalled();
+            jasmine.Clock.tick(1);
+            expect(notifySpy.argsForCall).toEqual([ ['B'] ]);
+        });
+
+        it('Is default behavior when "ko.options.deferUpdates" is "true"', function() {
+            this.restoreAfter(ko.options, 'deferUpdates');
+            ko.options.deferUpdates = true;
+
+            var data = ko.observable('A'),
+                computed = ko.computed(data),
+                notifySpy = jasmine.createSpy('notifySpy'),
+                subscription = computed.subscribe(notifySpy);
+
+            // Notification is deferred
+            data('B');
+            expect(notifySpy).not.toHaveBeenCalled();
+
             jasmine.Clock.tick(1);
             expect(notifySpy.argsForCall).toEqual([ ['B'] ]);
         });

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -14,7 +14,7 @@ describe("Deferred bindings", function() {
         };
     });
     afterEach(function() {
-        expect(ko.tasks.reset()).toEqual(0);
+        expect(ko.tasks.resetForTesting()).toEqual(0);
         jasmine.Clock.reset();
         ko.options.deferUpdates = false;
         bindingSpy = ko.bindingHandlers.test = null;

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -1,0 +1,128 @@
+describe("Deferred bindings", function() {
+    var bindingSpy;
+
+    beforeEach(function() {
+        jasmine.prepareTestNode();
+        jasmine.Clock.useMockForTasks();
+
+        ko.options.deferUpdates = true;
+
+        bindingSpy = jasmine.createSpy('bindingSpy');
+        ko.bindingHandlers.test = {
+            init: function (element, valueAccessor) { bindingSpy('init', ko.unwrap(valueAccessor())); },
+            update: function (element, valueAccessor) { bindingSpy('update', ko.unwrap(valueAccessor())); }
+        };
+    });
+    afterEach(function() {
+        expect(ko.tasks.reset()).toEqual(0);
+        jasmine.Clock.reset();
+        ko.options.deferUpdates = false;
+        bindingSpy = ko.bindingHandlers.test = null;
+    });
+
+    it("Should update bindings asynchronously", function() {
+        var observable = ko.observable('A');
+
+        // The initial "applyBindings" is synchronous
+        testNode.innerHTML = "<div data-bind='test: myObservable'></div>";
+        ko.applyBindings({ myObservable: observable }, testNode);
+        expect(bindingSpy.argsForCall).toEqual([ ['init', 'A'], ['update', 'A'] ]);
+
+        // When changing the observable, the update is deferred
+        bindingSpy.reset();
+        observable('B');
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        // Update is still deferred
+        observable('C');
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        jasmine.Clock.tick(1);
+        // Only the latest value is notified
+        expect(bindingSpy.argsForCall).toEqual([ ['update', 'C'] ]);
+    });
+
+    it("Should update templates asynchronously", function() {
+        var observable = ko.observable('A');
+
+        testNode.innerHTML = "<div data-bind='template: {data: myObservable}'><div data-bind='test: $data'></div></div>";
+        ko.applyBindings({ myObservable: observable }, testNode);
+        expect(bindingSpy.argsForCall).toEqual([ ['init', 'A'], ['update', 'A'] ]);
+
+        // mutate; template should not be updated yet
+        bindingSpy.reset();
+        observable('B');
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        // mutate again; template should not be updated yet
+        observable('C');
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        jasmine.Clock.tick(1);
+        // only the latest value should be used
+        expect(bindingSpy.argsForCall).toEqual([ ['init', 'C'], ['update', 'C'] ]);
+    });
+
+    it("Should update 'foreach' items asynchronously", function() {
+        var observable = ko.observableArray(["A"]);
+
+        testNode.innerHTML = "<div data-bind='foreach: {data: myObservables}'><div data-bind='test: $data'></div></div>";
+        ko.applyBindings({ myObservables: observable }, testNode);
+        expect(bindingSpy.argsForCall).toEqual([ ['init', 'A'], ['update', 'A'] ]);
+
+        // mutate; template should not be updated yet
+        bindingSpy.reset();
+        observable(["A", "B"]);
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        // mutate again; template should not be updated yet
+        observable(["A", "C"]);
+        expect(bindingSpy).not.toHaveBeenCalled();
+
+        jasmine.Clock.tick(1);
+        // only the latest value should be used ("C" added but not "B")
+        expect(bindingSpy.argsForCall).toEqual([ ['init', 'C'], ['update', 'C'] ]);
+
+        // When an element is deleted and then added in a new place, it should register as a move and
+        // not create new DOM elements or update any child bindings
+        bindingSpy.reset();
+        observable.remove("A");
+        observable.push("A");
+
+        var nodeA = testNode.childNodes[0].childNodes[0],
+            nodeB = testNode.childNodes[0].childNodes[1];
+        jasmine.Clock.tick(1);
+        expect(bindingSpy).not.toHaveBeenCalled();
+        expect(testNode.childNodes[0].childNodes[0]).toBe(nodeB);
+        expect(testNode.childNodes[0].childNodes[1]).toBe(nodeA);
+    });
+
+    it("Should be able to force an update using runEarly", function() {
+        // This is based on the logic used in https://github.com/rniemeyer/knockout-sortable that when an item
+        // is dragged and dropped in the same list, it must be deleted and re-added instead of being moved.
+
+        testNode.innerHTML = "<div data-bind='foreach: someItems'><span data-bind='text: childProp'></span></div>";
+        var someItems = ko.observableArray([
+            { childProp: 'first child' },
+            { childProp: 'second child' },
+            { childProp: 'moving child' }
+        ]);
+        ko.applyBindings({ someItems: someItems }, testNode);
+        expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span><span data-bind="text: childprop">moving child</span>');
+
+        var sourceIndex = 2,
+            targetIndex = 0,
+            itemNode = testNode.childNodes[0].childNodes[sourceIndex],
+            item = someItems()[sourceIndex];
+
+        // Simply removing and re-adding item isn't sufficient because it will be registered as a move and no new element will be added
+        // Using ko.tasks.runEarly between the updates ensures that the binding sees each individual update
+        someItems.splice(sourceIndex, 1);
+        ko.tasks.runEarly();
+        someItems.splice(targetIndex, 0, item);
+
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">moving child</span><span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span>');
+        expect(testNode.childNodes[0].childNodes[targetIndex]).not.toBe(itemNode);    // node was create anew so it's not the same
+    });
+});

--- a/spec/components/componentBindingBehaviors.js
+++ b/spec/components/componentBindingBehaviors.js
@@ -15,7 +15,7 @@ describe('Components: Component binding', function() {
     });
 
     afterEach(function() {
-        expect(ko.tasks.length()).toEqual(0);
+        expect(ko.tasks.reset()).toEqual(0);
         jasmine.Clock.reset();
         ko.components.unregister(testComponentName);
     });

--- a/spec/components/componentBindingBehaviors.js
+++ b/spec/components/componentBindingBehaviors.js
@@ -15,7 +15,7 @@ describe('Components: Component binding', function() {
     });
 
     afterEach(function() {
-        expect(ko.tasks.reset()).toEqual(0);
+        expect(ko.tasks.resetForTesting()).toEqual(0);
         jasmine.Clock.reset();
         ko.components.unregister(testComponentName);
     });

--- a/spec/components/customElementBehaviors.js
+++ b/spec/components/customElementBehaviors.js
@@ -5,7 +5,7 @@ describe('Components: Custom elements', function() {
     });
 
     afterEach(function() {
-        expect(ko.tasks.length()).toEqual(0);
+        expect(ko.tasks.reset()).toEqual(0);
         jasmine.Clock.reset();
         ko.components.unregister('test-component');
     });

--- a/spec/components/customElementBehaviors.js
+++ b/spec/components/customElementBehaviors.js
@@ -5,7 +5,7 @@ describe('Components: Custom elements', function() {
     });
 
     afterEach(function() {
-        expect(ko.tasks.reset()).toEqual(0);
+        expect(ko.tasks.resetForTesting()).toEqual(0);
         jasmine.Clock.reset();
         ko.components.unregister('test-component');
     });

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -20,6 +20,7 @@
         <script type="text/javascript" src="arrayEditDetectionBehaviors.js"></script>
         <script type="text/javascript" src="arrayToDomEditDetectionBehaviors.js"></script>
         <script type="text/javascript" src="asyncBehaviors.js"></script>
+        <script type="text/javascript" src="asyncBindingBehaviors.js"></script>
         <script type="text/javascript" src="memoizationBehaviors.js"></script>
         <script type="text/javascript" src="subscribableBehaviors.js"></script>
         <script type="text/javascript" src="observableBehaviors.js"></script>

--- a/spec/taskBehaviors.js
+++ b/spec/taskBehaviors.js
@@ -47,20 +47,21 @@ describe('Tasks', function() {
     });
 
     it('Should run tasks again if scheduled after a previous run', function() {
-        var runValues = [];
-        var func = function(value) {
-            runValues.push(value);
+        var runCount = 0;
+        var func = function() {
+            runCount++;
         };
-        ko.tasks.schedule(func.bind(null, 1));
-        expect(runValues).toEqual([]);
+        ko.tasks.schedule(func);
+        expect(runCount).toEqual(0);
 
         jasmine.Clock.tick(1);
-        expect(runValues).toEqual([1]);
+        expect(runCount).toEqual(1);
 
-        ko.tasks.schedule(func.bind(null, 2));
+        ko.tasks.schedule(func);
+        expect(runCount).toEqual(1);
 
         jasmine.Clock.tick(1);
-        expect(runValues).toEqual([1,2]);
+        expect(runCount).toEqual(2);
     });
 
     it('Should process newly scheduled tasks during task processing', function() {

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,6 @@
+// For any options that may affect various areas of Knockout and aren't directly associated with data binding.
+ko.options = {
+    'deferUpdates': false
+};
+
+//ko.exportSymbol('options', ko.options);   // 'options' isn't minified

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -334,6 +334,10 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         }
     }
 
+    if (ko.options['deferUpdates']) {
+        ko.extenders['deferred'](dependentObservable, true);
+    }
+
     // Evaluate, unless sleeping or deferEvaluation is true
     if (!isSleeping && !options['deferEvaluation'])
         evaluateImmediate();

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -32,6 +32,10 @@ ko.observable = function (initialValue) {
     ko.exportProperty(observable, "valueHasMutated", observable.valueHasMutated);
     ko.exportProperty(observable, "valueWillMutate", observable.valueWillMutate);
 
+    if (ko.options['deferUpdates']) {
+        ko.extenders['deferred'](observable, true);
+    }
+
     return observable;
 }
 

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -19,6 +19,17 @@ ko.subscribable = function () {
 
 var defaultEvent = "change";
 
+// Moved out of "limit" to avoid the extra closure
+function rateLimitedNotifySubscribers(value, event) {
+    if (!event || event === defaultEvent) {
+        this._rateLimitedChange(value);
+    } else if (event === 'beforeChange') {
+        this._rateLimitedBeforeChange(value);
+    } else {
+        this._origNotifySubscribers(value, event);
+    }
+}
+
 var ko_subscribable_fn = {
     subscribe: function (callback, callbackTarget, event) {
         var self = this;
@@ -80,15 +91,7 @@ var ko_subscribable_fn = {
 
         if (!self._origNotifySubscribers) {
             self._origNotifySubscribers = self["notifySubscribers"];
-            self["notifySubscribers"] = function(value, event) {
-                if (!event || event === defaultEvent) {
-                    self._rateLimitedChange(value);
-                } else if (event === beforeChange) {
-                    self._rateLimitedBeforeChange(value);
-                } else {
-                    self._origNotifySubscribers(value, event);
-                }
-            };
+            self["notifySubscribers"] = rateLimitedNotifySubscribers;
         }
 
         var finish = limitFunction(function() {

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -6,14 +6,16 @@ ko.tasks = (function () {
         nextIndexToProcess = 0;
 
     if (window['MutationObserver']) {
-        // Chrome 27+, Firefox 14+, IE 11+, Opera 15+, Safari 6.1+; borrowed from https://github.com/petkaantonov/bluebird
+        // Chrome 27+, Firefox 14+, IE 11+, Opera 15+, Safari 6.1+
+        // From https://github.com/petkaantonov/bluebird * Copyright (c) 2014 Petka Antonov * License: MIT
         scheduler = (function (callback) {
             var div = document.createElement("div");
             new MutationObserver(callback).observe(div, {attributes: true});
             return function () { div.classList.toggle("foo"); };
         })(scheduledProcess);
     } else if (document && "onreadystatechange" in document.createElement("script")) {
-        // IE 6-10; borrowed from https://github.com/YuzuJS/setImmediate
+        // IE 6-10
+        // From https://github.com/YuzuJS/setImmediate * Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola * License: MIT
         scheduler = function (callback) {
             var script = document.createElement("script");
             script.onreadystatechange = function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -350,6 +350,13 @@ ko.utils = (function () {
             return setTimeout(ko.utils.catchFunctionErrors(handler), timeout);
         },
 
+        deferError: function (error) {
+            setTimeout(function () {
+                ko['onError'] && ko['onError'](error);
+                throw error;
+            }, 0);
+        },
+
         registerEventHandler: function (element, eventType, handler) {
             var wrappedHandler = ko.utils.catchFunctionErrors(handler);
 


### PR DESCRIPTION
After reading @brianmhunt's [comment](https://github.com/knockout/knockout/issues/1603#issuecomment-90278568) on #1603, I thought of using the same API for controlling whether to use global deferred updates. But I like `ko.options` instead of `ko.settings`, so we have `ko.options.deferUpdates`.

Following the information I presented in #1728, this also includes a method to run pending tasks immediately. Instead of `ko.tasks.runTasks`, the name I had used in #1738, I decided on `ko.tasks.runEarly`, which I think makes its purpose more clear.