### PR TITLE
#1591 Test for checked with writeable computed

### DIFF
--- a/spec/defaultBindings/checkedBehaviors.js
+++ b/spec/defaultBindings/checkedBehaviors.js
@@ -198,6 +198,21 @@ describe('Binding: Checked', function() {
         expect(testNode.childNodes[0].checked).toEqual(true);
     });
 
+    it('Should be able to write to a writeable computed observable backed with an array', function () {
+    	var array = ko.observableArray([]);
+    	var myComputed = ko.computed({
+    		read: function () {return array();},
+    		write: function (value) { array(array().push(value));}
+    	});
+    	var model = { array: array, myComputed: myComputed};
+    	testNode.innerHTML = "<input value='2' type='checkbox' data-bind='checked: myComputed' />";
+    	ko.applyBindings(model, testNode);
+
+    	// Checking the checkbox triggers a write to the computed observable
+    	ko.utils.triggerEvent(testNode.childNodes[0], "click");
+    	expect(model.array()).toEqual([2]);
+    });
+
     describe("With \'checkedValue\'", function() {
         it('When a \'checkedValue\' is specified, should use that as the checkbox value in the array', function() {
             var model = { myArray: ko.observableArray([1,3]) };


### PR DESCRIPTION
This is a failing test for checked binding backed to a writeable computed observable that is backed by an array. Currently writing to this will throw an error because the code assumes the writeable computed is an array and attempts to perform array operations on it.

I'm not sure the correct approach for fixing this.  To me it seems like you could update ```ko.utils.addOrRemoveItem``` to deal with the case where it's a writeable computed or have ```updateModel``` in the checked binding do something different if it's a writeable computed.  I'm happy to take a look at fixing this if someone can suggest the best approach.