### PR TITLE
Adding the preferJQueryEvents option as a way to avoid using jquery eventing in knockout.

### DIFF
--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -344,14 +344,14 @@ describe('Function.bind', function() {
 });
 
 describe('registerEventHandler', function() {
-    it ('should not use jQuery eventing with noJQueryEvents options', function() {
+    it ('should not use jQuery eventing with useJQueryEventing option set to false', function() {
         var jQueryLoaded = (typeof jQuery !== 'undefined');
         var element = document.createElement('DIV');
         var eventFired = false;
         var jQueryUsed = false;
 
         // Set the option to true.
-        ko.options.noJQueryEvents = true;
+        ko.options.useJQueryEventing = false;
 
         // If jQuery is present, verify jQuery is not used in event binding.
         if (jQueryLoaded) {
@@ -365,7 +365,7 @@ describe('registerEventHandler', function() {
         ko.utils.triggerEvent(element, 'click');
 
         // Reset the option.
-        ko.options.noJQueryEvents = false;
+        ko.options.useJQueryEventing = true;
 
         expect(!jQueryLoaded || (eventFired && !jQueryUsed)).toBe(true);
     });

--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -343,3 +343,31 @@ describe('Function.bind', function() {
     });
 });
 
+describe('registerEventHandler', function() {
+    it ('should not use jQuery eventing with noJQueryEvents options', function() {
+        var jQueryLoaded = (typeof jQuery !== 'undefined');
+        var element = document.createElement('DIV');
+        var eventFired = false;
+        var jQueryUsed = false;
+
+        // Set the option to true.
+        ko.options.noJQueryEvents = true;
+
+        // If jQuery is present, verify jQuery is not used in event binding.
+        if (jQueryLoaded) {
+            ko.utils.registerEventHandler(element, 'click', function(eventArgs) {
+                eventFired = true;
+                jQueryUsed = !!eventArgs.originalEvent;
+            });
+        }
+
+        // Trigger the event.
+        ko.utils.triggerEvent(element, 'click');
+
+        // Reset the option.
+        ko.options.noJQueryEvents = false;
+
+        expect(!jQueryLoaded || (eventFired && !jQueryUsed)).toBe(true);
+    });
+});
+

--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -344,14 +344,14 @@ describe('Function.bind', function() {
 });
 
 describe('registerEventHandler', function() {
-    it ('should not use jQuery eventing with useJQueryEventing option set to false', function() {
+    it ('should not use jQuery eventing with preferJQueryEvents option set to false', function() {
         var jQueryLoaded = (typeof jQuery !== 'undefined');
         var element = document.createElement('DIV');
         var eventFired = false;
         var jQueryUsed = false;
 
         // Set the option to true.
-        ko.options.useJQueryEventing = false;
+        ko.options.preferJQueryEvents = false;
 
         // If jQuery is present, verify jQuery is not used in event binding.
         if (jQueryLoaded) {
@@ -365,7 +365,7 @@ describe('registerEventHandler', function() {
         ko.utils.triggerEvent(element, 'click');
 
         // Reset the option.
-        ko.options.useJQueryEventing = true;
+        ko.options.preferJQueryEvents = true;
 
         expect(!jQueryLoaded || (eventFired && !jQueryUsed)).toBe(true);
     });

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,7 @@
 // For any options that may affect various areas of Knockout and aren't directly associated with data binding.
 ko.options = {
-    'deferUpdates': false
+    'deferUpdates': false,
+    'noJQueryEvents': false
 };
 
 //ko.exportSymbol('options', ko.options);   // 'options' isn't minified

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 // For any options that may affect various areas of Knockout and aren't directly associated with data binding.
 ko.options = {
     'deferUpdates': false,
-    'useJQueryEventing': true
+    'preferJQueryEvents': true
 };
 
 //ko.exportSymbol('options', ko.options);   // 'options' isn't minified

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 // For any options that may affect various areas of Knockout and aren't directly associated with data binding.
 ko.options = {
     'deferUpdates': false,
-    'noJQueryEvents': false
+    'useJQueryEventing': true
 };
 
 //ko.exportSymbol('options', ko.options);   // 'options' isn't minified

--- a/src/utils.js
+++ b/src/utils.js
@@ -361,7 +361,7 @@ ko.utils = (function () {
             var wrappedHandler = ko.utils.catchFunctionErrors(handler);
 
             var mustUseAttachEvent = ieVersion && eventsThatMustBeRegisteredUsingAttachEvent[eventType];
-            if (!mustUseAttachEvent && jQueryInstance) {
+            if (!ko.options['noJQueryEvents'] && !mustUseAttachEvent && jQueryInstance) {
                 jQueryInstance(element)['bind'](eventType, wrappedHandler);
             } else if (!mustUseAttachEvent && typeof element.addEventListener == "function")
                 element.addEventListener(eventType, wrappedHandler, false);

--- a/src/utils.js
+++ b/src/utils.js
@@ -389,7 +389,7 @@ ko.utils = (function () {
             // In both cases, we'll use the click method instead.
             var useClickWorkaround = isClickOnCheckableElement(element, eventType);
 
-            if (jQueryInstance && !useClickWorkaround) {
+            if (!ko.options['noJQueryEvents'] && jQueryInstance && !useClickWorkaround) {
                 jQueryInstance(element)['trigger'](eventType);
             } else if (typeof document.createEvent == "function") {
                 if (typeof element.dispatchEvent == "function") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -361,7 +361,7 @@ ko.utils = (function () {
             var wrappedHandler = ko.utils.catchFunctionErrors(handler);
 
             var mustUseAttachEvent = ieVersion && eventsThatMustBeRegisteredUsingAttachEvent[eventType];
-            if (ko.options['useJQueryEventing'] && !mustUseAttachEvent && jQueryInstance) {
+            if (ko.options['preferJQueryEvents'] && !mustUseAttachEvent && jQueryInstance) {
                 jQueryInstance(element)['bind'](eventType, wrappedHandler);
             } else if (!mustUseAttachEvent && typeof element.addEventListener == "function")
                 element.addEventListener(eventType, wrappedHandler, false);
@@ -389,7 +389,7 @@ ko.utils = (function () {
             // In both cases, we'll use the click method instead.
             var useClickWorkaround = isClickOnCheckableElement(element, eventType);
 
-            if (ko.options['useJQueryEventing'] && jQueryInstance && !useClickWorkaround) {
+            if (ko.options['preferJQueryEvents'] && jQueryInstance && !useClickWorkaround) {
                 jQueryInstance(element)['trigger'](eventType);
             } else if (typeof document.createEvent == "function") {
                 if (typeof element.dispatchEvent == "function") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -361,7 +361,7 @@ ko.utils = (function () {
             var wrappedHandler = ko.utils.catchFunctionErrors(handler);
 
             var mustUseAttachEvent = ieVersion && eventsThatMustBeRegisteredUsingAttachEvent[eventType];
-            if (!ko.options['noJQueryEvents'] && !mustUseAttachEvent && jQueryInstance) {
+            if (ko.options['useJQueryEventing'] && !mustUseAttachEvent && jQueryInstance) {
                 jQueryInstance(element)['bind'](eventType, wrappedHandler);
             } else if (!mustUseAttachEvent && typeof element.addEventListener == "function")
                 element.addEventListener(eventType, wrappedHandler, false);
@@ -389,7 +389,7 @@ ko.utils = (function () {
             // In both cases, we'll use the click method instead.
             var useClickWorkaround = isClickOnCheckableElement(element, eventType);
 
-            if (!ko.options['noJQueryEvents'] && jQueryInstance && !useClickWorkaround) {
+            if (ko.options['useJQueryEventing'] && jQueryInstance && !useClickWorkaround) {
                 jQueryInstance(element)['trigger'](eventType);
             } else if (typeof document.createEvent == "function") {
                 if (typeof element.dispatchEvent == "function") {


### PR DESCRIPTION
Usage:
```html
<head>
    <script src="knockout.js"></script>
    <script type="text/javascript">
        ko.options.preferJQueryEvents = false;
    </script>
   <script src="jquery.js"></script>
</head>
```
// Now all events fired from knockout should not have jquery in the callstack. It is assumed the option is set before applyBindings is called.

