### PR TITLE
Add afterRenderAll and beforeRenderAll callbacks to foreach binding

### DIFF
--- a/src/binding/defaultBindings/foreach.js
+++ b/src/binding/defaultBindings/foreach.js
@@ -21,6 +21,8 @@ ko.bindingHandlers['foreach'] = {
                 'afterAdd': unwrappedValue['afterAdd'],
                 'beforeRemove': unwrappedValue['beforeRemove'],
                 'afterRender': unwrappedValue['afterRender'],
+                'afterRenderAll': unwrappedValue['afterRenderAll'],
+                'beforeRenderAll': unwrappedValue['beforeRenderAll'],
                 'beforeMove': unwrappedValue['beforeMove'],
                 'afterMove': unwrappedValue['afterMove'],
                 'templateEngine': ko.nativeTemplateEngine.instance

--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -118,6 +118,9 @@
         // Store a copy of the array items we just considered so we can difference it next time
         ko.utils.domData.set(domNode, lastMappingResultDomDataKey, newMappingResult);
 
+        if(options['beforeRenderAll'])
+            options['beforeRenderAll']();
+        
         // Call beforeMove first before any changes have been made to the DOM
         callCallback(options['beforeMove'], itemsForMoveCallbacks);
 
@@ -153,6 +156,9 @@
         // Finally call afterMove and afterAdd callbacks
         callCallback(options['afterMove'], itemsForMoveCallbacks);
         callCallback(options['afterAdd'], itemsForAfterAddCallbacks);
+        
+        if(options['afterRenderAll'])
+            options['afterRenderAll']();
     }
 })();
 


### PR DESCRIPTION
This pull request will allow the developer define methods to be called before any items are rendered and after alll items have rendered.