### PR TITLE
Fix for potential memory leak

### DIFF
--- a/src/components/componentBinding.js
+++ b/src/components/componentBinding.js
@@ -11,7 +11,7 @@
                     if (typeof currentViewModelDispose === 'function') {
                         currentViewModelDispose.call(currentViewModel);
                     }
-
+                    currentViewModel = null;
                     // Any in-flight loading operation is no longer relevant, so make sure we ignore its completion
                     currentLoadingOperationId = null;
                 },


### PR DESCRIPTION
We detected that when we remove a component binding from the page (via a knockout if binding) then for some reason our viewModel still lives in the heap. The retainer (in the memory profiler) seems to be the "currentViewModel" variable... I wonder if it is required once the viewModel has been disposed? Because setting it to null like this seems to fix the problem and completely remove the viewModel from the heap. Is there another way this gets cleaned up that we're missing?