### PR TITLE
fail rendering template foreach in an external window in ie

### DIFF
--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -178,7 +178,7 @@
             });
 
             var templateName = resolveTemplateName(template, arrayValue, arrayItemContext);
-            return executeTemplate(null, "ignoreTargetNode", templateName, arrayItemContext, options);
+            return executeTemplate(targetNode, "ignoreTargetNode", templateName, arrayItemContext, options);
         }
 
         // This will be called whenever setDomNodeChildrenFromArrayMapping has added nodes to targetNode


### PR DESCRIPTION
IE currently fails when using foreach in a template binding in a new window.

I'm doing window.open then passing a reference to the original windows ko.  
`newWin = window.open(...`  
`newWin.ko = window.ko;`  
`ko.applyBindings(koData, newWin.document.getElementById('main'));`  
`<!-- ko template: {name: templateName, foreach: templateData} --><!-- /ko -->`

I've got it to work by passing the target node to executetemplate in rendertemplateforeach.

`return executeTemplate(targetNode, "ignoreTargetNode", templateName, arrayItemContext, options);`

This is related to:
Multi-window situation crashed in IE10 due to not being able to call the appendChild method with argument being an element from a different window. [#1321](https://github.com/knockout/knockout/pull/1321)
