### PR TITLE
fix for #1943

### DIFF
--- a/src/subscribables/extenders.js
+++ b/src/subscribables/extenders.js
@@ -49,6 +49,7 @@ ko.extenders = {
             target.limit(function (callback) {
                 var handle;
                 return function () {
+                    if (ko.tasks.isScheduled(callback)) return;
                     ko.tasks.cancel(handle);
                     handle = ko.tasks.schedule(callback);
                     target['notifySubscribers'](undefined, 'dirty');

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -89,6 +89,13 @@ ko.tasks = (function () {
             }
         },
 
+        isScheduled: function(func) {
+            var keys = Object.keys(taskQueue);
+            for (var a = keys.length - 1; a >= 0; a--)
+                if (taskQueue[keys[a]] === func) return true;
+            return false;
+        },
+
         // For testing only: reset the queue and return the previous queue length
         'resetForTesting': function () {
             var length = taskQueueLength - nextIndexToProcess;


### PR DESCRIPTION
Checks whether a task is already queued and if so, ignores it.