### PR TITLE
Adding method to retrieve ordered list of dependencies for computed observables

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -557,6 +557,7 @@ describe('Rate-limited', function() {
             expect(computed()).toEqual(1);
             // The computed should not be dependent on the second observable
             expect(computed.getDependenciesCount()).toEqual(1);
+            expect(computed.getDependencies()).toEqual([observableSwitch]);
 
             // Updating the second observable shouldn't re-evaluate computed
             observableValue(2);

--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -257,12 +257,14 @@ describe('Dependent Observable', function() {
         );
         expect(timesEvaluated).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([ underlyingObservable ]);
         expect(computed.isActive()).toEqual(true);
 
         timeToDispose = true;
         underlyingObservable(101);
         expect(timesEvaluated).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
         expect(computed.isActive()).toEqual(false);
     });
 
@@ -356,12 +358,14 @@ describe('Dependent Observable', function() {
 
         // initially computed has no dependencies since it has not been evaluated
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
 
         // Now subscribe to computed
         computed.subscribe(result);
 
         // The dependency should now be tracked
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([ data ]);
 
         // But the subscription should not have sent down the initial value
         expect(result()).toEqual(undefined);
@@ -411,6 +415,7 @@ describe('Dependent Observable', function() {
 
         // initially there is only one dependency
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
 
         // create a change subscription that also accesses an observable
         computed.subscribe(function() { observableIndependent() });
@@ -418,11 +423,13 @@ describe('Dependent Observable', function() {
         observableDependent(1);
         // there should still only be one dependency
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
 
         // also test with a beforeChange subscription
         computed.subscribe(function() { observableIndependent() }, null, 'beforeChange');
         observableDependent(2);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
     });
 
     it('Should not subscribe to observables accessed through change notifications of a modified observable', function() {
@@ -434,6 +441,7 @@ describe('Dependent Observable', function() {
 
         // initially there is only one dependency
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
 
         // create a change subscription that also accesses an observable
         observableModified.subscribe(function() { observableIndependent() });
@@ -441,11 +449,13 @@ describe('Dependent Observable', function() {
         observableDependent(1);
         // there should still only be one dependency
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
 
         // also test with a beforeChange subscription
         observableModified.subscribe(function() { observableIndependent() }, null, 'beforeChange');
         observableDependent(2);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableDependent]);
     });
 
     it('Should be able to re-evaluate a computed that previously threw an exception', function() {
@@ -470,6 +480,7 @@ describe('Dependent Observable', function() {
         expect(computed()).toEqual(1);
         // The computed should not be dependent on the second observable
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([observableSwitch]);
 
         // Updating the second observable shouldn't re-evaluate computed
         observableValue(2);
@@ -571,6 +582,7 @@ describe('Dependent Observable', function() {
         expect(evaluateCount).toEqual(1);
         expect(computed()).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
     });
 
     it('Should not evaluate (or add dependencies) after it has been disposed if created with "deferEvaluation"', function () {
@@ -591,6 +603,7 @@ describe('Dependent Observable', function() {
         expect(evaluateCount).toEqual(0);
         expect(computed()).toEqual(undefined);
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
     });
 
     it('Should not add dependencies if disposed during evaluation', function () {
@@ -611,6 +624,7 @@ describe('Dependent Observable', function() {
         expect(evaluateCount).toEqual(1);
         expect(computed()).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(2);
+        expect(computed.getDependencies()).toEqual([observableToTriggerDisposal, observableGivingValue]);
         expect(observableGivingValue.getSubscriptionsCount()).toEqual(1);
 
         // Now cause a disposal during evaluation
@@ -618,6 +632,7 @@ describe('Dependent Observable', function() {
         expect(evaluateCount).toEqual(2);
         expect(computed()).toEqual(2);
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
         expect(observableGivingValue.getSubscriptionsCount()).toEqual(0);
     });
 
@@ -668,26 +683,33 @@ describe('Dependent Observable', function() {
                     ++evaluationCount;
                     // no dependencies at first
                     expect(ko.computedContext.getDependenciesCount()).toEqual(0);
+                    expect(ko.computedContext.getDependencies()).toEqual([]);
                     // add a single dependency
                     observable1();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(1);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1]);
                     // add a second one
                     observable2();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(2);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1, observable2]);
                     // accessing observable again doesn't affect count
                     observable1();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(2);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1, observable2]);
                 });
 
             expect(evaluationCount).toEqual(1);     // single evaluation
             expect(computed.getDependenciesCount()).toEqual(2); // matches value from context
+            expect(computed.getDependencies()).toEqual([observable1, observable2]);
 
             observable1(2);
             expect(evaluationCount).toEqual(2);     // second evaluation
             expect(computed.getDependenciesCount()).toEqual(2); // matches value from context
+            expect(computed.getDependencies()).toEqual([observable1, observable2]);
 
             // value outside of computed is undefined
             expect(ko.computedContext.getDependenciesCount()).toBeUndefined();
+            expect(ko.computedContext.getDependencies()).toBeUndefined();
         });
     });
 });

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -93,6 +93,7 @@ describe('Pure Computed', function() {
 
         // getDependenciesCount returns the correct number
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([data]);
     });
 
     it('Should not evaluate after it has been disposed', function () {
@@ -121,6 +122,7 @@ describe('Pure Computed', function() {
         computed.subscribe(function (value) { notifiedValues.push(value); });
         expect(data.getSubscriptionsCount()).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([data]);
 
         // The subscription should not have sent down the initial value
         expect(notifiedValues).toEqual([]);
@@ -137,12 +139,14 @@ describe('Pure Computed', function() {
 
         expect(data.getSubscriptionsCount()).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([data]);
 
         // Dispose the subscription to the computed
         subscription.dispose();
         // It goes to sleep, disposing its subscription to the observable
         expect(data.getSubscriptionsCount()).toEqual(0);
         expect(computed.getDependenciesCount()).toEqual(1);     // dependency count of computed doesn't change
+        expect(computed.getDependencies()).toEqual([data]);
     });
 
     it('Should fire "awake" and "asleep" events when changing state', function() {
@@ -183,6 +187,7 @@ describe('Pure Computed', function() {
         expect(computed()).toEqual('A');
         expect(timesEvaluated).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(1);
+        expect(computed.getDependencies()).toEqual([data]);
 
         // Subscribing to the computed adds a subscription to the dependency without re-evaluating
         subscription = computed.subscribe(subscribeFunc);
@@ -314,12 +319,14 @@ describe('Pure Computed', function() {
         expect(computed()).toEqual('A');
         expect(timesEvaluated).toEqual(1);
         expect(computed.getDependenciesCount()).toEqual(2);
+        expect(computed.getDependencies()).toEqual([observableToTriggerDisposal, observableGivingValue]);
 
         // Now cause a disposal during evaluation
         observableToTriggerDisposal(true);
         expect(computed()).toEqual('A');
         expect(timesEvaluated).toEqual(2);
         expect(computed.getDependenciesCount()).toEqual(0);
+        expect(computed.getDependencies()).toEqual([]);
     });
 
     describe('Should maintain order of subscriptions', function () {
@@ -400,25 +407,31 @@ describe('Pure Computed', function() {
                 computed = ko.pureComputed(function() {
                     // no dependencies at first
                     expect(ko.computedContext.getDependenciesCount()).toEqual(0);
+                    expect(ko.computedContext.getDependencies()).toEqual([]);
                     // add a single dependency
                     observable1();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(1);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1]);
                     // add a second one
                     observable2();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(2);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1, observable2]);
                     // accessing observable again doesn't affect count
                     observable1();
                     expect(ko.computedContext.getDependenciesCount()).toEqual(2);
+                    expect(ko.computedContext.getDependencies()).toEqual([observable1, observable2]);
 
                     return ++evaluationCount;
                 });
 
             expect(computed()).toEqual(1);     // single evaluation
             expect(computed.getDependenciesCount()).toEqual(2); // matches value from context
+            expect(computed.getDependencies()).toEqual([observable1, observable2]);
 
             observable1(2);
             expect(computed()).toEqual(2);     // second evaluation
             expect(computed.getDependenciesCount()).toEqual(2); // matches value from context
+            expect(computed.getDependencies()).toEqual([observable1, observable2]);
         });
     });
 });

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -64,6 +64,7 @@ ko.computedContext = ko.dependencyDetection = (function () {
 
 ko.exportSymbol('computedContext', ko.computedContext);
 ko.exportSymbol('computedContext.getDependenciesCount', ko.computedContext.getDependenciesCount);
+ko.exportSymbol('computedContext.getDependencies', ko.computedContext.getDependencies);
 ko.exportSymbol('computedContext.isInitial', ko.computedContext.isInitial);
 
 ko.exportSymbol('ignoreDependencies', ko.ignoreDependencies = ko.dependencyDetection.ignore);

--- a/src/subscribables/dependencyDetection.js
+++ b/src/subscribables/dependencyDetection.js
@@ -50,6 +50,11 @@ ko.computedContext = ko.dependencyDetection = (function () {
                 return currentFrame.computed.getDependenciesCount();
         },
 
+        getDependencies: function () {
+            if (currentFrame)
+                return currentFrame.computed.getDependencies();
+        },
+
         isInitial: function() {
             if (currentFrame)
                 return currentFrame.isInitial;

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -143,6 +143,15 @@ var computedFn = {
     getDependenciesCount: function () {
         return this[computedState].dependenciesCount;
     },
+    getDependencies: function () {
+        var dependencyTracking = this[computedState].dependencyTracking, dependentObservables = [];
+
+        ko.utils.objectForEach(dependencyTracking, function (id, dependency) {
+            dependentObservables[dependency._order] = dependency._target;
+        });
+
+        return dependentObservables;
+    },
     addDependencyTracking: function (id, target, trackingObj) {
         if (this[computedState].pure && target === this) {
             throw Error("A 'pure' computed must not be called recursively");

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -463,6 +463,7 @@ ko.exportProperty(computedFn, 'peek', computedFn.peek);
 ko.exportProperty(computedFn, 'dispose', computedFn.dispose);
 ko.exportProperty(computedFn, 'isActive', computedFn.isActive);
 ko.exportProperty(computedFn, 'getDependenciesCount', computedFn.getDependenciesCount);
+ko.exportProperty(computedFn, 'getDependencies', computedFn.getDependencies);
 
 ko.pureComputed = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget) {
     if (typeof evaluatorFunctionOrOptions === 'function') {


### PR DESCRIPTION
Hi,

I've added a method for retrieving the list of dependencies relating to a computed observable.
This is useful in contexts where you wish to interrogate the dependent observables or their extensions, such as during validation.

Some example pseudo-code

var ajaxData = ko.computed(function () { return vm.toJJSON(); });
var isInvalid = ajaxData.getDependencies().some(function (dependent) { return dependent.hasError(); });

See this post for the (rather short) discussion leading to this pull request: https://groups.google.com/forum/#!topic/knockoutjs/FAsQPtGR2J8
