### PR TITLE
Feature request: alias binding

### DIFF
--- a/build/fragments/source-references.js
+++ b/build/fragments/source-references.js
@@ -35,6 +35,7 @@ knockoutDebugCallback([
     'src/binding/defaultBindings/hasfocus.js',
     'src/binding/defaultBindings/html.js',
     'src/binding/defaultBindings/ifIfnotWith.js',
+    'src/binding/defaultBindings/let.js',
     'src/binding/defaultBindings/options.js',
     'src/binding/defaultBindings/selectedOptions.js',
     'src/binding/defaultBindings/style.js',

--- a/spec/defaultBindings/letBehaviors.js
+++ b/spec/defaultBindings/letBehaviors.js
@@ -1,0 +1,35 @@
+describe('Binding: Let', function() {
+    beforeEach(jasmine.prepareTestNode);
+
+    it('Should be able to add custom properties that will be available to all child contexts', function() {
+        testNode.innerHTML = "<div data-bind=\"let: { '$customProp': 'my value' }\"><div data-bind='with: true'><div data-bind='text: $customProp'></div></div></div>";
+        ko.applyBindings(null, testNode);
+        expect(testNode).toContainText("my value");
+    });
+
+    it('Should update all child contexts when custom properties are updated', function() {
+        var observable = ko.observable(1);
+        testNode.innerHTML = "<div data-bind='let: { prop1 : prop()*2 }'><div data-bind='text: prop1'></div></div>";
+        ko.applyBindings({prop: observable}, testNode);
+        expect(testNode).toContainText("2");
+
+        // change observable
+        observable(2);
+        expect(testNode).toContainText("4");
+    });
+
+    it('Should update all custom properties when the parent context is updated', function() {
+        testNode.innerHTML = "<div data-bind='let: {obj1: $data}'><span data-bind='text:obj1.prop1'></span><span data-bind='text:prop2'></span></div>";
+        var vm = ko.observable({prop1: "First ", prop2: "view model"});
+        ko.applyBindings(vm, testNode);
+        expect(testNode).toContainText("First view model");
+
+        // change view model to new object
+        vm({prop1: "Second view ", prop2: "model"});
+        expect(testNode).toContainText("Second view model");
+
+        // change it again
+        vm({prop1: "Third view model", prop2: ""});
+        expect(testNode).toContainText("Third view model");
+    });
+});

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="defaultBindings/htmlBehaviors.js"></script>
         <script type="text/javascript" src="defaultBindings/ifBehaviors.js"></script>
         <script type="text/javascript" src="defaultBindings/ifnotBehaviors.js"></script>
+        <script type="text/javascript" src="defaultBindings/letBehaviors.js"></script>
         <script type="text/javascript" src="defaultBindings/optionsBehaviors.js"></script>
         <script type="text/javascript" src="defaultBindings/selectedOptionsBehaviors.js"></script>
         <script type="text/javascript" src="defaultBindings/styleBehaviors.js"></script>

--- a/src/binding/defaultBindings/let.js
+++ b/src/binding/defaultBindings/let.js
@@ -1,0 +1,10 @@
+ko.bindingHandlers['let'] = {
+    'init': function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        // Make a modified binding context, with extra properties, and apply it to descendant elements
+        var innerContext = bindingContext['extend'](valueAccessor);
+        ko.applyBindingsToDescendants(innerContext, element);
+
+        return { 'controlsDescendantBindings': true };
+    }
+};
+ko.virtualElements.allowedBindings['let'] = true;


### PR DESCRIPTION
If I've got some particularly complex screens, it's handy for something deep down (nested in a couple of foreach bindings for example) to have quick access to the main view model of the screen.  Inspired by the ability of foreach taking 'as' to given an alias to $data, and reading the KO docs (http://knockoutjs.com/documentation/custom-bindings-controlling-descendant-bindings.html), I came up with this

```

//A binding handler that allows us to alias $data as a new variable in the context
//Sourced from the KO documentation, with changes:   http://knockoutjs.com/documentation/custom-bindings-controlling-descendant-bindings.html
ko.bindingHandlers.alias = {
    init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {

        //value accessor should be a name of a property to which we'll alias
        var aliasPropertyName = valueAccessor();
        var extraContext = {};
        extraContext[aliasPropertyName] = bindingContext.$data;
        extraContext['raw' + aliasPropertyName] = bindingContext.$rawData;

        // Make a modified binding context, with a extra properties, and apply it to descendant elements
        var innerBindingContext = bindingContext.extend(extraContext);
        ko.applyBindingsToDescendants(innerBindingContext, element);

        // Also tell KO *not* to bind the descendants itself, otherwise they will be bound twice
        return { controlsDescendantBindings: true };
    }
};
ko.virtualElements.allowedBindings.alias = true;
```

It means I can do something like

```
<!--ko alias: '$viewModel'-->

  SNIP
  <div data-bind="foreach: {data: $viewModel.suppliers, as: '$supplier'}>
    SNIP
    <div data-bind="foreach: {data: $viewModel.bins, as: '$bin'}">
        <span data-bind="text: $viewModel.someCalculation($supplier, $bin)>
    </div>
  </div>
<!--/ko-->
```

I can insert an extra layer of binding context in there, move things around, etc and not worry about counting $parents[1] or $parents[2], etc.  This is similar to $root and $component, except it starts and stops at a scope I specify.

It's easy to have as a separate binding handler but I thought it might be useful in core. Thoughts?  `as` might be a better name than `alias` since `as` is already used in the `foreach` binding.