### PR TITLE
Align mobile Safari focus behavior to other browsers

### DIFF
--- a/src/binding/defaultBindings/hasfocus.js
+++ b/src/binding/defaultBindings/hasfocus.js
@@ -35,6 +35,15 @@ ko.bindingHandlers['hasfocus'] = {
         ko.utils.registerEventHandler(element, "focusin", handleElementFocusIn); // For IE
         ko.utils.registerEventHandler(element, "blur",  handleElementFocusOut);
         ko.utils.registerEventHandler(element, "focusout",  handleElementFocusOut); // For IE
+
+        if (/i(Pad|Phone|Pod)/.test(window.navigator.userAgent)) {
+            // Mobile Safari readonly inputs don't trigger the focus event:
+            ko.utils.registerEventHandler(element, "touchstart", function() {
+                if (element.readOnly) {
+                    element.focus();
+                }
+            });
+        }
     },
     'update': function(element, valueAccessor) {
         var value = !!ko.utils.unwrapObservable(valueAccessor()); //force boolean to compare with last value


### PR DESCRIPTION
Mobile Safari browsers do not trigger the focus event reliably in
case of input elements that are set to 'readonly'. This change
will ensure the 'hasfocus' binding works as expected.