### PR TITLE
Faster computeds

### DIFF
--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -32,7 +32,7 @@ ko.computedContext = ko.dependencyDetection = (function () {
             if (currentFrame) {
                 if (!ko.isSubscribable(subscribable))
                     throw new Error("Only subscribable things can act as dependencies");
-                currentFrame.callback(subscribable, subscribable._id || (subscribable._id = getId()));
+                currentFrame.callback.call(currentFrame.callbackTarget, subscribable, subscribable._id || (subscribable._id = getId()));
             }
         },
 

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -114,7 +114,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
 };
 
 // Utility function that disposes a given dependencyTracking entry
-var computedDisposeDependencyCallback = function(id, entryToDispose) {
+function computedDisposeDependencyCallback(id, entryToDispose) {
     if (entryToDispose !== null && entryToDispose.dispose) {
         entryToDispose.dispose();
     }
@@ -122,7 +122,7 @@ var computedDisposeDependencyCallback = function(id, entryToDispose) {
 
 // This function gets called each time a dependency is detected while evaluating a computed.
 // It's factored out as a shared function to avoid creating unnecessary function instances during evaluation.
-var computedBeginDependencyDetectionCallback = function(subscribable, id) {
+function computedBeginDependencyDetectionCallback(subscribable, id) {
     var computedObservable = this.computedObservable,
         state = computedObservable[computedState];
     if (!state.isDisposed) {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -1,4 +1,4 @@
-var computedState = ko.utils.getSymbolOrString('_state');
+var computedState = ko.utils.createSymbolOrString('_state');
 
 ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget, options) {
     if (typeof evaluatorFunctionOrOptions === "object") {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -80,11 +80,6 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
         ko.utils.extend(dependentObservable, deferEvaluationOverrides);
     }
 
-    ko.exportProperty(dependentObservable, 'peek', dependentObservable.peek);
-    ko.exportProperty(dependentObservable, 'dispose', dependentObservable.dispose);
-    ko.exportProperty(dependentObservable, 'isActive', dependentObservable.isActive);
-    ko.exportProperty(dependentObservable, 'getDependenciesCount', dependentObservable.getDependenciesCount);
-
     // Add a "disposeWhen" callback that, on each evaluation, disposes if the node was removed without using ko.removeNode.
     if (state.disposeWhenNodeIsRemoved) {
         // Since this computed is associated with a DOM node, and we don't want to dispose the computed
@@ -418,6 +413,11 @@ ko.dependentObservable['fn'][protoProp] = ko.dependentObservable;
 ko.exportSymbol('dependentObservable', ko.dependentObservable);
 ko.exportSymbol('computed', ko.dependentObservable); // Make "ko.computed" an alias for "ko.dependentObservable"
 ko.exportSymbol('isComputed', ko.isComputed);
+
+ko.exportProperty(ko.dependentObservable['fn'], 'peek', ko.dependentObservable['fn'].peek);
+ko.exportProperty(ko.dependentObservable['fn'], 'dispose', ko.dependentObservable['fn'].dispose);
+ko.exportProperty(ko.dependentObservable['fn'], 'isActive', ko.dependentObservable['fn'].isActive);
+ko.exportProperty(ko.dependentObservable['fn'], 'getDependenciesCount', ko.dependentObservable['fn'].getDependenciesCount);
 
 ko.pureComputed = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget) {
     if (typeof evaluatorFunctionOrOptions === 'function') {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -105,7 +105,7 @@ ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, eva
     // Attach a DOM node disposal callback so that the computed will be proactively disposed as soon as the node is
     // removed using ko.removeNode. But skip if isActive is false (there will never be any dependencies to dispose).
     if (state.disposeWhenNodeIsRemoved && computedObservable.isActive()) {
-        ko.utils.domNodeDisposal.addDisposeCallback(state.disposeWhenNodeIsRemoved, state.domNodeDisposalCallback = function() {
+        ko.utils.domNodeDisposal.addDisposeCallback(state.disposeWhenNodeIsRemoved, state.domNodeDisposalCallback = function () {
             computedObservable.dispose();
         });
     }
@@ -118,7 +118,7 @@ function computedDisposeDependencyCallback(id, entryToDispose) {
     if (entryToDispose !== null && entryToDispose.dispose) {
         entryToDispose.dispose();
     }
-};
+}
 
 // This function gets called each time a dependency is detected while evaluating a computed.
 // It's factored out as a shared function to avoid creating unnecessary function instances during evaluation.
@@ -136,14 +136,14 @@ function computedBeginDependencyDetectionCallback(subscribable, id) {
             computedObservable.addDependencyTracking(id, subscribable, state.isSleeping ? { _target: subscribable } : computedObservable.subscribeToDependency(subscribable));
         }
     }
-};
+}
 
 var computedFn = {
     "equalityComparer": valuesArePrimitiveAndEqual,
     getDependenciesCount: function () {
         return this[computedState].dependenciesCount;
     },
-    addDependencyTracking: function(id, target, trackingObj) {
+    addDependencyTracking: function (id, target, trackingObj) {
         if (this[computedState].pure && target === this) {
             throw Error("A 'pure' computed must not be called recursively");
         }
@@ -152,7 +152,7 @@ var computedFn = {
         trackingObj._order = this[computedState].dependenciesCount++;
         trackingObj._version = target.getVersion();
     },
-    haveDependenciesChanged: function() {
+    haveDependenciesChanged: function () {
         var id, dependency, dependencyTracking = this[computedState].dependencyTracking;
         for (id in dependencyTracking) {
             if (dependencyTracking.hasOwnProperty(id)) {
@@ -163,22 +163,22 @@ var computedFn = {
             }
         }
     },
-    markDirty: function() {
+    markDirty: function () {
         // Process "dirty" events if we can handle delayed notifications
         if (this._evalDelayed && !this[computedState].isBeingEvaluated) {
             this._evalDelayed();
         }
     },
-    isActive: function() {
+    isActive: function () {
         return this[computedState].isStale || this[computedState].dependenciesCount > 0;
     },
-    respondToChange: function() {
+    respondToChange: function () {
         // Ignore "change" events if we've already scheduled a delayed notification
         if (!this._notificationIsPending) {
             this.evaluatePossiblyAsync();
         }
     },
-    subscribeToDependency: function(target) {
+    subscribeToDependency: function (target) {
         if (target._deferUpdates && !this[computedState].disposeWhenNodeIsRemoved) {
             var dirtySub = target.subscribe(this.markDirty, this, 'dirty'),
                 changeSub = target.subscribe(this.respondToChange, this);
@@ -193,7 +193,7 @@ var computedFn = {
             return target.subscribe(this.evaluatePossiblyAsync, this);
         }
     },
-    evaluatePossiblyAsync: function() {
+    evaluatePossiblyAsync: function () {
         var computedObservable = this,
             throttleEvaluationTimeout = computedObservable['throttleEvaluation'];
         if (throttleEvaluationTimeout && throttleEvaluationTimeout >= 0) {
@@ -207,10 +207,9 @@ var computedFn = {
             computedObservable.evaluateImmediate(true /*notifyChange*/);
         }
     },
-    evaluateImmediate: function(notifyChange) {
+    evaluateImmediate: function (notifyChange) {
         var computedObservable = this,
             state = computedObservable[computedState],
-            readFunction = state.readFunction,
             disposeWhen = state.disposeWhen;
 
         if (state.isBeingEvaluated) {
@@ -244,10 +243,11 @@ var computedFn = {
             state.isBeingEvaluated = false;
         }
 
-        if (!state.dependenciesCount)
+        if (!state.dependenciesCount) {
             computedObservable.dispose();
+        }
     },
-    evaluateImmediate_CallReadWithDependencyDetection: function(notifyChange) {
+    evaluateImmediate_CallReadWithDependencyDetection: function (notifyChange) {
         // This function is really just part of the evaluateImmediate logic. You would never call it from anywhere else.
         // Factoring it out into a separate function means it can be independent of the try/catch block in evaluateImmediate,
         // which contributes to saving about 40% off the CPU overhead of computed evaluation (on V8 at least).
@@ -294,7 +294,7 @@ var computedFn = {
             computedObservable["notifySubscribers"](state.latestValue, "awake");
         }
     },
-    evaluateImmediate_CallReadThenEndDependencyDetection: function(state, dependencyDetectionContext) {
+    evaluateImmediate_CallReadThenEndDependencyDetection: function (state, dependencyDetectionContext) {
         // This function is really part of the evaluateImmediate_CallReadWithDependencyDetection logic.
         // You'd never call it from anywhere else. Factoring it out means that evaluateImmediate_CallReadWithDependencyDetection
         // can be independent of try/finally blocks, which contributes to saving about 40% off the CPU
@@ -314,7 +314,7 @@ var computedFn = {
             state.isStale = false;
         }
     },
-    peek: function() {
+    peek: function () {
         // Peek won't re-evaluate, except while the computed is sleeping or to get the initial value when "deferEvaluation" is set.
         var state = this[computedState];
         if ((state.isStale && !state.dependenciesCount) || (state.isSleeping && this.haveDependenciesChanged())) {
@@ -322,10 +322,10 @@ var computedFn = {
         }
         return state.latestValue;
     },
-    limit: function(limitFunction) {
+    limit: function (limitFunction) {
         // Override the limit function with one that delays evaluation as well
         ko.subscribable['fn'].limit.call(this, limitFunction);
-        this._evalDelayed = function() {
+        this._evalDelayed = function () {
             this._limitBeforeChange(this[computedState].latestValue);
 
             this[computedState].isStale = true; // Mark as dirty
@@ -335,7 +335,7 @@ var computedFn = {
             this._limitChange(this);
         }
     },
-    dispose: function() {
+    dispose: function () {
         var state = this[computedState];
         if (!state.isSleeping && state.dependencyTracking) {
             ko.utils.objectForEach(state.dependencyTracking, function (id, dependency) {
@@ -374,7 +374,7 @@ var pureComputedOverrides = {
                     dependeciesOrder[dependency._order] = id;
                 });
                 // Next, subscribe to each one
-                ko.utils.arrayForEach(dependeciesOrder, function(id, order) {
+                ko.utils.arrayForEach(dependeciesOrder, function (id, order) {
                     var dependency = state.dependencyTracking[id],
                         subscription = computedObservable.subscribeToDependency(dependency._target);
                     subscription._order = order;
@@ -436,7 +436,7 @@ var protoProp = ko.observable.protoProperty; // == "__ko_proto__"
 ko.computed[protoProp] = ko.observable;
 computedFn[protoProp] = ko.computed;
 
-ko.isComputed = function(instance) {
+ko.isComputed = function (instance) {
     return ko.hasPrototype(instance, ko.computed);
 };
 

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -1,4 +1,4 @@
-var observableLatestValue = ko.utils.getSymbolOrString('_latestValue');
+var observableLatestValue = ko.utils.createSymbolOrString('_latestValue');
 
 ko.observable = function (initialValue) {
     function observable() {

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -1,5 +1,4 @@
-var shouldUseSymbol = !DEBUG && typeof Symbol === 'function';
-var latestValueSymbol = shouldUseSymbol ? Symbol('_latestValue') : '_latestValue';
+var observableLatestValue = ko.utils.getSymbolOrString('_latestValue');
 
 ko.observable = function (initialValue) {
     function observable() {
@@ -7,9 +6,9 @@ ko.observable = function (initialValue) {
             // Write
 
             // Ignore writes if the value hasn't changed
-            if (observable.isDifferent(observable[latestValueSymbol], arguments[0])) {
+            if (observable.isDifferent(observable[observableLatestValue], arguments[0])) {
                 observable.valueWillMutate();
-                observable[latestValueSymbol] = arguments[0];
+                observable[observableLatestValue] = arguments[0];
                 observable.valueHasMutated();
             }
             return this; // Permits chained assignments
@@ -17,11 +16,11 @@ ko.observable = function (initialValue) {
         else {
             // Read
             ko.dependencyDetection.registerDependency(observable); // The caller only needs to be notified of changes if they did a "read" operation
-            return observable[latestValueSymbol];
+            return observable[observableLatestValue];
         }
     }
 
-    observable[latestValueSymbol] = initialValue;
+    observable[observableLatestValue] = initialValue;
 
     // Inherit from 'subscribable'
     if (!ko.utils.canSetPrototype) {
@@ -43,9 +42,9 @@ ko.observable = function (initialValue) {
 // Define prototype for observables
 var observableFn = {
     'equalityComparer': valuesArePrimitiveAndEqual,
-    peek: function() { return this[latestValueSymbol]; },
-    valueHasMutated: function () { this['notifySubscribers'](this[latestValueSymbol]); },
-    valueWillMutate: function () { this['notifySubscribers'](this[latestValueSymbol], 'beforeChange'); }
+    peek: function() { return this[observableLatestValue]; },
+    valueHasMutated: function () { this['notifySubscribers'](this[observableLatestValue]); },
+    valueWillMutate: function () { this['notifySubscribers'](this[observableLatestValue], 'beforeChange'); }
 };
 
 // Note that for browsers that don't support proto assignment, the

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -24,13 +24,11 @@ ko.observable = function (initialValue) {
     observable[latestValueSymbol] = initialValue;
 
     // Inherit from 'subscribable'
-    if (ko.utils.canSetPrototype) {
-        // 'subscribable' will come for free when we inherit from 'observable', so just set up the internal state needed for subscribables
-        ko.subscribable['fn'].init(observable);
-    } else {
+    if (!ko.utils.canSetPrototype) {
         // 'subscribable' won't be on the prototype chain unless we put it there directly
-        ko.subscribable.call(observable);
+        ko.utils.extend(observable, ko.subscribable['fn']);
     }
+    ko.subscribable['fn'].init(observable);
 
     // Inherit from 'observable'
     ko.utils.setPrototypeOfOrExtend(observable, observableFn);

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -12,7 +12,7 @@ ko.subscription.prototype.dispose = function () {
 };
 
 ko.subscribable = function () {
-    ko.utils.setPrototypeOfOrExtend(this, ko.subscribable['fn']);
+    ko.utils.setPrototypeOfOrExtend(this, ko_subscribable_fn);
     ko_subscribable_fn.init(this);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -490,7 +490,7 @@ ko.utils = (function () {
             return result;
         },
 
-        getSymbolOrString: function(identifier) {
+        createSymbolOrString: function(identifier) {
             return canUseSymbols ? Symbol(identifier) : identifier;
         },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,7 @@ ko.utils = (function () {
     }
 
     var canSetPrototype = ({ __proto__: [] } instanceof Array);
+    var canUseSymbols = !DEBUG && typeof Symbol === 'function';
 
     // Represent the known event types in a compact way, then at runtime transform it into a hash with event name as key (for fast lookup)
     var knownEvents = {}, knownEventTypesByEventName = {};
@@ -487,6 +488,10 @@ ko.utils = (function () {
                 result.push(arrayLikeObject[i]);
             };
             return result;
+        },
+
+        getSymbolOrString: function(identifier) {
+            return canUseSymbols ? Symbol(identifier) : identifier;
         },
 
         isIe6 : isIe6,


### PR DESCRIPTION
Similar to #1840, this pull request improves the performance of `ko.computed` initialisation. It reduces the time taken to construct computed instances by about 50%, and perhaps more importantly, reduces the memory overhead to about half of what it was before.

Like #1840, the approach is mainly to factor out all the closure-captured function instances and put them on the prototype instead.

### Review notes

This change touches (or will touch) nearly every line in `ko.dependentObservable.js`, because it involves factoring out most of the logic inside `ko.computed`. That makes it a bit hard to review - sorry about that - couldn't avoid it! To make it a bit easier to review, I've broken it down into more commits than would be normal. But let me know if you suspect I might have unintentionally changed any behavior. Specs are all still passing.

### Compatibility

Like #1840, there should be no compatibility difference, except for scenarios where code does equality comparisons on methods (e.g., `myComputed1.peek === myComputed2.peek` will always be true now). If anyone objects to this, please let us know! (I think we would do it anyway though)

### Not yet complete!

There's still quite a big, confusing mass of setup code relating to dispose handlers. I would like to clean this up further (both for perf, but mainly for readability) but am out of time for today. If anyone else wants to jump in here you'd be welcome :)
