### PR TITLE
Handle empty, non-blank string in default css binding

### DIFF
--- a/spec/defaultBindings/cssBehaviors.js
+++ b/spec/defaultBindings/cssBehaviors.js
@@ -49,6 +49,8 @@ describe('Binding: CSS classes', function() {
         expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 another_Rule my-Rule");
         observable1(undefined);
         expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
+        observable1(" ");
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass1");
     });
 
     it('Should work with any arbitrary class names', function() {

--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -8,7 +8,7 @@ ko.bindingHandlers['css'] = {
                 ko.utils.toggleDomNodeCssClass(element, className, shouldHaveClass);
             });
         } else {
-            value = String(value || ''); // Make sure we don't try to store or set a non-string value
+            value = String(value || '').trim(); // Make sure we don't try to store or set a non-string value
             ko.utils.toggleDomNodeCssClass(element, element[classesWrittenByBindingKey], false);
             element[classesWrittenByBindingKey] = value;
             ko.utils.toggleDomNodeCssClass(element, value, true);

--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -8,7 +8,7 @@ ko.bindingHandlers['css'] = {
                 ko.utils.toggleDomNodeCssClass(element, className, shouldHaveClass);
             });
         } else {
-            value = String(ko.utils.stringTrim(value) || ''); // Make sure we don't try to store or set a non-string value
+            value = ko.utils.stringTrim(String(value || '')); // Make sure we don't try to store or set a non-string value
             ko.utils.toggleDomNodeCssClass(element, element[classesWrittenByBindingKey], false);
             element[classesWrittenByBindingKey] = value;
             ko.utils.toggleDomNodeCssClass(element, value, true);

--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -8,7 +8,7 @@ ko.bindingHandlers['css'] = {
                 ko.utils.toggleDomNodeCssClass(element, className, shouldHaveClass);
             });
         } else {
-            value = String(value || '').trim(); // Make sure we don't try to store or set a non-string value
+            value = String(ko.utils.stringTrim(value) || ''); // Make sure we don't try to store or set a non-string value
             ko.utils.toggleDomNodeCssClass(element, element[classesWrittenByBindingKey], false);
             element[classesWrittenByBindingKey] = value;
             ko.utils.toggleDomNodeCssClass(element, value, true);


### PR DESCRIPTION
In the default CSS binding, trim the `value` before attempting to toggle the
DOM node CSS classes.  An empty, non-blank string is evaulated as truthy.  The
`toggleDomNodeCssClass` uses an `if (classNames) ...` condition to check for
the existence of a class name before trying to match and loop through them.
Since the non-empty string was being passed, it was attempting to use the
`arrayForEach` method on a `null` value.

Fixes #1431