### PR TITLE
Component named "watch" will give an error in Firefox

### DIFF
--- a/spec/components/defaultLoaderBehaviors.js
+++ b/spec/components/defaultLoaderBehaviors.js
@@ -24,6 +24,9 @@ describe('Components: Default loader', function() {
         expect(ko.components.isRegistered(prototypeProperty)).toBe(false);
         ko.components.register(prototypeProperty, {});
         expect(ko.components.isRegistered(prototypeProperty)).toBe(true);
+
+        ko.components.unregister(prototypeProperty);
+        expect(ko.components.isRegistered(prototypeProperty)).toBe(false);
     });
 
     it('Throws if you try to register a component that is already registered', function() {

--- a/spec/components/defaultLoaderBehaviors.js
+++ b/spec/components/defaultLoaderBehaviors.js
@@ -18,6 +18,14 @@ describe('Components: Default loader', function() {
         expect(ko.components.isRegistered(testComponentName)).toBe(false);
     });
 
+    it('Allows registering component names that may conflict with properties on Object.prototype', function() {
+        var prototypeProperty = 'toString';
+
+        expect(ko.components.isRegistered(prototypeProperty)).toBe(false);
+        ko.components.register(prototypeProperty, {});
+        expect(ko.components.isRegistered(prototypeProperty)).toBe(true);
+    });
+
     it('Throws if you try to register a component that is already registered', function() {
         ko.components.register(testComponentName, {});
 

--- a/src/components/defaultLoader.js
+++ b/src/components/defaultLoader.js
@@ -22,16 +22,16 @@
         }
 
         defaultConfigRegistry[componentName] = config;
-    }
+    };
 
     ko.components.isRegistered = function(componentName) {
-        return componentName in defaultConfigRegistry;
-    }
+        return defaultConfigRegistry.hasOwnProperty(componentName);
+    };
 
     ko.components.unregister = function(componentName) {
         delete defaultConfigRegistry[componentName];
         ko.components.clearCachedDefinition(componentName);
-    }
+    };
 
     ko.components.defaultLoader = {
         'getConfig': function(componentName, callback) {


### PR DESCRIPTION
Naming a component `watch` gives the following warning in Firefox 37:

`Error: Component watch is already registered`

I've created a gist of a barebones application which demonstrates this:
https://gist.github.com/msteward/c3a0298322277adae29e

This error is not thrown in Chrome or IE. For now I can choose another name but curious as to why this would fail in only Firefox? 

