### PR TITLE
typed observables

### DIFF
--- a/build/fragments/source-references.js
+++ b/build/fragments/source-references.js
@@ -17,6 +17,7 @@ knockoutDebugCallback([
     'src/subscribables/observableArray.changeTracking.js',
     'src/subscribables/dependentObservable.js',
     'src/subscribables/mappingHelpers.js',
+    'src/subscribables/typedObservables.js',
     'src/binding/selectExtensions.js',
     'src/binding/expressionRewriting.js',
     'src/virtualElements.js',
@@ -46,6 +47,7 @@ knockoutDebugCallback([
     'src/binding/defaultBindings/visible.js',
     // click depends on event - The order matters for specs, which includes each file individually
     'src/binding/defaultBindings/click.js',
+    'src/binding/defaultBindings/typeSpecific.js',
     'src/templating/templateEngine.js',
     'src/templating/templateRewriting.js',
     'src/templating/templateSources.js',

--- a/spec/runner.node.js
+++ b/spec/runner.node.js
@@ -39,6 +39,7 @@ require('./mappingHelperBehaviors');
 require('./observableArrayBehaviors');
 require('./observableArrayChangeTrackingBehaviors');
 require('./observableBehaviors');
+require('./typedObservablesBehaviors');
 require('./subscribableBehaviors');
 require('./taskBehaviors');
 require('./utilsBehaviors');

--- a/spec/typedObservablesBehaviors.js
+++ b/spec/typedObservablesBehaviors.js
@@ -1,0 +1,76 @@
+describe('ObservableBool', function() {
+  it('Should be instanciated with value false by default', function () {
+    var noValueInstance = ko.observableBool(),
+        falseValueInstance = ko.observableBool(false),
+        wrongValueInstance = ko.observableBool('a wrong value');
+
+    expect(noValueInstance()).toEqual(false);
+    expect(falseValueInstance()).toEqual(false);
+    expect(wrongValueInstance()).toEqual(false);
+  });
+
+  it('Should be toggelable', function () {
+    var instance = ko.observableBool(false);
+    instance.toggle();
+    expect(instance()).toEqual(true);
+  });
+
+  it('Should normalize setValues', function() {
+    var instance = ko.observableBool(true);
+
+    // check none-bool value
+    instance("value that will be normalized to false");
+    expect(instance()).toEqual(false);
+
+    // check every value that should be normalized to true (reset)
+    instance(true);
+    expect(instance()).toEqual(true);
+
+    instance(false); // reset
+    instance(1);
+    expect(instance()).toEqual(true);
+
+    instance(false); // reset
+    instance("1");
+    expect(instance()).toEqual(true);
+  });
+});
+
+describe('ObservableNumber', function() {
+  it('Incremention / Decremention should work', function() {
+    var instance = ko.observableNumber(13);
+    instance.increment();
+    expect(instance()).toEqual(14);
+    instance.decrement();
+    expect(instance()).toEqual(13);
+  });
+
+  it('Abs / Positive / Negative dynamic attribute should work', function() {
+    var instance = ko.observableNumber(13);
+    expect(instance.abs()).toEqual(13);
+    expect(instance.negative()).toEqual(false);
+    expect(instance.positive()).toEqual(true);
+
+    instance(-13);
+    expect(instance.abs()).toEqual(13);
+    expect(instance.negative()).toEqual(true);
+    expect(instance.positive()).toEqual(false);
+  });
+});
+
+describe('ObservableInt', function() {
+  it('Should inherit all methods and attributes from Number', function() {
+    var instance = ko.observableInt(13);
+    instance.increment(); // proto method
+    expect(instance()).toEqual(14);
+    expect(instance.positive()).toEqual(true); // dynamic attribute
+  });
+
+  it('Hex dynamic attribute should work', function() {
+    var instance = ko.observableInt(25);
+    expect(instance.hex()).toEqual('19'); // Test getter
+
+    instance.hex('4dd'); // Test setter
+    expect(instance()).toEqual(1245);
+  });
+});

--- a/src/binding/defaultBindings/typeSpecific.js
+++ b/src/binding/defaultBindings/typeSpecific.js
@@ -1,0 +1,5 @@
+// Bool specific
+
+// Number specific
+
+// Int specific

--- a/src/subscribables/typedObservables.js
+++ b/src/subscribables/typedObservables.js
@@ -1,0 +1,85 @@
+// Generator
+ko.registerType = function(name, options) {
+  var rawType = 'observable' + (options['extends'] || ''),
+      normalize = options.normalize || function(value) { return value; },
+      typedObservable = function(initialValue) {
+        var raw = ko[rawType](normalize(initialValue)),
+            wrapper = ko.pureComputed({
+              read: raw,
+              write: function(value) {
+                raw(normalize(value));
+              }
+            });
+
+        // apply super attributes (prototype methods and dyn attributes)
+        if (rawType !== 'observable')
+          for (var attr in raw)
+            if (!wrapper[attr]) wrapper[attr] = raw[attr];
+
+        // TODO: Validate name conflicts in debug build
+        for (var method in options['prototypeMethods']) { // jshint ignore: line
+          wrapper[method] = (function(method) {
+            return function() { method.call(raw, arguments); };
+          })(options['prototypeMethods'][method]); // jshint ignore: line
+        }
+
+        for (var attribute in options['dynamicAttributes']) { // jshint ignore: line
+          wrapper[attribute] = ko.pureComputed(options['dynamicAttributes'][attribute], raw); // jshint ignore: line
+        }
+
+        return wrapper;
+      };
+
+  ko['observable' + name] = typedObservable;
+  ko.exportSymbol('observable' + name, typedObservable);
+};
+
+ko.exportSymbol('registerType', ko.registerType);
+
+// Register core types
+ko.registerType('Bool', {
+  normalize: function(value) { return value == true }, // jshint ignore: line
+  'prototypeMethods': {
+    'toggle': function() {
+      this(!this());
+    }
+  }
+});
+
+ko.registerType('Number', {
+  normalize: function(value) { return parseFloat(value) || 0; },
+  'prototypeMethods': {
+    'increment': function() {
+      this(this() + 1);
+    },
+    'decrement': function() {
+      this(this() - 1);
+    }
+  },
+  'dynamicAttributes': {
+    'abs': function() {
+      return Math.abs(this());
+    },
+    'negative': function() {
+      return this() < 0;
+    },
+    'positive': function() {
+      return this() >= 0;
+    }
+  }
+});
+
+ko.registerType('Int', {
+  normalize: function(value) { return parseInt(value); },
+  extends: 'Number',
+  'dynamicAttributes': {
+    'hex': {
+      'read': function() {
+        return this().toString(16);
+      },
+      'write': function(newValue) {
+        this(parseInt(newValue, 16));
+      }
+    }
+  }
+});


### PR DESCRIPTION
In one of my current projects I use **typed observables** to easily validate types of values I store in a database later. I thought you might be interested in adding this to the knockout core.

In this fork i added a **ko.registerType**-method and short implementations of a **Bool**, **Number** and **Int** type to show you how this could look like. These types are available as **ko.observableBool** and so on. Types can be subtypes of another.

Each type has some additional methods and attributes. As an example, ko.observableBool has a toggle method: toggling such an observable can easily be done by adding
```<button data-bind="click: aBoolObservable.toggle"></button>```
to the markup. The view model in this case would simply be
```{ aBoolObservable: ko.observableBool() }```.

I created a [Codepen](http://codepen.io/ls-age/pen/OyOmwQ?editors=101) providing a simple example of all the methods and attributes I added to this fork.

If you were interested in adding this to the knockout core, I would be happy to help you implementing it.