### PR TITLE
Use file URI scheme

### DIFF
--- a/spec/runner.phantom.js
+++ b/spec/runner.phantom.js
@@ -31,6 +31,7 @@
 //THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 var system = require('system');
+var fs = require('fs');
 
 /**
  * Wait until the test condition is true or a timeout occurs. Useful for waiting
@@ -76,9 +77,8 @@ console.log("Running Knockout tests in Phantom.js");
 page.onConsoleMessage = function(msg) {
     console.log(msg);
 };
-
 // Run the specs against the latest minified build
-page.open(system.args[1] || 'spec/runner.html?src=build/output/knockout-latest.js', function(status){
+page.open('file:///' + fs.absolute('./spec/runner.html?src=build/output/knockout-latest.js'), function(status){
     if (status !== "success") {
         console.log("Unable to access network");
         phantom.exit();


### PR DESCRIPTION
PhantomJS 2.0 does not work with a relative path. The recommendation is to use the `file:///` URI scheme for local resources. This change is backwards compatible with PhantomJS 1.9.
