### PR TITLE
Setting hasFocus to false in IE clears focus from all other elements

### DIFF
--- a/spec/defaultBindings/hasfocusBehaviors.js
+++ b/spec/defaultBindings/hasfocusBehaviors.js
@@ -84,4 +84,15 @@ describe('Binding: Hasfocus', function() {
         model.isFocused(null);
         expect(didBlurAgain).toEqual(false);
     });
+
+    it('Should not cause unrelated items to lose focus when initialized with false', function () {
+        // See #1893
+        testNode.innerHTML = '<input data-bind="hasFocus: true" value="This should be focused initially" /><input data-bind="hasFocus: false" value="This should not be focused" />';
+        ko.applyBindings({}, testNode);
+
+        // Can only test for focus in browsers that support it
+        if ("activeElement" in document) {
+            expect(document.activeElement).toBe(testNode.childNodes[0]);
+        }
+    });
 });

--- a/src/binding/defaultBindings/hasfocus.js
+++ b/src/binding/defaultBindings/hasfocus.js
@@ -37,10 +37,20 @@ ko.bindingHandlers['hasfocus'] = {
         ko.utils.registerEventHandler(element, "focusout",  handleElementFocusOut); // For IE
     },
     'update': function(element, valueAccessor) {
-        var value = !!ko.utils.unwrapObservable(valueAccessor()); //force boolean to compare with last value
+        var value = !!ko.utils.unwrapObservable(valueAccessor());
+
         if (!element[hasfocusUpdatingProperty] && element[hasfocusLastValue] !== value) {
-            value ? element.focus() : (element.blur(), element.ownerDocument.body.focus());
-            ko.dependencyDetection.ignore(ko.utils.triggerEvent, null, [element, value ? "focusin" : "focusout"]); // For IE, which doesn't reliably fire "focus" or "blur" events synchronously
+            value ? element.focus() : element.blur();
+
+            // In IE, the blur method doesn't always cause the element to lose focus (for example, if the window is not in focus).
+            // Setting focus to the body element does seem to be reliable in IE, but should only be used if we know that the current
+            // element was focused already.
+            if (!value && element[hasfocusLastValue]) {
+                element.ownerDocument.body.focus();
+            }
+
+            // For IE, which doesn't reliably fire "focus" or "blur" events synchronously
+            ko.dependencyDetection.ignore(ko.utils.triggerEvent, null, [element, value ? "focusin" : "focusout"]);
         }
     }
 };


### PR DESCRIPTION
The behavior of the ```hasFocus``` binding has broken in IE since version ```3.3.0```. Specifically, assigning a value of ```false``` to the binding when the element is rendered now clears focus from all other elements, because it invokes ```element.ownerDocument.body.focus()```.

Here is a very simple example:

``` html
<p tabindex="0" data-bind="hasFocus: true">This should have focus initially.</p>
<p tabindex="0" data-bind="hasFocus: false">This should not have focus.</p>
```

``` javascript
ko.applyBindings()
```

In Chrome and Firefox, the first paragraph starts as focused. In IE, however, neither paragraph is focused.

Here is a JSFiddle of the simple case: http://jsfiddle.net/ThomasMichon/ef3u690p/ (look for a red outline around the focused paragraph).
Here is a more thorough example showing how this behavior disrupts keyboard usage: http://jsfiddle.net/ThomasMichon/5toqrqn3/ (note how the selected item loses focus when a new item is rendered).

My understanding is that passing ```false``` to the ```hasFocus``` binding is simply supposed to blur that one element, not clear focus from all elements. I think we just need just need to ensure that the bound element is the current value of ```document.activeElement``` before using body focus as a way to blur it.

