### PR TITLE
Fixes #1772: simpleHtmlParse and components starting with thead, tbody, etc.

### DIFF
--- a/spec/parseHtmlFragment.js
+++ b/spec/parseHtmlFragment.js
@@ -1,0 +1,24 @@
+describe('Parse HTML fragment', function() {
+    [
+        { html: '<tr-component></tr-component>', parsed: ['<tr-component></tr-component>'] },
+        { html: '<thead><tr><th><thcomponent>Hello</thcomponent></th></tr></thead>', parsed: ['<thead><tr><th><thcomponent>Hello</thcomponent></th></tr></thead>'] },
+        { html: '<tbody-component>World</tbody-component>', parsed: ['<tbody-component>World</tbody-component>'] },
+        { html: '<tfoot-component>foo</tfoot-component>', parsed: ['<tfoot-component>foo</tfoot-component>'] },
+        { html: '<div></div>', parsed: ['<div></div>'] },
+        { html: '<custom></custom>', parsed: ['<custom></custom>'] },
+        { html: '<tr></tr>', parsed: ['<tr></tr>'] },
+        { html: '<tr></tr><tr></tr>', parsed: ['<tr></tr>', '<tr></tr>'] },
+        { html: '<td></td>', parsed: ['<td></td>'] },
+        { html: '<th></th>', parsed: ['<th></th>'] },
+        { html: '<tbody></tbody>', parsed: ['<tbody></tbody>'] },
+        { html: '<table><tbody></tbody></table>', parsed: ['<table><tbody></tbody></table>'] },
+        { html: '<div></div><div></div>', parsed: ['<div></div>', '<div></div>'] }
+    ].forEach(function (data) {
+        it('should parse ' + data.html + ' correctly', function () {
+            var parsed = ko.utils.parseHtmlFragment(data.html, document);
+            expect(ko.utils.arrayMap(parsed, function (element) {
+                return element.outerHTML;
+            })).toEqual(data.parsed);
+        });
+    });
+});

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -43,6 +43,7 @@
         <script type="text/javascript" src="utilsBehaviors.js"></script>
         <script type="text/javascript" src="utilsDomBehaviors.js"></script>
         <script type="text/javascript" src="onErrorBehaviors.js"></script>
+        <script type="text/javascript" src="parseHtmlFragment.js"></script>
         <script type="text/javascript" src="components/loaderRegistryBehaviors.js"></script>
         <script type="text/javascript" src="components/defaultLoaderBehaviors.js"></script>
         <script type="text/javascript" src="components/componentBindingBehaviors.js"></script>

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -1,6 +1,25 @@
 (function () {
     var leadingCommentRegex = /^(\s*)<!--(.*?)-->/;
 
+    function getWrap(tags) {
+        var m = tags.match(/^<(thead|tbody|tfoot|tr|td|th)( |>)/);
+        var tagName = m && m[1];
+
+        switch (tagName) {
+        case 'thead':
+        case 'tbody':
+        case 'tfoot':
+            return [1, "<table>", "</table>"];
+        case 'tr':
+            return [2, "<table><tbody>", "</tbody></table>"];
+        case 'td':
+        case 'th':
+            return [3, "<table><tbody><tr>", "</tr></tbody></table>"];
+        default:
+            return [0, "", ""];
+        }
+    }
+
     function simpleHtmlParse(html, documentContext) {
         documentContext || (documentContext = document);
         var windowContext = documentContext['parentWindow'] || documentContext['defaultView'] || window;
@@ -15,12 +34,7 @@
 
         // Trim whitespace, otherwise indexOf won't work as expected
         var tags = ko.utils.stringTrim(html).toLowerCase(), div = documentContext.createElement("div");
-
-        // Finds the first match from the left column, and returns the corresponding "wrap" data from the right column
-        var wrap = tags.match(/^<(thead|tbody|tfoot)/)              && [1, "<table>", "</table>"] ||
-                   !tags.indexOf("<tr")                             && [2, "<table><tbody>", "</tbody></table>"] ||
-                   (!tags.indexOf("<td") || !tags.indexOf("<th"))   && [3, "<table><tbody><tr>", "</tr></tbody></table>"] ||
-                   /* anything else */                                 [0, "", ""];
+        var wrap = getWrap(tags);
 
         // Go to html and back, then peel off extra wrappers
         // Note that we always prefix with some dummy text, because otherwise, IE<9 will strip out leading comment nodes in descendants. Total madness.

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -2,7 +2,7 @@
     var leadingCommentRegex = /^(\s*)<!--(.*?)-->/;
 
     function getWrap(tags) {
-        var m = tags.match(/^<(thead|tbody|tfoot|tr|td|th)( |>)/);
+        var m = tags.match(/^<(thead|tbody|tfoot|tr|td|th)(?: |>)/);
         var tagName = m && m[1];
 
         switch (tagName) {


### PR DESCRIPTION
simpleHtmlParse() fails to parse components having names beginning with thead, tbody, tfoot, tr, th and td