### PR TITLE
beforeRenderAll and afterRenderAll events

### DIFF
--- a/src/binding/defaultBindings/foreach.js
+++ b/src/binding/defaultBindings/foreach.js
@@ -21,6 +21,8 @@ ko.bindingHandlers['foreach'] = {
                 'afterAdd': unwrappedValue['afterAdd'],
                 'beforeRemove': unwrappedValue['beforeRemove'],
                 'afterRender': unwrappedValue['afterRender'],
+                'beforeRenderAll': unwrappedValue['beforeRenderAll'],
+                'afterRenderAll':unwrappedValue['afterRenderAll'],
                 'beforeMove': unwrappedValue['beforeMove'],
                 'afterMove': unwrappedValue['afterMove'],
                 'templateEngine': ko.nativeTemplateEngine.instance


### PR DESCRIPTION
Allow user to define functions to execute before and after all items have rendered respectively in binding declaration