### PR TITLE
Make observables 2-3 times faster to instantiate, and reduce their memory use by over half

### DIFF
--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -13,8 +13,7 @@ ko.subscription.prototype.dispose = function () {
 
 ko.subscribable = function () {
     ko.utils.setPrototypeOfOrExtend(this, ko.subscribable['fn']);
-    this._subscriptions = {};
-    this._versionNumber = 1;
+    ko_subscribable_fn.init(this);
 }
 
 var defaultEvent = "change";
@@ -31,6 +30,11 @@ function limitNotifySubscribers(value, event) {
 }
 
 var ko_subscribable_fn = {
+    init: function(instance) {
+        instance._subscriptions = {};
+        instance._versionNumber = 1;
+    },
+
     subscribe: function (callback, callbackTarget, event) {
         var self = this;
 


### PR DESCRIPTION
I've been doing some perf investigations for the very large KO-based web app I work on. Although KO is only a small slice of our overall CPU use, there are some worthwile opportunities for improvement.

In particular I've found that the instantiation of `ko.observable` and `ko.computed` take up a large percentage of the time our app spends inside KO code. Also, since we create such a huge number of them, the memory use and resulting GC time is quite noticeable too.

## Net result

This pull request makes `ko.observable` about 2-3 times faster to instantiate. On a test where I instantiate 1 million of them, the time drops from roughly 2.7s to roughly 1.2s on Chrome, and from roughly 4.5s to 1.5s on Firefox.

This pull request also reduces the memory use by over half. According to the Chrome profiler, the memory overhead of each observable reduces from about 500 bytes to about 225 bytes with this change.

## Approach

The most expensive thing seems to be constructing function instances. A `ko.observable` inherently needs at least one unique one (since an observable *is* a function instance), but we can avoid the need to construct additional ones (for `peek`, `valueHasUpdated`, etc.) by moving those to `ko.observable.fn`. Making this work means that `_latestValue` can no longer be a closure variable, but instead needs to be a property on the observable instance.

A further minor speedup comes from streamlining how we inherit from `ko.subscribable`. For browsers that support `__proto__` modification, we don't have to add `ko.subscribable.fn` to the prototype chain on each instantiation, because it comes for free when we inherit from `ko.observable.fn`.

I tried various approaches to speed up creation of the one remaining function instance in each `ko.observable`, but every alternative I tried was slower. For example, I tried having a single shared function and then cloning it using `.bind()`, but that was much slower. I also tried using ES2015 inheritance (i.e., `extends Function`), and that's unbelievably slow.

## Drawbacks

None that I know of. Compatibility should be identical (unless you do something mad like identity-comparing `someObservable.peek` function instances). We can even retain the encapsulation of `_latestValue` in non-debug mode by using an ES2015 `Symbol` where available.

The only behavior change I can think of is that now, in debug mode, you can write to the private `_latestValue` property and it will silently change the value of the observable, whereas before if you did that it would not change the value of the observable since it was a separate copy of the value. I don't think this is a problem because that's obviously not a supported scenario (it's a private property) and it is not the case in release builds (at least, on browsers that support `Symbol`).

## Next steps

I'm going to look into `ko.computed` and see if similar techniques reduce its setup, evaluation, and memory costs.