### PR TITLE
Evaluate the valueAccessor in a separate dependentObservable

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -365,11 +365,23 @@
                     validateThatBindingIsAllowedForVirtualElements(bindingKey);
                 }
 
+                var valueAccessor = ko.pureComputed(
+                    function() {
+                        var value = getValueAccessor(bindingKey);
+                        if (typeof value === "function") {
+                            value = value();
+                        }
+                        return value;
+                    },
+                    null,
+                    { disposeWhenNodeIsRemoved: node }
+                );
+
                 try {
                     // Run init, ignoring any dependencies
                     if (typeof handlerInitFn == "function") {
                         ko.dependencyDetection.ignore(function() {
-                            var initResult = handlerInitFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+                            var initResult = handlerInitFn(node, valueAccessor, allBindings, bindingContext['$data'], bindingContext);
 
                             // If this binding handler claims to control descendant bindings, make a note of this
                             if (initResult && initResult['controlsDescendantBindings']) {
@@ -384,7 +396,7 @@
                     if (typeof handlerUpdateFn == "function") {
                         ko.dependentObservable(
                             function() {
-                                handlerUpdateFn(node, getValueAccessor(bindingKey), allBindings, bindingContext['$data'], bindingContext);
+                                handlerUpdateFn(node, valueAccessor, allBindings, bindingContext['$data'], bindingContext);
                             },
                             null,
                             { disposeWhenNodeIsRemoved: node }

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -367,11 +367,7 @@
 
                 var valueAccessor = ko.pureComputed(
                     function() {
-                        var value = getValueAccessor(bindingKey);
-                        if (typeof value === "function") {
-                            value = value();
-                        }
-                        return value;
+                        return getValueAccessor(bindingKey);
                     },
                     null,
                     { disposeWhenNodeIsRemoved: node }
@@ -381,7 +377,7 @@
                     // Run init, ignoring any dependencies
                     if (typeof handlerInitFn == "function") {
                         ko.dependencyDetection.ignore(function() {
-                            var initResult = handlerInitFn(node, valueAccessor, allBindings, bindingContext['$data'], bindingContext);
+                            var initResult = handlerInitFn(node, valueAccessor(), allBindings, bindingContext['$data'], bindingContext);
 
                             // If this binding handler claims to control descendant bindings, make a note of this
                             if (initResult && initResult['controlsDescendantBindings']) {
@@ -396,7 +392,7 @@
                     if (typeof handlerUpdateFn == "function") {
                         ko.dependentObservable(
                             function() {
-                                handlerUpdateFn(node, valueAccessor, allBindings, bindingContext['$data'], bindingContext);
+                                handlerUpdateFn(node, valueAccessor(), allBindings, bindingContext['$data'], bindingContext);
                             },
                             null,
                             { disposeWhenNodeIsRemoved: node }


### PR DESCRIPTION
On a binding update the javascript expression defined in the data-bind attribute is re-evaluated each time. This is not necessary. Actually, this makes expressions returning a dynamically new created dependentObservable nearly impossible.

When evaluation the expression in a dependentObservable, the result is saved in this expression and only re-evaluated when necessary.

It would be kind, if you take my suggestion into account. Thank you.
