### PR TITLE
Endless recursion possible in evaluateImmediate

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -502,8 +502,8 @@ describe('Dependent Observable', function() {
     it('Should allow long chains without overflowing the stack', function() {
         // maximum with previous code (when running this test only): Chrome 28: 1310, IE 10: 2200; FF 23: 103
         // maximum with changed code: Chrome 28: 2620, +100%, IE 10: 4900, +122%; FF 23: 267, +160%
-        // (per #1622, max depth reduced to pass tests in older FF)
-        var depth = 175;
+        // (per #1622 and #1905, max depth reduced to pass tests in older FF)
+        var depth = 100;
         var first = ko.observable(0);
         var last = first;
         for (var i = 0; i < depth; i++) {


### PR DESCRIPTION
It looks like ```evaluateImmediate``` was changed in PR #1622 so that the calls to ```notifySubscribers``` are now made outside the window during which ```state.isBeingEvaluated``` is ```true```. This is a breaking change because it now produces stack overflows if two computed observables have a circular dependency.

**Update**: I've isolated this to the case where a ```computed``` returns an ```object``` on its evaluation, which is then used to trigger a circular dependency.