### PR TITLE
Allow Dynamic and Static Classes with CSS Binding

### DIFF
--- a/spec/defaultBindings/cssBehaviors.js
+++ b/spec/defaultBindings/cssBehaviors.js
@@ -102,4 +102,31 @@ describe('Binding: CSS classes', function() {
         observable1("my-Rule");
         expect(testNode.childNodes[0].className).toEqual("unrelatedClass1 my-Rule");
     });
+
+    it('Should be aliased as class as well as css', function() {
+        expect(ko.bindingHandlers['class']).toEqual(ko.bindingHandlers.css);
+    });
+
+    it('Should be able to combine "class" and "css" bindings with dynamic and static classes', function () {
+        // This test doesn't cover cases where the static and dynamic bindings try to set or unset the same class name
+        // because the behavior for that scenario isn't defined.
+
+        var booleanProp = new ko.observable(false);
+        var stringProp = new ko.observable("");
+        testNode.innerHTML = "<div class='unrelatedClass' data-bind='css: { staticClass: booleanProp }, class: stringProp'></div>";
+
+        ko.applyBindings({ booleanProp: booleanProp, stringProp: stringProp }, testNode);
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass");
+
+        booleanProp(true);
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass staticClass");
+
+        stringProp("dynamicClass");
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass staticClass dynamicClass");
+
+        booleanProp(false);
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass dynamicClass");
+        stringProp(null);
+        expect(testNode.childNodes[0].className).toEqual("unrelatedClass");
+    });
 });

--- a/src/binding/defaultBindings/css.js
+++ b/src/binding/defaultBindings/css.js
@@ -1,5 +1,5 @@
 var classesWrittenByBindingKey = '__ko__cssValue';
-ko.bindingHandlers['css'] = {
+ko.bindingHandlers['class'] = ko.bindingHandlers['css'] = {
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor());
         if (value !== null && typeof value == "object") {


### PR DESCRIPTION
I am wanting to apply a CSS binding with both a dynamic and static class. I have been reading around on forums for solutions to this and I guess I am looking for a reason not to find a way to implement this into the library. If it is a principle of the library to not support this, that answer would be fine as well. The only way I could think of handling this would be to allow the CSS binding to take an array that contains strings or objects that then get handled appropriately by the binding to apply the classes.

Thanks