### PR TITLE
Fix parse html on old IE

### DIFF
--- a/spec/defaultBindings/foreachBehaviors.js
+++ b/spec/defaultBindings/foreachBehaviors.js
@@ -575,23 +575,29 @@ describe('Binding: Foreach', function() {
     });
 
     it('Should be able to output HTML5 elements (even on IE<9, as long as you reference either innershiv.js or jQuery1.7+Modernizr)', function() {
-        // Represents https://github.com/SteveSanderson/knockout/issues/194
-        ko.utils.setHtml(testNode, "<div data-bind='foreach:someitems'><section data-bind='text: $data'></section></div>");
-        var viewModel = {
-            someitems: [ 'Alpha', 'Beta' ]
-        };
-        ko.applyBindings(viewModel, testNode);
-        expect(testNode).toContainHtml('<div data-bind="foreach:someitems"><section data-bind="text: $data">alpha</section><section data-bind="text: $data">beta</section></div>');
+        var isSupported = jasmine.ieVersion >= 9 || window.innerShiv || window.jQuery;
+        if (isSupported) {
+            // Represents https://github.com/SteveSanderson/knockout/issues/194
+            ko.utils.setHtml(testNode, "<div data-bind='foreach:someitems'><section data-bind='text: $data'></section></div>");
+            var viewModel = {
+                someitems: [ 'Alpha', 'Beta' ]
+            };
+            ko.applyBindings(viewModel, testNode);
+            expect(testNode).toContainHtml('<div data-bind="foreach:someitems"><section data-bind="text: $data">alpha</section><section data-bind="text: $data">beta</section></div>');
+        }
     });
 
     it('Should be able to output HTML5 elements within container-less templates (same as above)', function() {
-        // Represents https://github.com/SteveSanderson/knockout/issues/194
-        ko.utils.setHtml(testNode, "xxx<!-- ko foreach:someitems --><div><section data-bind='text: $data'></section></div><!-- /ko -->");
-        var viewModel = {
-            someitems: [ 'Alpha', 'Beta' ]
-        };
-        ko.applyBindings(viewModel, testNode);
-        expect(testNode).toContainHtml('xxx<!-- ko foreach:someitems --><div><section data-bind="text: $data">alpha</section></div><div><section data-bind="text: $data">beta</section></div><!-- /ko -->');
+        var isSupported = jasmine.ieVersion >= 9 || window.innerShiv || window.jQuery;
+        if (isSupported) {
+            // Represents https://github.com/SteveSanderson/knockout/issues/194
+            ko.utils.setHtml(testNode, "xxx<!-- ko foreach:someitems --><div><section data-bind='text: $data'></section></div><!-- /ko -->");
+            var viewModel = {
+                someitems: [ 'Alpha', 'Beta' ]
+            };
+            ko.applyBindings(viewModel, testNode);
+            expect(testNode).toContainHtml('xxx<!-- ko foreach:someitems --><div><section data-bind="text: $data">alpha</section></div><div><section data-bind="text: $data">beta</section></div><!-- /ko -->');
+        }
     });
 
     it('Should provide access to observable array items through $rawData', function() {

--- a/spec/lib/innershiv.js
+++ b/spec/lib/innershiv.js
@@ -1,2 +1,39 @@
 // http://bit.ly/ishiv | WTFPL License
-window.innerShiv=function(){function h(c,e,b){return/^(?:area|br|col|embed|hr|img|input|link|meta|param)$/i.test(b)?c:e+"></"+b+">"}var c,e=document,j,g="abbr article aside audio canvas datalist details figcaption figure footer header hgroup mark meter nav output progress section summary time video".split(" ");return function(d,i){if(!c&&(c=e.createElement("div"),c.innerHTML="<nav></nav>",j=c.childNodes.length!==1)){for(var b=e.createDocumentFragment(),f=g.length;f--;)b.createElement(g[f]);b.appendChild(c)}d=d.replace(/^\s\s*/,"").replace(/\s\s*$/,"").replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,"").replace(/(<([\w:]+)[^>]*?)\/>/g,h);c.innerHTML=(b=d.match(/^<(tbody|tr|td|col|colgroup|thead|tfoot)/i))?"<table>"+d+"</table>":d;b=b?c.getElementsByTagName(b[1])[0].parentNode:c;if(i===!1)return b.childNodes;for(var f=e.createDocumentFragment(),k=b.childNodes.length;k--;)f.appendChild(b.firstChild);return f}}();
+window.innerShiv=function(){
+	function h(c,e,b){
+		return/^(?:area|br|col|embed|hr|img|input|link|meta|param)$/i.test(b)?c:e+"></"+b+">"
+	}
+
+	var c,
+		e=document,
+		j,
+		g="abbr article aside audio canvas datalist details figcaption figure footer header hgroup mark meter nav output progress section summary time video".split(" ");
+
+	var result = function(d,i){
+		if(!c&&(c=e.createElement("div"),c.innerHTML="<nav></nav>",j=c.childNodes.length!==1)) {
+			for(var b=e.createDocumentFragment(),f=g.length;f--;)
+				b.createElement(g[f]);
+			b.appendChild(c)
+		}
+		d=d.replace(/^\s\s*/,"").replace(/\s\s*$/,"").replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,"").replace(/(<([\w:]+)[^>]*?)\/>/g,h);
+		c.innerHTML=(b=d.match(/^<(tbody|tr|td|col|colgroup|thead|tfoot)/i))?"<table>"+d+"</table>":d;
+		b=b?c.getElementsByTagName(b[1])[0].parentNode:c;
+
+		if(i===!1)
+			return b.childNodes;
+		for(var f=e.createDocumentFragment(),k=b.childNodes.length;k--;)
+			f.appendChild(b.firstChild);
+		return f
+	}
+
+	// Note that innerShiv is deprecated in favour of html5shiv. KO retains support for innerShiv for back-compat.
+	//
+	// innerShiv only works with KO custom elements if you've registered *all* your custom elements before
+	// the first time innerShiv is invoked. This is because innerShiv caches the documentFragment it uses
+	// for parsing. Since KO's tests need to register different components over time, this is a modified
+	// version of innerShiv that supports a 'reset' method to clear its cache. You don't need this functionality
+	// in production code.
+	result.reset = function () { c = null; };
+
+	return result;
+}();

--- a/spec/lib/jasmine.extensions.js
+++ b/spec/lib/jasmine.extensions.js
@@ -27,13 +27,16 @@ jasmine.Matchers.prototype.toEqualOneOf = function (expectedPossibilities) {
     return false;
 };
 
-jasmine.Matchers.prototype.toContainHtml = function (expectedHtml) {
+jasmine.Matchers.prototype.toContainHtml = function (expectedHtml, postProcessCleanedHtml) {
     var cleanedHtml = this.actual.innerHTML.toLowerCase().replace(/\r\n/g, "");
     // IE < 9 strips whitespace immediately following comment nodes. Normalize by doing the same on all browsers.
     cleanedHtml = cleanedHtml.replace(/(<!--.*?-->)\s*/g, "$1");
     expectedHtml = expectedHtml.replace(/(<!--.*?-->)\s*/g, "$1");
     // Also remove __ko__ expando properties (for DOM data) - most browsers hide these anyway but IE < 9 includes them in innerHTML
     cleanedHtml = cleanedHtml.replace(/ __ko__\d+=\"(ko\d+|null)\"/g, "");
+    if (postProcessCleanedHtml) {
+        cleanedHtml = postProcessCleanedHtml(cleanedHtml);
+    }
     this.actual = cleanedHtml;      // Fix explanatory message
     return cleanedHtml === expectedHtml;
 };

--- a/spec/lib/loadDependencies.js
+++ b/spec/lib/loadDependencies.js
@@ -19,15 +19,14 @@
         },
         // Knockout polyfills
         innershiv: {
-            // Note: Nobody should use innershiv - it's deprecated in favour of html5shiv (https://github.com/aFarkas/html5shiv)
-            // Using innershiv will prevent you from using custom elements on IE6/7, since innershiv always
-            // parses HTML inside a new temporary document context, meaning that the document.createElement('my-element')
-            // trick won't work.
-            // Knockout retains backward-compatible support for innershiv just to avoid breaking any applications that
-            // use innershiv-supported HTML5 elements (section, etc.) even though it's incompatible with custom elements.
-            // KO should drop innershiv support completely as of the next major KO version.
+            // Note: innerShiv is deprecated in favour of html5shiv (https://github.com/aFarkas/html5shiv)
+            // KO retains back-compatible support for innershiv, but we will consider dropping this and
+            // supporting only html5shiv as of the next major version of KO (unless KO itself drops support
+            // for IE 6-8 in the next major version, in which case this is all irrelevant).
+            // It doesn't really matter very much, because essentially everyone who targets IE6-8 is also
+            // using jQuery, and if you are using jQuery then you don't need innerShiv.
             url: "lib/innershiv.js",
-            include: false
+            include: true
         },
         json2: {
             url: "lib/json2.js",

--- a/spec/lib/loadDependencies.js
+++ b/spec/lib/loadDependencies.js
@@ -19,8 +19,15 @@
         },
         // Knockout polyfills
         innershiv: {
+            // Note: Nobody should use innershiv - it's deprecated in favour of html5shiv (https://github.com/aFarkas/html5shiv)
+            // Using innershiv will prevent you from using custom elements on IE6/7, since innershiv always
+            // parses HTML inside a new temporary document context, meaning that the document.createElement('my-element')
+            // trick won't work.
+            // Knockout retains backward-compatible support for innershiv just to avoid breaking any applications that
+            // use innershiv-supported HTML5 elements (section, etc.) even though it's incompatible with custom elements.
+            // KO should drop innershiv support completely as of the next major KO version.
             url: "lib/innershiv.js",
-            include: true
+            include: false
         },
         json2: {
             url: "lib/json2.js",

--- a/spec/parseHtmlFragment.js
+++ b/spec/parseHtmlFragment.js
@@ -1,11 +1,19 @@
+var temporarilyRegisteredComponents = [];
+
 describe('Parse HTML fragment', function() {
     beforeEach(jasmine.prepareTestNode);
+    afterEach(function() {
+        ko.utils.arrayForEach(temporarilyRegisteredComponents, function(componentName) {
+            ko.components.unregister(componentName);
+        });
+        temporarilyRegisteredComponents = [];
+    });
 
     ko.utils.arrayForEach(
     [
         { html: '<tr-component></tr-component>', parsed: ['<tr-component></tr-component>'] },
         { html: '<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>', parsed: ['<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>'], ignoreRedundantTBody: true },
-        { html: '<tbody-component>world</tbody-component>', parsed: ['<tbody-component>world</tbody-component>'] },
+        { html: '<tbody-component>world</tbody-component>', parsed: ['<tbody-component>world</tbody-component>'], minSupportedIEVersion: 8 },
         { html: '<tfoot-component>foo</tfoot-component>', parsed: ['<tfoot-component>foo</tfoot-component>'] },
         { html: '<div></div>', parsed: ['<div></div>'] },
         { html: '<custom-component></custom-component>', parsed: ['<custom-component></custom-component>'] },
@@ -20,19 +28,48 @@ describe('Parse HTML fragment', function() {
         { html: '<option>text</option>', parsed: [ '<option>text</option>' ] }
     ], function (data) {
         it('should parse ' + data.html + ' correctly', function () {
-            // For this test to be valid on IE6-8, we need any custom elements to be preregistered
-            // This is a general requirement for using custom elements on IE6-8, for KO or any other library
+            // IE 6-8 has a lot of trouble with custom elements. We have several strategies for dealing with
+            // this, each involving different (awkward) requirements for the application.
+            // [1] If you use KO alone, then the document.createElement('my-element') hack is sufficient.
+            //     However, most people don't use KO alone if they target IE 6-8 - typically they will use
+            //     at least jQuery or innerShiv as well.
+            // [2] If you use jQuery, then your custom elements must be preregistered as *KO components*
+            //     before you make the browser parse any HTML containing them. Just document.createElement
+            //     alone is not enough, because jQuery's HTML parsing runs in a separate document context.
+            //     KO hooks into this especially for registered components.
+            // [3] If you use innerShiv, then you have the same requirement as [2] (because innerShiv uses
+            //     the same createDocumentFragment technique as jQuery), but additionally you cannot modify
+            //     the set of custom elements after innerShiv runs for the first time, because innerShiv
+            //     caches and reuses its document fragment. For this test, we deal with this by using a
+            //     modified version of innerShiv that supports a 'reset' method. In production code, people
+            //     should not use 'reset' like this - instead ensure that all custom elements are preregistered.
+            // None of this mess affects other browsers.
             if (jasmine.ieVersion <= 8) {
-                data.html.replace(/\<([^\s\>]+)/g, function(ignored, foundTagName) {
-                    document.createElement(foundTagName);
+                data.html.replace(/\<([a-z0-9\-]+)/g, function(ignored, foundTagName) {
+                    if (!ko.components.isRegistered(foundTagName)) {
+                        temporarilyRegisteredComponents.push(foundTagName);
+                        ko.components.register(foundTagName, {});
+                    }
                 });
+
+                if (window.innerShiv) {
+                    window.innerShiv.reset();
+                }
+
+                // Out of all the combinations above, there is still one edge case we can't support without
+                // dropping jQuery HTML parsing altogether. That is, if you're using jQuery, its parser fails
+                // on elements named 'tbody-*', on IE 6 and 7 (but it works on IE 8+). This is such an extreme
+                // edge case that it's preferable to leave this element name unsupported.
+                if (jasmine.ieVersion < data.minSupportedIEVersion) {
+                    return;
+                }
             }
 
             var parsedNodes = ko.utils.parseHtmlFragment(data.html, document);
 
             // Normalise the output
             if (jasmine.ieVersion <= 8 && data.ignoreRedundantTBody) {
-                if (parsedNodes[parsedNodes.length - 1].tagName === "TBODY") {
+                if (parsedNodes[parsedNodes.length - 1].tagName === 'TBODY') {
                     // IE 7 adds a tbody tag; ignore it for the purpose of the test
                     parsedNodes.pop();
                 }

--- a/spec/parseHtmlFragment.js
+++ b/spec/parseHtmlFragment.js
@@ -4,7 +4,7 @@ describe('Parse HTML fragment', function() {
     ko.utils.arrayForEach(
     [
         { html: '<tr-component></tr-component>', parsed: ['<tr-component></tr-component>'] },
-        { html: '<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>', parsed: ['<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>'] },
+        { html: '<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>', parsed: ['<thead><tr><th><thcomponent>hello</thcomponent></th></tr></thead>'], ignoreRedundantTBody: true },
         { html: '<tbody-component>world</tbody-component>', parsed: ['<tbody-component>world</tbody-component>'] },
         { html: '<tfoot-component>foo</tfoot-component>', parsed: ['<tfoot-component>foo</tfoot-component>'] },
         { html: '<div></div>', parsed: ['<div></div>'] },
@@ -16,26 +16,38 @@ describe('Parse HTML fragment', function() {
         { html: '<tbody></tbody>', parsed: ['<tbody></tbody>'] },
         { html: '<table><tbody></tbody></table>', parsed: ['<table><tbody></tbody></table>'] },
         { html: '<div></div><div></div>', parsed: ['<div></div>', '<div></div>'] },
-        { html: '<optgroup label="x"><option>text</option></optgroup>', parsed: [ '<optgroup label="?x"?><option>text</option></optgroup>' ] },
+        { html: '<optgroup label=x><option>text</option></optgroup>', parsed: ['<optgroup label=x><option>text</option></optgroup>'] },
         { html: '<option>text</option>', parsed: [ '<option>text</option>' ] }
     ], function (data) {
         it('should parse ' + data.html + ' correctly', function () {
+            // For this test to be valid on IE6-8, we need any custom elements to be preregistered
+            // This is a general requirement for using custom elements on IE6-8, for KO or any other library
+            if (jasmine.ieVersion <= 8) {
+                data.html.replace(/\<([^\s\>]+)/g, function(ignored, foundTagName) {
+                    document.createElement(foundTagName);
+                });
+            }
+
             var parsedNodes = ko.utils.parseHtmlFragment(data.html, document);
 
-            if (jasmine.ieVersion <= 8 && parsedNodes.length > 1 && data.parsed && data.parsed.length == 1) {
-                if (parsedNodes[1].tagName === "TBODY") {
+            // Normalise the output
+            if (jasmine.ieVersion <= 8 && data.ignoreRedundantTBody) {
+                if (parsedNodes[parsedNodes.length - 1].tagName === "TBODY") {
                     // IE 7 adds a tbody tag; ignore it for the purpose of the test
                     parsedNodes.pop();
                 }
-                ko.utils.arrayForEach(parsedNodes, function (node) {
-                    testNode.appendChild(node);
+            }
+
+            // Assert that we have the expected collection of elements (not just the correct .innerHTML string)
+            expect(parsedNodes.length).toEqual(data.parsed.length);
+            for (var i = 0; i < parsedNodes.length; i++) {
+                testNode.innerHTML = '';
+                testNode.appendChild(parsedNodes[i]);
+                expect(testNode).toContainHtml(data.parsed[i], function(htmlToClean) {
+                    // Old IE strips quotes from certain attributes. The easiest way of normalising this across
+                    // browsers is to forcibly strip the equivalent quotes in all browsers for the test.
+                    return htmlToClean.replace(/"x"/g, 'x');
                 });
-                expect(testNode).toContainHtml(data.parsed[0]);
-            } else {
-                var parsedStrings = ko.utils.arrayMap(parsedNodes, function (node) {
-                    return node.outerHTML && node.outerHTML.toLowerCase().replace(/\r\n/g, "");
-                });
-                expect(parsedStrings).toMatch(data.parsed);
             }
         });
     });

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -119,7 +119,7 @@
             // jQuery contains a lot of sophisticated code to parse arbitrary HTML fragments,
             // for example <tr> elements which are not normally allowed to exist on their own.
             // If you've referenced jQuery we'll use that rather than duplicating its code.
-            if (jQueryInstance) {
+            if (allowJQueryHtmlParsing && jQueryInstance) {
                 jQueryInstance(node)['html'](html);
             } else {
                 // ... otherwise, use KO's own parsing logic.


### PR DESCRIPTION
I don't think our current `parseHtmlFragment` implementation or its tests are correct. The tests claim success even though the parser output is actually wrong. This is because the assertions are only looking at `theParsedResult.outerHTML` instead of checking that the actual DOM element structure is correct. For custom elements like `<my-element></my-element>`, old IE parses it as two separate nodes - `<my-element>` and the very weird `</my-element>` element instead of one single element.

Fixing it is tricky. There are three cases:

1. **If you're just using KO alone**, then this pull request fixes the implementation and tests. We require you to be using the `document.createElement('my-element')` hack, since that is the only way that IE6-8 will not mangle the DOM. This pull request updates the test to use that hack. Also it updates the parsing code to be compatible with that hack (i.e., run the parsing in the same document context).
2. **If you're using KO and innershiv**, then it's still broken, because innershiv does the parsing inside a separate document context, so the `document.createElement` hack is of no use (it's a different context). Since innershiv itself is deprecated (in favour of html5shiv), and since it's always been broken and there's no reasonable way we can fix this anyway since it's a problem in innershiv, I propose we consider this scenario unsupported.
3. **If you're using KO and jQuery**, then it's still broken, because jQuery's HTML parsing has never supported custom elements on old IE. I am coming to think that, like @brianmhunt suggested in #1858, we should stop using jQuery for HTML parsing altogether. Thoughts on that:
 * Pro: For old browsers, it means we can support the KO+jQuery+oldIE+customelements combination. I can't think of any other way of supporting this combination.
 * Pro: Probably would have no impact on modern browsers, as KO's native parsing is likely to be totally robust - modern browsers don't have the edge cases that old IE does. If anything, our code is probably faster because it deals with fewer old-browser edge cases.
 * Pro: It means we wouldn't need 200f196c
 * Con: There is probably some unknown edge case where jQuery's HTML parser works correctly on old IE and KO's does not. Switching parsers could break some apps on old IE, though we don't know of any specific scenarios.

Overall, I think the decision on (3) comes down to whether it's more important not to break some as-yet-unknown edge-case scenario on old IE, or to enable support for custom elements on old IE. I am tending to prefer the latter (enabling custom elements by dropping the jQuery HTML parser) because old idiosyncratic apps targetting very old IE are probably not even upgrading to the latest KO, whereas newly-written apps that use the latest KO might well want to support IE8. If people report bugs in KO's HTML parser on IE6-8, we can fix them. **Anyone else got a preference on this?**

Further points:
* We should consider adding support for html5shiv as a replacement for the now-deprecated innershiv. I don't think it's urgent, since it only affects IE6-8 and our focus is not on adding features that only a vanishingly small percentage of applications are going to benefit from.
* The change in 200f196c that is meant to disable jQuery HTML parsing for elements with hyphens - I don't think this is a general solution, since it only looks at the top-level element and not any descendants. And changing it to look at all descendants would be a perf concern. It might be worse to have this than not, because some scenarios will appear to work correctly, but then break if the developer makes a seemingly innocuous change to their code (e.g., nesting some markup in a container). @mbest - is my assessment correct here? If so, can we revert 200f196c? I would prefer just not using jQuery HTML parsing at all, since at least the story would be consistent.