### PR TITLE
observableArray sort function confusion

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -277,6 +277,14 @@ describe('Observable Array', function() {
         expect(timesEvaluated).toEqual(1);
     });
 
+    it('Should return the observableArray reference from "sort" and "reverse"', function() {
+        expect(testObservableArray.reverse()).toBe(testObservableArray);
+        expect(testObservableArray.sort()).toBe(testObservableArray);
+
+        // Verify that reverse and sort notified their changes
+        expect(notifiedValues).toEqual([ [3, 2, 1], [1, 2, 3] ]);
+    });
+
     it('Should inherit any properties defined on ko.subscribable.fn, ko.observable.fn, or ko.observableArray.fn', function() {
         this.after(function() {
             delete ko.subscribable.fn.subscribableProp; // Will be able to reach this

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -101,7 +101,8 @@ ko.utils.arrayForEach(["pop", "push", "reverse", "shift", "sort", "splice", "uns
         this.cacheDiffForKnownOperation(underlyingArray, methodName, arguments);
         var methodCallResult = underlyingArray[methodName].apply(underlyingArray, arguments);
         this.valueHasMutated();
-        return methodCallResult;
+        // The native sort and reverse methods return a reference to the array, but it makes more sense to return the observable array instead.
+        return methodCallResult === underlyingArray ? this : methodCallResult;
     };
 });
 


### PR DESCRIPTION
`observableArray.sort()` is just a wrapper for `Array.sort` and thus sorts the underlying array, returning the array. I did a quick search and found many examples of using `Array.sort`, and not one of them used the return value. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), for example.

But when sorting an observable array, I often see the return value of the `sort` function being used. For example, here's a [StackOverflow answer](http://stackoverflow.com/a/14513294/1287183) that suggests using `sort` in a binding like `foreach: items.sort(...)`. The biggest problem with this approach is that `observableArray.sort` doesn't establish a dependency on the array, so the binding won't get updated.

Of course, some people might use `foreach: items().sort(...)` instead. This provides the dependency on the array, but has a different problem--that other subscribers of the array don't get notified that the array was sorted.

To clarify the intended use of `observableArray.sort()`, I suggest that we change it to not return the array. To support displaying a sorted version of an observable array, we could add `observableArray.sortCopy()` (or `sorted()`, etc.) that will sort and return a copy the array.
