### PR TITLE
New beforeRemove behavior can break non-removed items

### DIFF
--- a/src/binding/editDetection/arrayToDomNodeChildren.js
+++ b/src/binding/editDetection/arrayToDomNodeChildren.js
@@ -91,12 +91,18 @@
                         }
 
                         // Queue these nodes for later removal
-                        nodesToDelete.push.apply(nodesToDelete, ko.utils.fixUpContinuousNodeArray(mapData.mappedNodes, domNode) || []);
-                        if (options['beforeRemove'] && mapData.mappedNodes.length) {
-                            newMappingResult.push(mapData);
-                            itemsToProcess.push(mapData);
-                            if (mapData.arrayEntry !== deletedItemDummyValue) {
-                                itemsForBeforeRemoveCallbacks[i] = mapData;
+                        if (ko.utils.fixUpContinuousNodeArray(mapData.mappedNodes, domNode).length) {
+                            if (options['beforeRemove']) {
+                                newMappingResult.push(mapData);
+                                itemsToProcess.push(mapData);
+                                if (mapData.arrayEntry === deletedItemDummyValue) {
+                                    mapData = null;
+                                } else {
+                                    itemsForBeforeRemoveCallbacks[i] = mapData;
+                                }
+                            }
+                            if (mapData) {
+                                nodesToDelete.push.apply(nodesToDelete, mapData.mappedNodes);
                             }
                         }
                     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -272,7 +272,7 @@ ko.utils = (function () {
 
                 // Rule [B]
                 while (continuousNodeArray.length > 1 && continuousNodeArray[continuousNodeArray.length - 1].parentNode !== parentNode)
-                    continuousNodeArray.splice(-1, 1);
+                    continuousNodeArray.length--;
 
                 // Rule [C]
                 if (continuousNodeArray.length > 1) {
@@ -282,10 +282,6 @@ ko.utils = (function () {
                     while (current !== last) {
                         continuousNodeArray.push(current);
                         current = current.nextSibling;
-                        if (!current) { // Won't happen, except if the developer has manually removed some DOM elements (then we're in an undefined scenario)
-                            continuousNodeArray.length = 0;
-                            return continuousNodeArray;
-                        }
                     }
                     continuousNodeArray.push(last);
                 }


### PR DESCRIPTION
While re-testing the examples included with #1256, I discovered that when removing items from an array, following items might be "cleaned" so that their bindings no longer worked. This happens when the nodes for an item aren't all removed at the same time and `fixUpContinuousNodeArray` exits with the "undefined scenario".