### PR TITLE
Deferred updates, part 3: dependency tree scheduling

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -636,6 +636,17 @@ describe('Deferred', function() {
             expect(notifySpy.argsForCall).toEqual([ ['A'] ]);
         });
 
+        it('Should throw if you attempt to turn off deferred', function() {
+            // As of commit 6d5d786, the 'deferred' option cannot be deactivated (once activated for
+            // a given observable).
+            var observable = ko.observable();
+
+            observable.extend({deferred: true});
+            expect(function() {
+                observable.extend({deferred: false});    
+            }).toThrow('The \'deferred\' extender only accepts the value \'true\', because it is not supported to turn deferral off once enabled.');
+        });
+
         it('Should notify subscribers about only latest value', function() {
             var observable = ko.observable().extend({notify:'always', deferred:true});  // include notify:'always' to ensure notifications weren't suppressed by some other means
             var notifySpy = jasmine.createSpy('notifySpy');

--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -643,7 +643,7 @@ describe('Deferred', function() {
 
             observable.extend({deferred: true});
             expect(function() {
-                observable.extend({deferred: false});    
+                observable.extend({deferred: false});
             }).toThrow('The \'deferred\' extender only accepts the value \'true\', because it is not supported to turn deferral off once enabled.');
         });
 

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -125,4 +125,13 @@ describe("Deferred bindings", function() {
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: childprop">moving child</span><span data-bind="text: childprop">first child</span><span data-bind="text: childprop">second child</span>');
         expect(testNode.childNodes[0].childNodes[targetIndex]).not.toBe(itemNode);    // node was create anew so it's not the same
     });
+
+    it('Should throw an exception for value binding on multiple select boxes', function() {
+        testNode.innerHTML = "<select data-bind=\"options: ['abc','def','ghi'], value: x\"></select><select data-bind=\"options: ['xyz','uvw'], value: x\"></select>";
+        var observable = ko.observable();
+        ko.applyBindings({ x: observable }, testNode);
+        expect(function() {
+            jasmine.Clock.tick(1);
+        }).toThrowContaining('Too much recursion');
+    });
 });

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -126,12 +126,13 @@ describe("Deferred bindings", function() {
         expect(testNode.childNodes[0].childNodes[targetIndex]).not.toBe(itemNode);    // node was create anew so it's not the same
     });
 
-    it('Should throw an exception for value binding on multiple select boxes', function() {
+    it('Should not throw an exception for value binding on multiple select boxes', function() {
         testNode.innerHTML = "<select data-bind=\"options: ['abc','def','ghi'], value: x\"></select><select data-bind=\"options: ['xyz','uvw'], value: x\"></select>";
         var observable = ko.observable();
-        ko.applyBindings({ x: observable }, testNode);
         expect(function() {
+            ko.applyBindings({ x: observable }, testNode);
             jasmine.Clock.tick(1);
-        }).toThrowContaining('Too much recursion');
+        }).not.toThrow();
+        expect(observable()).not.toBeUndefined();       // The spec doesn't specify which of the two possible values is actually set
     });
 });

--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -510,6 +510,15 @@ describe('Binding: Value', function() {
             expect(dropdown.selectedIndex).toEqual(2);
         });
 
+        it('Should not throw an exception for value binding on multiple select boxes', function() {
+            testNode.innerHTML = "<select data-bind=\"options: ['abc','def','ghi'], value: x\"></select><select data-bind=\"options: ['xyz','uvw'], value: x\"></select>";
+            var observable = ko.observable();
+            expect(function() {
+                ko.applyBindings({ x: observable }, testNode);
+            }).not.toThrow();
+            expect(observable()).not.toBeUndefined();       // The spec doesn't specify which of the two possible values is actually set
+        });
+
         describe('Using valueAllowUnset option', function () {
             it('Should display the caption when the model value changes to undefined, null, or \"\" when using \'options\' binding', function() {
                 var observable = ko.observable('B');

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -60,6 +60,5 @@ ko.computedContext = ko.dependencyDetection = (function () {
 ko.exportSymbol('computedContext', ko.computedContext);
 ko.exportSymbol('computedContext.getDependenciesCount', ko.computedContext.getDependenciesCount);
 ko.exportSymbol('computedContext.isInitial', ko.computedContext.isInitial);
-ko.exportSymbol('computedContext.isSleeping', ko.computedContext.isSleeping);
 
 ko.exportSymbol('ignoreDependencies', ko.ignoreDependencies = ko.dependencyDetection.ignore);

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -58,7 +58,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
     }
 
     function subscribeToDependency(target) {
-        if (target._deferUpdates) {
+        if (target._deferUpdates && !disposeWhenNodeIsRemoved) {
             var dirtySub = target.subscribe(markDirty, null, 'dirty'),
                 changeSub = target.subscribe(respondToChange);
             return {

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -39,22 +39,15 @@ ko.extenders = {
         });
     },
 
-    'deferred': function(target, value) {
-        // Calling with a true value sets up and enables deferred updates.
-        // A false value turns off deferred updates if it was previously enabled, but won't unnecessarily set a limit function.
-        target._deferUpdates = value;
-        if (value) {
+    'deferred': function(target, options) {
+        if (!target._deferUpdates) {
+            target._deferUpdates = true;
             target.limit(function (callback) {
                 var handle;
                 return function () {
                     ko.tasks.cancel(handle);
-                    if (target._deferUpdates) {
-                        handle = ko.tasks.schedule(callback);
-                        target['notifySubscribers'](undefined, 'dirty');
-                    } else {
-                        handle = 0;
-                        callback();
-                    }
+                    handle = ko.tasks.schedule(callback);
+                    target['notifySubscribers'](undefined, 'dirty');
                 };
             });
         }

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -47,6 +47,7 @@ ko.extenders = {
                     ko.tasks.cancel(handle);
                     if (target._deferUpdates) {
                         handle = ko.tasks.schedule(callback);
+                        target['notifySubscribers'](undefined, 'dirty');
                     } else {
                         handle = 0;
                         callback();

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -40,6 +40,10 @@ ko.extenders = {
     },
 
     'deferred': function(target, options) {
+        if (options !== true) {
+            throw new Error('The \'deferred\' extender only accepts the value \'true\', because it is not supported to turn deferral off once enabled.')
+        }
+
         if (!target._deferUpdates) {
             target._deferUpdates = true;
             target.limit(function (callback) {

--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -30,6 +30,9 @@ ko.extenders = {
             method = options['method'];
         }
 
+        // rateLimit supersedes deferred updates
+        target._deferUpdates = false;
+
         limitFunction = method == 'notifyWhenChangesStop' ?  debounce : throttle;
         target.limit(function(callback) {
             return limitFunction(callback, timeout);

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -87,7 +87,7 @@ var ko_subscribable_fn = {
 
     limit: function(limitFunction) {
         var self = this, selfIsObservable = ko.isObservable(self),
-            isPending, previousValue, pendingValue, beforeChange = 'beforeChange';
+            skipBeforeChange, previousValue, pendingValue, beforeChange = 'beforeChange';
 
         if (!self._origNotifySubscribers) {
             self._origNotifySubscribers = self["notifySubscribers"];
@@ -95,24 +95,26 @@ var ko_subscribable_fn = {
         }
 
         var finish = limitFunction(function() {
+            self._rateLimitIsPending = false;
+
             // If an observable provided a reference to itself, access it to get the latest value.
             // This allows computed observables to delay calculating their value until needed.
             if (selfIsObservable && pendingValue === self) {
                 pendingValue = self();
             }
-            isPending = false;
+            skipBeforeChange = false;
             if (self.isDifferent(previousValue, pendingValue)) {
                 self._origNotifySubscribers(previousValue = pendingValue);
             }
         });
 
         self._rateLimitedChange = function(value) {
-            isPending = true;
+            self._rateLimitIsPending = skipBeforeChange = true;
             pendingValue = value;
             finish();
         };
         self._rateLimitedBeforeChange = function(value) {
-            if (!isPending) {
+            if (!skipBeforeChange) {
                 previousValue = value;
                 self._origNotifySubscribers(value, beforeChange);
             }
@@ -129,7 +131,8 @@ var ko_subscribable_fn = {
         } else {
             var total = 0;
             ko.utils.objectForEach(this._subscriptions, function(eventName, subscriptions) {
-                total += subscriptions.length;
+                if (eventName != 'dirty')
+                    total += subscriptions.length;
             });
             return total;
         }

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -20,11 +20,11 @@ ko.subscribable = function () {
 var defaultEvent = "change";
 
 // Moved out of "limit" to avoid the extra closure
-function rateLimitedNotifySubscribers(value, event) {
+function limitNotifySubscribers(value, event) {
     if (!event || event === defaultEvent) {
-        this._rateLimitedChange(value);
+        this._limitChange(value);
     } else if (event === 'beforeChange') {
-        this._rateLimitedBeforeChange(value);
+        this._limitBeforeChange(value);
     } else {
         this._origNotifySubscribers(value, event);
     }
@@ -87,32 +87,34 @@ var ko_subscribable_fn = {
 
     limit: function(limitFunction) {
         var self = this, selfIsObservable = ko.isObservable(self),
-            isPending, previousValue, pendingValue, beforeChange = 'beforeChange';
+            ignoreBeforeChange, previousValue, pendingValue, beforeChange = 'beforeChange';
 
         if (!self._origNotifySubscribers) {
             self._origNotifySubscribers = self["notifySubscribers"];
-            self["notifySubscribers"] = rateLimitedNotifySubscribers;
+            self["notifySubscribers"] = limitNotifySubscribers;
         }
 
         var finish = limitFunction(function() {
+            self._notificationIsPending = false;
+
             // If an observable provided a reference to itself, access it to get the latest value.
             // This allows computed observables to delay calculating their value until needed.
             if (selfIsObservable && pendingValue === self) {
                 pendingValue = self();
             }
-            isPending = false;
+            ignoreBeforeChange = false;
             if (self.isDifferent(previousValue, pendingValue)) {
                 self._origNotifySubscribers(previousValue = pendingValue);
             }
         });
 
-        self._rateLimitedChange = function(value) {
-            isPending = true;
+        self._limitChange = function(value) {
+            self._notificationIsPending = ignoreBeforeChange = true;
             pendingValue = value;
             finish();
         };
-        self._rateLimitedBeforeChange = function(value) {
-            if (!isPending) {
+        self._limitBeforeChange = function(value) {
+            if (!ignoreBeforeChange) {
                 previousValue = value;
                 self._origNotifySubscribers(value, beforeChange);
             }
@@ -129,7 +131,7 @@ var ko_subscribable_fn = {
         } else {
             var total = 0;
             ko.utils.objectForEach(this._subscriptions, function(eventName, subscriptions) {
-                if (eventName != 'dirty')
+                if (eventName !== 'dirty')
                     total += subscriptions.length;
             });
             return total;


### PR DESCRIPTION
This is the third, and final, part of supporting deferred updates in Knockout (#1728).

With multiple deferred computed observables in a dependency tree, use "dirty" events to schedule the complete set of updates in the correct order and mark each computed observable as "dirty" so it can be evaluated if needed with the latest value.