### PR TITLE
Restore original notifySubscribers method when unsubscribing from arrayChange events

### DIFF
--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -274,6 +274,14 @@ describe('Observable Array change tracking', function() {
         expect(source.getSubscriptionsCount()).toBe(0);
     });
 
+    it('should restore previous subscription notifications', function () {
+        var source = ko.observableArray();
+        var notifySubscribers = source.notifySubscribers;
+        var arrayChange = source.subscribe(function () { }, null, 'arrayChange');
+        arrayChange.dispose();
+        expect(source.notifySubscribers).toBe(notifySubscribers);
+    });
+
     it('Should support tracking of a computed observable using extender', function() {
         var myArray = ko.observable(['Alpha', 'Beta', 'Gamma']),
             myComputed = ko.computed(function() {

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -15,6 +15,7 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         cachedDiff = null,
         arrayChangeSubscription,
         pendingNotifications = 0,
+        underlyingNotifySubscribersFunction,
         underlyingBeforeSubscriptionAddFunction = target.beforeSubscriptionAdd,
         underlyingAfterSubscriptionRemoveFunction = target.afterSubscriptionRemove;
 
@@ -31,6 +32,10 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         if (underlyingAfterSubscriptionRemoveFunction)
             underlyingAfterSubscriptionRemoveFunction.call(target, event);
         if (event === arrayChangeEventName && !target.hasSubscriptionsForEvent(arrayChangeEventName)) {
+            if (underlyingNotifySubscribersFunction) {
+                target['notifySubscribers'] = underlyingNotifySubscribersFunction;
+                underlyingNotifySubscribersFunction = undefined;
+            }
             arrayChangeSubscription.dispose();
             trackingChanges = false;
         }
@@ -45,7 +50,7 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         trackingChanges = true;
 
         // Intercept "notifySubscribers" to track how many times it was called.
-        var underlyingNotifySubscribersFunction = target['notifySubscribers'];
+        underlyingNotifySubscribersFunction = target['notifySubscribers'];
         target['notifySubscribers'] = function(valueToNotify, event) {
             if (!event || event === defaultEvent) {
                 ++pendingNotifications;


### PR DESCRIPTION
This fixes issue #1973 by restoring the `underlyingNotifySubscribersFunction` in the `afterSubscriptionRemove` override imposed by the `trackArrayChanges` extender.

The impact of this change is that it eliminates memory leaks encountered when repeatedly subscribing and unsubscribing to the `arrayChange` events of observable arrays.