### PR TITLE
compareArrays 'dontLimitMoves' option is no longer respected

### DIFF
--- a/spec/arrayEditDetectionBehaviors.js
+++ b/spec/arrayEditDetectionBehaviors.js
@@ -88,4 +88,18 @@ describe('Compare Arrays', function() {
             { status: "deleted", value: "E", index: 4, moved: 2 }
         ]);
     });
+
+    it('Should honor "dontLimitMoves" option', function() {
+        // In order to test this, we must have a scenario in which a move is not recognized as such without the option.
+        // This scenario doesn't represent the definition of the spec itself and may need to be modified if the move
+        // detection algorithm in Knockout is changed.
+        var oldArray = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T"];
+        var newArray = [1, 2, 3, 4, "T", 6, 7, 8, 9, 10];
+
+        var compareResult = ko.utils.compareArrays(oldArray, newArray);
+        expect(compareResult[compareResult.length-1]).toEqual({ status: 'deleted', value: 'T', index: 19 });
+
+        compareResult = ko.utils.compareArrays(oldArray, newArray, { dontLimitMoves: true });
+        expect(compareResult[compareResult.length-1]).toEqual({ status: 'deleted', value: 'T', index: 19, moved: 4 });
+    });
 });

--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -266,7 +266,7 @@ describe('Observable Array change tracking', function() {
     });
 
     // Per: https://github.com/knockout/knockout/issues/1503
-    it('Should cleanup a single arrayChange dependency', function() {
+    it('Should clean up a single arrayChange dependency', function() {
         var source = ko.observableArray();
         var arrayChange = source.subscribe(function() {}, null, "arrayChange");
         expect(source.getSubscriptionsCount("arrayChange")).toBe(1);
@@ -357,6 +357,31 @@ describe('Observable Array change tracking', function() {
         // See that descendent nodes are also added
         expect(list()).toEqual([ toAdd, toAdd.nodes[0], toAdd.nodes[1], toAdd.nodes[2], toAdd.nodes[0].nodes[0] ]);
     });
+
+    it('Should honor "dontLimitMoves" option', function() {
+        // In order to test this, we must have a scenario in which a move is not recognized as such without the option.
+        // This scenario doesn't represent the definition of the spec itself and may need to be modified if the move
+        // detection algorithm in Knockout is changed. (See also the similar test in arrayEditDetectionBehaviors.js)
+        var array1 = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T"];
+        var array2 = [1, 2, 3, 4, "T", 6, 7, 8, 9, 10];
+
+        var myArray = ko.observableArray(array1),
+            changelist;
+
+        myArray.subscribe(function(changes) {
+            changelist = changes;
+        }, null, 'arrayChange');
+
+        // The default behavior is to limit moves
+        myArray(array2);
+        expect(changelist[changelist.length-1]).toEqual({ status: 'deleted', value: 'T', index: 19 });
+
+        // Change the behavior by extending again with the dontLimitMoves option
+        myArray.extend({ trackArrayChanges: { dontLimitMoves: true } });
+        myArray(array1);
+        expect(changelist[changelist.length-1]).toEqual({ status: 'added', value: 'T', index: 19, moved: 4 });
+    });
+
 
     function testKnownOperation(array, operationName, options) {
         var changeList,

--- a/src/binding/editDetection/compareArrays.js
+++ b/src/binding/editDetection/compareArrays.js
@@ -91,7 +91,7 @@ ko.utils.compareArrays = (function () {
 
         // Set a limit on the number of consecutive non-matching comparisons; having it a multiple of
         // smlIndexMax keeps the time complexity of this algorithm linear.
-        ko.utils.findMovesInArrayComparison(notInSml, notInBig, smlIndexMax * 10);
+        ko.utils.findMovesInArrayComparison(notInBig, notInSml, !options['dontLimitMoves'] && smlIndexMax * 10);
 
         return editScript.reverse();
     }

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -1,5 +1,12 @@
 var arrayChangeEventName = 'arrayChange';
-ko.extenders['trackArrayChanges'] = function(target) {
+ko.extenders['trackArrayChanges'] = function(target, options) {
+    // Use the provided options--each call to trackArrayChanges overwrites the previously set options
+    target.compareArrayOptions = {};
+    if (options && typeof options == "object") {
+        ko.utils.extend(target.compareArrayOptions, options);
+    }
+    target.compareArrayOptions['sparse'] = true;
+
     // Only modify the target observable once
     if (target.cacheDiffForKnownOperation) {
         return;
@@ -76,7 +83,7 @@ ko.extenders['trackArrayChanges'] = function(target) {
         // plugin, which without this check would not be compatible with arrayChange notifications. Normally,
         // notifications are issued immediately so we wouldn't be queueing up more than one.
         if (!cachedDiff || pendingNotifications > 1) {
-            cachedDiff = ko.utils.compareArrays(previousContents, currentContents, { 'sparse': true });
+            cachedDiff = ko.utils.compareArrays(previousContents, currentContents, target.compareArrayOptions);
         }
 
         return cachedDiff;


### PR DESCRIPTION
In commit [`0e0559`](https://github.com/knockout/knockout/commit/0e0559bdfb67e707a45afe7707fc8a228aab56de), support for the obscure `dontLimitMoves` option was removed from `compareArrays.js`. I'm unsure whether this was deliberate.

There is still some hangover code that interprets a boolean `options` value as meaning `{ 'dontLimitMoves': yourBooleanOptionsValue }`, but no other code actually uses the `dontLimitMoves` setting anywhere. I guess this flag was somehow missed from test coverage.

I'm not saying we should put it back, unless anyone has a practical need for it (in which case, I'm surprised this wasn't reported already).