### PR TITLE
textInput error in IE9

### DIFF
--- a/src/binding/defaultBindings/textInput.js
+++ b/src/binding/defaultBindings/textInput.js
@@ -72,6 +72,10 @@ ko.bindingHandlers['textInput'] = {
             }
         };
 
+        // IE9 will mess up the DOM if you handle events synchronously which results in DOM changes (such as other bindings);
+        // so we'll make sure all updates are asynchronous
+        var ieUpdateModel = ko.utils.ieVersion == 9 ? deferUpdateModel : updateModel;
+
         var updateView = function () {
             var modelValue = ko.utils.unwrapObservable(valueAccessor());
 
@@ -113,7 +117,7 @@ ko.bindingHandlers['textInput'] = {
                 // when using autocomplete, we'll use 'propertychange' for it also.
                 onEvent('propertychange', function(event) {
                     if (event.propertyName === 'value') {
-                        updateModel(event);
+                        ieUpdateModel(event);
                     }
                 });
 
@@ -130,7 +134,7 @@ ko.bindingHandlers['textInput'] = {
                     // out of the field, and cutting or deleting text using the context menu. 'selectionchange'
                     // can detect all of those except dragging text out of the field, for which we use 'dragend'.
                     // These are also needed in IE8 because of the bug described above.
-                    registerForSelectionChangeEvent(element, updateModel);  // 'selectionchange' covers cut, paste, drop, delete, etc.
+                    registerForSelectionChangeEvent(element, ieUpdateModel);  // 'selectionchange' covers cut, paste, drop, delete, etc.
                     onEvent('dragend', deferUpdateModel);
                 }
             } else {


### PR DESCRIPTION
In IE9, notifySubscriber eats(destroys) HTML when undoing/CTRL+Z on a textarea with maxlength extender.

Reproduction steps:
0. Using IE9 (not IE11 with compatibility set to IE9)
1. Navigate to http://jsfiddle.net/h4r91bcg/3/ 
2. Paste in a text inside the textarea that is too long. Ex. "In snooker," (without the double quotes)
3. Hit CTRL+Z or right click undo
4. Repeat the paste/undo combo

Expected Result:
1. Text area clears the contents with no side effects to the surrounding DOM

Actual Result:
1. Undo eats up DOM due to IE9 bug.

Workaround (c/o Michael Best!)
1. Define pre databind tags to the text itself and the text.view
2. Further extend the ko.pureComputed function by adding in ".extend({ rateLimit: 0, notify: 'always' });" to the end
3. See http://jsfiddle.net/h4r91bcg/10/