### PR TITLE
Knockout shouldn't define a "custom" element if a component name matches a standard element name

### DIFF
--- a/spec/components/customElementBehaviors.js
+++ b/spec/components/customElementBehaviors.js
@@ -26,6 +26,38 @@ describe('Components: Custom elements', function() {
         expect(testNode).toContainHtml('<div>hello <test-component>custom element <span data-bind="text: 123">123</span></test-component></div>');
     });
 
+    it('Inserts components into custom elements with matching non-dashed names', function() {
+        if (jasmine.ieVersion || window.HTMLUnknownElement) {   // Phantomjs 1.x doesn't include HTMLUnknownElement and will fail this test
+            this.after(function () { ko.components.unregister('somefaroutname'); });
+            ko.components.register('somefaroutname', {
+                template: 'custom element <span data-bind="text: 123"></span>'
+            });
+            var initialMarkup = '<div>hello <somefaroutname></somefaroutname></div>';
+            testNode.innerHTML = initialMarkup;
+
+            // Since components are loaded asynchronously, it doesn't show up synchronously
+            ko.applyBindings(null, testNode);
+            expect(testNode).toContainHtml(initialMarkup);
+
+            // ... but when the component is loaded, it does show up
+            jasmine.Clock.tick(1);
+            expect(testNode).toContainHtml('<div>hello <somefaroutname>custom element <span data-bind="text: 123">123</span></somefaroutname></div>');
+        }
+    });
+
+    it('Does not insert components into standard elements with matching names', function() {
+        this.after(function () { ko.components.unregister('em'); });
+        ko.components.register('em', {
+            template: 'custom element <span data-bind="text: 123"></span>'
+        });
+        var initialMarkup = '<div>hello <em></em></div>';
+        testNode.innerHTML = initialMarkup;
+
+        ko.applyBindings(null, testNode);
+        jasmine.Clock.tick(1);
+        expect(testNode).toContainHtml(initialMarkup);
+    });
+
     it('Is possible to override getComponentNameForNode to determine which component goes into which element', function() {
         ko.components.register('test-component', { template: 'custom element'});
         this.restoreAfter(ko.components, 'getComponentNameForNode');

--- a/src/components/customElements.js
+++ b/src/components/customElements.js
@@ -3,7 +3,12 @@
     // you can for example map specific tagNames to components that are not preregistered.
     ko.components['getComponentNameForNode'] = function(node) {
         var tagNameLower = ko.utils.tagNameLower(node);
-        return ko.components.isRegistered(tagNameLower) && tagNameLower;
+        if (ko.components.isRegistered(tagNameLower)) {
+            // Try to determine that this node can be considered a *custom* element; see https://github.com/knockout/knockout/issues/1603
+            if (tagNameLower.indexOf('-') != -1 || ('' + node) == "[object HTMLUnknownElement]" || node.tagName === tagNameLower) {
+                return tagNameLower;
+            }
+        }
     };
 
     ko.components.addBindingsForCustomElement = function(allBindings, node, bindingContext, valueAccessors) {

--- a/src/components/customElements.js
+++ b/src/components/customElements.js
@@ -5,7 +5,7 @@
         var tagNameLower = ko.utils.tagNameLower(node);
         if (ko.components.isRegistered(tagNameLower)) {
             // Try to determine that this node can be considered a *custom* element; see https://github.com/knockout/knockout/issues/1603
-            if (tagNameLower.indexOf('-') != -1 || ('' + node) == "[object HTMLUnknownElement]" || node.tagName === tagNameLower) {
+            if (tagNameLower.indexOf('-') != -1 || ('' + node) == "[object HTMLUnknownElement]" || (ko.utils.ieVersion <= 8 && node.tagName === tagNameLower)) {
                 return tagNameLower;
             }
         }


### PR DESCRIPTION
For example, the following will basically break your app:

    ko.components.register('div', { });

demo: http://jsfiddle.net/mbest/hxqdbho9/