### PR TITLE
Support 3-state checkboxes

### DIFF
--- a/spec/defaultBindings/checkedBehaviors.js
+++ b/spec/defaultBindings/checkedBehaviors.js
@@ -27,9 +27,19 @@ describe('Binding: Checked', function() {
 
         ko.applyBindings({ someProp: myobservable }, testNode);
         expect(testNode.childNodes[0].checked).toEqual(true);
+        expect(testNode.childNodes[0].indeterminate).toEqual(false);
 
         myobservable(false);
         expect(testNode.childNodes[0].checked).toEqual(false);
+        expect(testNode.childNodes[0].indeterminate).toEqual(false);
+
+        myobservable('mixed');
+        expect(testNode.childNodes[0].checked).toEqual(true);
+        expect(testNode.childNodes[0].indeterminate).toEqual(true);
+
+        myobservable(true);
+        expect(testNode.childNodes[0].checked).toEqual(true);
+        expect(testNode.childNodes[0].indeterminate).toEqual(false);
     });
 
     it('Should update observable properties on the underlying model when the checkbox click event fires', function () {

--- a/src/binding/defaultBindings/checked.js
+++ b/src/binding/defaultBindings/checked.js
@@ -67,7 +67,14 @@ ko.bindingHandlers['checked'] = {
                 element.checked = ko.utils.arrayIndexOf(modelValue, checkedValue()) >= 0;
             } else if (isCheckbox) {
                 // When a checkbox is bound to any other value (not an array), being checked represents the value being trueish
-                element.checked = modelValue;
+                if (modelValue === 'mixed') {
+                    element.checked = true;
+                    element.indeterminate = true;
+                }
+                else {
+                    element.checked = !!modelValue;
+                    element.indeterminate = false;
+                }
             } else {
                 // For radio buttons, being checked means that the radio button's value corresponds to the model value
                 element.checked = (checkedValue() === modelValue);


### PR DESCRIPTION
HTML5 allows for a 3-state checkbox, and the ARIA spec defines 3 discrete values (see http://www.w3.org/TR/wai-aria/roles#checkbox). Modern browsers can visualize the indeterminate/mixed state, and it can be set programmatically by setting the `indeterminate` property of the corresponding DOM element (see https://css-tricks.com/indeterminate-checkboxes/). This PR modifies the `checked` binding to support 3-state checkboxes by recognizing the special value 'mixed'. Note that the modifications *do not* inject any `aria-` attributes.