### PR TITLE
long chains without overflowing the stack fails on FF 10-23

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -497,7 +497,8 @@ describe('Dependent Observable', function() {
     it('Should allow long chains without overflowing the stack', function() {
         // maximum with previous code (when running this test only): Chrome 28: 1310, IE 10: 2200; FF 23: 103
         // maximum with changed code: Chrome 28: 2620, +100%, IE 10: 4900, +122%; FF 23: 267, +160%
-        var depth = 200;
+        // (per #1622, max depth reduced to pass tests in older FF)
+        var depth = 175;
         var first = ko.observable(0);
         var last = first;
         for (var i = 0; i < depth; i++) {


### PR DESCRIPTION
The test [Dependent Observable Should allow long chains without overflowing the stack](https://github.com/knockout/knockout/blob/05f4cdcbd2ba653f06ec19240fc100056c5e006b/spec/dependentObservableBehaviors.js#L486) fails [on FF 10-23](https://travis-ci.org/brianmhunt/knockout#L654) with `InternalError: too much recusion`.

Noting: #358 & #359.