### PR TITLE
Improve the propagation of change notifications

### DIFF
--- a/build/fragments/source-references.js
+++ b/build/fragments/source-references.js
@@ -8,6 +8,7 @@ knockoutDebugCallback([
     'src/utils.domManipulation.js',
     'src/memoization.js',
     'src/tasks.js',
+    'src/subscribables/notifyQueue.js',
     'src/subscribables/extenders.js',
     'src/subscribables/subscribable.js',
     'src/subscribables/dependencyDetection.js',

--- a/spec/dependencyResolutionBehaviors.js
+++ b/spec/dependencyResolutionBehaviors.js
@@ -64,4 +64,30 @@ describe('Dependency Resolution', function() {
 
     });
 
+    it('Should prioritise subscriptions deeper in the graph', function() {
+
+        /* Arrange */
+        var a = ko.observable('a'),
+            b = ko.computed(function() {
+                return a() + 'b';
+            }),
+            spy = jasmine.createSpy('callback'),
+            subscription;
+
+        b.subscribe(function(b) {
+            if (b === 'aab') {
+                subscription.dispose();
+            }
+        });
+
+        subscription = a.subscribe(spy);
+
+        /* Act */
+        a('aa');
+
+        /* Assert */
+        expect(spy.calls.length).toEqual(0);
+
+    });
+
 });

--- a/spec/dependencyResolutionBehaviors.js
+++ b/spec/dependencyResolutionBehaviors.js
@@ -1,0 +1,67 @@
+describe('Dependency Resolution', function() {
+
+    it('Should not evaluate dependencies at the end of a simple graph multiple times', function() {
+
+        /* Arrange */
+        var a = ko.observable('a'),
+            b = ko.pureComputed(function() {
+                return a() + 'b';
+            }),
+            c = ko.pureComputed(function() {
+                return a() + b() + 'c';
+            }),
+            spy = jasmine.createSpy('callback');
+
+        c.subscribe(spy);
+
+        /* Act */
+        a('aaa');
+
+        /* Assert */
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.argsForCall[0][0]).toEqual('aaaaaabc');
+
+    });
+
+    it('Should not evaluate dependencies at the end of a complex graph multiple times', function() {
+
+        /* Arrange */
+        var a = ko.observable('a'),
+            b = ko.pureComputed(function() {
+                return a() + 'b';
+            }),
+            c = ko.pureComputed(function() {
+                return a() + 'c';
+            }),
+            d = ko.pureComputed(function() {
+                return b() + c() + 'd';
+            }),
+            e = ko.pureComputed(function() {
+                return a() + 'e';
+            }),
+            f = ko.pureComputed(function() {
+                return a() + 'f';
+            }),
+            g = ko.pureComputed(function() {
+                return e() + f() + 'g';
+            }),
+            h = ko.pureComputed(function() {
+                return c() + g() + d() + 'h';
+            }),
+            i = ko.pureComputed(function() {
+                return a() + h() + b() + f();
+            }),
+            spy = jasmine.createSpy('callback');
+
+        i.subscribe(spy);
+
+        /* Act */
+        a('aa');
+
+        /* Assert */
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.argsForCall[0][0]).toEqual('aaaacaaeaafgaabaacdhaabaaf');
+
+    });
+
+});

--- a/spec/dependencyResolutionBehaviors.js
+++ b/spec/dependencyResolutionBehaviors.js
@@ -64,7 +64,48 @@ describe('Dependency Resolution', function() {
 
     });
 
-    it('Should prioritise subscriptions deeper in the graph', function() {
+    it('Should handle the complex graph when using computeds too', function() {
+
+        /* Arrange */
+        var a = ko.observable('a'),
+            b = ko.computed(function() {
+                return a() + 'b';
+            }),
+            c = ko.computed(function() {
+                return a() + 'c';
+            }),
+            d = ko.computed(function() {
+                return b() + c() + 'd';
+            }),
+            e = ko.computed(function() {
+                return a() + 'e';
+            }),
+            f = ko.computed(function() {
+                return a() + 'f';
+            }),
+            g = ko.computed(function() {
+                return e() + f() + 'g';
+            }),
+            h = ko.computed(function() {
+                return c() + g() + d() + 'h';
+            }),
+            i = ko.computed(function() {
+                return a() + h() + b() + f();
+            }),
+            spy = jasmine.createSpy('callback');
+
+        i.subscribe(spy);
+
+        /* Act */
+        a('aa');
+
+        /* Assert */
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.argsForCall[0][0]).toEqual('aaaacaaeaafgaabaacdhaabaaf');
+
+    });
+
+    it('Should prioritise older subscriptions over newer ones', function() {
 
         /* Arrange */
         var a = ko.observable('a'),

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -355,6 +355,7 @@ describe('Pure Computed', function() {
         // when awakened after being accessed, such that it's not re-evaluated.
 
         it('when awakening, without re-evaluation', function() {
+
             var timesEvaluated = 0,
                 computed = ko.pureComputed(function () { ++timesEvaluated; return dataPureComputed() + data(); });
 

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -348,7 +348,7 @@ describe('Pure Computed', function() {
         it('base behavior: order is observable, pure computed', function() {
             // This one accesses the base observable first, which results in an update before 'dataPureComputed' has updated
             var computed = ko.pureComputed(function () { return data() + dataPureComputed(); });
-            subscribeAndUpdate(computed, 'B', ['BA', 'BB']);
+            subscribeAndUpdate(computed, 'B', ['BB']);
         });
 
         // This test sets up a pure computed using the first order and checks that the order stays correct
@@ -364,7 +364,7 @@ describe('Pure Computed', function() {
 
             // If the subscriptions happen in the wrong order, we'll get two notifications: 'AB', 'BB'
             subscribeAndUpdate(computed, 'B', ['BB']);
-            expect(timesEvaluated).toEqual(3);
+            expect(timesEvaluated).toEqual(2);
         });
     });
 

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -25,6 +25,7 @@
         <script type="text/javascript" src="observableBehaviors.js"></script>
         <script type="text/javascript" src="observableArrayBehaviors.js"></script>
         <script type="text/javascript" src="observableArrayChangeTrackingBehaviors.js"></script>
+        <script type="text/javascript" src="dependencyResolutionBehaviors.js"></script>
         <script type="text/javascript" src="dependentObservableBehaviors.js"></script>
         <script type="text/javascript" src="dependentObservableDomBehaviors.js"></script>
         <script type="text/javascript" src="pureComputedBehaviors.js"></script>

--- a/spec/runner.node.js
+++ b/spec/runner.node.js
@@ -31,6 +31,7 @@ if (process.argv.length > 2 && process.argv[2] == '--source') {
 // reference behaviors that should work out of browser
 require('./arrayEditDetectionBehaviors');
 require('./asyncBehaviors');
+require('./dependencyResolutionBehaviors');
 require('./dependentObservableBehaviors');
 require('./pureComputedBehaviors');
 require('./expressionRewritingBehaviors');

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -1,4 +1,5 @@
 ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget, options) {
+
     var _latestValue,
         _needsEvaluation = true,
         _isBeingEvaluated = false,
@@ -6,7 +7,8 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         _isDisposed = false,
         readFunction = evaluatorFunctionOrOptions,
         pure = false,
-        isSleeping = false;
+        isSleeping = false,
+        _latestGlobalVersionNumber = null;
 
     if (readFunction && typeof readFunction == "object") {
         // Single-parameter syntax - everything is on this "options" param
@@ -149,7 +151,10 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
                 }
 
                 _latestValue = newValue;
+
                 if (DEBUG) dependentObservable._latestValue = _latestValue;
+
+                _latestGlobalVersionNumber = globalVersionNumber;
 
                 if (isSleeping) {
                     dependentObservable.updateVersion();
@@ -179,6 +184,11 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
             }
             return this; // Permits chained assignments
         } else {
+
+            if (_latestGlobalVersionNumber !== globalVersionNumber) {
+                processQueue();
+            }
+
             // Reading the value
             ko.dependencyDetection.registerDependency(dependentObservable);
             if (_needsEvaluation || (isSleeping && haveDependenciesChanged())) {

--- a/src/subscribables/notifyQueue.js
+++ b/src/subscribables/notifyQueue.js
@@ -1,0 +1,12 @@
+var globalVersionNumber = 0;
+var notifyQueue = [];
+
+function processQueue() {
+
+    var currentNotify;
+
+    while (currentNotify = notifyQueue.shift()) {
+        currentNotify();
+    }
+
+}

--- a/src/subscribables/notifyQueue.js
+++ b/src/subscribables/notifyQueue.js
@@ -10,3 +10,7 @@ function processQueue() {
     }
 
 }
+
+function sortQueue() {
+    notifyQueue.sort(function(a, b) { return a.priority - b.priority; });
+}

--- a/src/subscribables/notifyQueue.js
+++ b/src/subscribables/notifyQueue.js
@@ -1,16 +1,55 @@
 var globalVersionNumber = 0;
-var notifyQueue = [];
+var computedQueue = [];
+var otherQueue = [];
+var queueIsProcessing = false;
+
+function addToQueue(queue, notify) {
+
+    var existing = ko.utils.arrayFirst(queue, function(item) {
+            return item.id === notify.id;
+        }),
+        existingIndex;
+
+    if (existing) {
+        existingIndex = ko.utils.arrayIndexOf(queue, existing);
+        queue.splice(existingIndex, 1, notify);
+    } else {
+        queue.unshift(notify);
+    }
+
+}
+
+function processComputedQueue() {
+
+    var currentNotify;
+
+    while (currentNotify = computedQueue.shift()) {
+        currentNotify.callback();
+    }
+
+}
 
 function processQueue() {
 
     var currentNotify;
 
-    while (currentNotify = notifyQueue.shift()) {
-        currentNotify();
+    if (queueIsProcessing) {
+        return;
+    }
+
+    queueIsProcessing = true;
+
+    try {
+        while (currentNotify = computedQueue.shift() || otherQueue.shift()) {
+            currentNotify.callback();
+        }
+    } finally {
+        queueIsProcessing = false;
     }
 
 }
 
 function sortQueue() {
-    notifyQueue.sort(function(a, b) { return a.priority - b.priority; });
+    computedQueue.sort(function(a, b) { return a.id - b.id; });
+    otherQueue.sort(function(a, b) { return a.id - b.id; });
 }

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -10,6 +10,7 @@ ko.observable = function (initialValue) {
                 observable.valueWillMutate();
                 _latestValue = arguments[0];
                 if (DEBUG) observable._latestValue = _latestValue;
+                globalVersionNumber++;
                 observable.valueHasMutated();
             }
             return this; // Permits chained assignments

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -10,7 +10,7 @@ ko.observable = function (initialValue) {
                 observable.valueWillMutate();
                 _latestValue = arguments[0];
                 if (DEBUG) observable._latestValue = _latestValue;
-                globalVersionNumber++;
+
                 observable.valueHasMutated();
             }
             return this; // Permits chained assignments
@@ -26,7 +26,10 @@ ko.observable = function (initialValue) {
 
     if (DEBUG) observable._latestValue = _latestValue;
     observable.peek = function() { return _latestValue };
-    observable.valueHasMutated = function () { observable["notifySubscribers"](_latestValue); }
+    observable.valueHasMutated = function () {
+        globalVersionNumber++;
+        observable["notifySubscribers"](_latestValue);
+    }
     observable.valueWillMutate = function () { observable["notifySubscribers"](_latestValue, "beforeChange"); }
 
     ko.exportProperty(observable, 'peek', observable.peek);

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -48,10 +48,11 @@ var ko_subscribable_fn = {
         }
         if (this.hasSubscriptionsForEvent(event)) {
 
-            for (var a = this._subscriptions[event].slice(0), i = 0, subscription; subscription = a[i]; ++i) {
+            // Add the callbacks for the most recent notify to the front of the queue
+            for (var a = this._subscriptions[event].slice(0), i = a.length; i > 0; i--) {
                 // In case a subscription was disposed during the arrayForEach cycle, check
                 // for isDisposed on each subscription before invoking its callback
-                notifyQueue.push(function(subscription) {
+                notifyQueue.unshift(function(subscription) {
 
                     if (!subscription.isDisposed) {
 
@@ -66,7 +67,7 @@ var ko_subscribable_fn = {
                         }
                     }
 
-                }.bind(null, subscription));
+                }.bind(null, a[i - 1]));
 
             }
 

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -1,4 +1,7 @@
+var nextSubscriptionPriority = 0;
+
 ko.subscription = function (target, callback, disposeCallback) {
+    this._priority = nextSubscriptionPriority++;
     this._target = target;
     this.callback = callback;
     this.disposeCallback = disposeCallback;
@@ -49,7 +52,7 @@ var ko_subscribable_fn = {
         if (this.hasSubscriptionsForEvent(event)) {
 
             // Add the callbacks for the most recent notify to the front of the queue
-            for (var a = this._subscriptions[event].slice(0), i = a.length; i > 0; i--) {
+            for (var a = this._subscriptions[event].slice(0), i = 0, subscription; subscription = a[i]; ++i) {
                 // In case a subscription was disposed during the arrayForEach cycle, check
                 // for isDisposed on each subscription before invoking its callback
                 notifyQueue.unshift(function(subscription) {
@@ -67,10 +70,13 @@ var ko_subscribable_fn = {
                         }
                     }
 
-                }.bind(null, a[i - 1]));
+                }.bind(null, subscription));
+
+                notifyQueue[0].priority = subscription._priority;
 
             }
 
+            sortQueue();
             processQueue();
 
         }


### PR DESCRIPTION
This PR solves two relatively high impact issues (for me at least):

 - Subscribers being notified many times following a single change to an observable.
 - Subscribers being notified with intermediate states which exist while the changes to computeds are propagating.

Currently I've found I'm abusing rateLimit: 0, adding superfluous conditionals to manage the intermediate states, and spending too much time planning dependency graphs (resulting in some very fragile code).

This solution is the result of a recent experiment of mine which can be [found here](https://github.com/dancras/reactiveComparison).

It works by queuing notifications to dependencies, and intercepting reads of computeds in order to evaluate the dependency graph breadth-first rather than depth-first.

It's fully unit tested, and it affected some existing tests because they are now performing fewer evaluations and skipping intermediate states. I had 63 failures running the browser test runner both before and after my changes; perhaps I'm missing something there?

I've also tried it out on the code [here](http://casumo.com) and everything seems to be working nicely.

Some possible future additions include:

 - Add a ko.bufferedUpdate function for updating multiple observables with only one re-evaluation of the dependency graph
 - Add a ko.sideEffects function so that code which performs side effects outside of the dependency graph can be performed last. This in combination with something like [fastdom](https://github.com/wilsonpage/fastdom) could really improve performance in the future.

Curious to hear your thoughts.
