### PR TITLE
3.4.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
         fragments: './build/fragments/',
         banner: '/*!\n' +
                 ' * Knockout JavaScript library v<%= pkg.version %>\n' +
-                ' * (c) Steven Sanderson - <%= pkg.homepage %>\n' +
+                ' * (c) The Knockout.js team - <%= pkg.homepage %>\n' +
                 ' * License: <%= pkg.licenses[0].type %> (<%= pkg.licenses[0].url %>)\n' +
                 ' */\n\n',
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "knockout",
   "description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
   "homepage": "http://knockoutjs.com/",
-  "version": "3.4.0",
+  "version": "3.4.1-pre",
   "license": "MIT",
   "author": "The Knockout.js team",
   "main": "build/output/knockout-latest.debug.js",

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -135,4 +135,29 @@ describe("Deferred bindings", function() {
         }).not.toThrow();
         expect(observable()).not.toBeUndefined();       // The spec doesn't specify which of the two possible values is actually set
     });
+
+    it('Should get latest value when conditionally included', function() {
+        // Test is based on example in https://github.com/knockout/knockout/issues/1975
+
+        testNode.innerHTML = "<div data-bind=\"if: show\"><div data-bind=\"text: status\"></div></div>";
+        var value = ko.observable(0),
+            is1 = ko.pureComputed(function () {  return value() == 1; }),
+            status = ko.pureComputed(function () { return is1() ? 'ok' : 'error'; }),
+            show = ko.pureComputed(function () { return value() > 0 && is1(); });
+
+        ko.applyBindings({ status: status, show: show }, testNode);
+        expect(testNode.childNodes[0]).toContainHtml('');
+
+        value(1);
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainHtml('<div data-bind="text: status">ok</div>');
+
+        value(0);
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainHtml('');
+
+        value(1);
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainHtml('<div data-bind="text: status">ok</div>');
+    });
 });

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -176,4 +176,20 @@ describe('Binding: With', function() {
         viewModel.topitem(null);
         expect(testNode).toContainHtml("hello <!-- ko with: topitem --><!-- /ko -->");
     });
+
+    it('Should provide access to an observable viewModel through $rawData', function() {
+        testNode.innerHTML = "<div data-bind='with: item'><input data-bind='value: $rawData'/></div>";
+        var item = ko.observable('one');
+        ko.applyBindings({ item: item }, testNode);
+        expect(testNode.childNodes[0]).toHaveValues(['one']);
+
+        // Should update observable when input is changed
+        testNode.childNodes[0].childNodes[0].value = 'two';
+        ko.utils.triggerEvent(testNode.childNodes[0].childNodes[0], "change");
+        expect(item()).toEqual('two');
+
+        // Should update the input when the observable changes
+        item('three');
+        expect(testNode.childNodes[0]).toHaveValues(['three']);
+    });
 });

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -181,6 +181,7 @@ describe('Binding: With', function() {
         testNode.innerHTML = "<div data-bind='with: item'><input data-bind='value: $rawData'/></div>";
         var item = ko.observable('one');
         ko.applyBindings({ item: item }, testNode);
+        expect(item.getSubscriptionsCount('change')).toEqual(2);    // only subscriptions are the with and value bindings
         expect(testNode.childNodes[0]).toHaveValues(['one']);
 
         // Should update observable when input is changed

--- a/spec/observableArrayChangeTrackingBehaviors.js
+++ b/spec/observableArrayChangeTrackingBehaviors.js
@@ -274,6 +274,14 @@ describe('Observable Array change tracking', function() {
         expect(source.getSubscriptionsCount()).toBe(0);
     });
 
+    it('should restore previous subscription notifications', function () {
+        var source = ko.observableArray();
+        var notifySubscribers = source.notifySubscribers;
+        var arrayChange = source.subscribe(function () { }, null, 'arrayChange');
+        arrayChange.dispose();
+        expect(source.notifySubscribers).toBe(notifySubscribers);
+    });
+
     it('Should support tracking of a computed observable using extender', function() {
         var myArray = ko.observable(['Alpha', 'Beta', 'Gamma']),
             myComputed = ko.computed(function() {

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -322,6 +322,29 @@ describe('Pure Computed', function() {
         expect(computed.getDependenciesCount()).toEqual(0);
     });
 
+    it('Should reevaluate if dependency was changed during awakening, but not otherwise', function() {
+        // See https://github.com/knockout/knockout/issues/1975
+        var data = ko.observable(0),
+            isEven = ko.pureComputed(function() { return !(data() % 2); }),
+            timesEvaluated = 0,
+            pureComputed = ko.pureComputed(function () { ++timesEvaluated; return isEven(); }),
+            subscription;
+
+        expect(pureComputed()).toEqual(true);
+        expect(timesEvaluated).toEqual(1);
+
+        data(1);
+        subscription = isEven.subscribe(function() {});
+        expect(pureComputed()).toEqual(false);
+        expect(timesEvaluated).toEqual(2);
+        subscription.dispose();
+
+        data(3);
+        subscription = isEven.subscribe(function() {});
+        expect(pureComputed()).toEqual(false);
+        expect(timesEvaluated).toEqual(2);
+    });
+
     describe('Should maintain order of subscriptions', function () {
         var data, dataPureComputed;
 

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -385,6 +385,22 @@ describe('Templating', function() {
         expect(testNode.childNodes[0]).toContainText("true");
     });
 
+    it('Data binding syntax should be able to use $rawData in binding value to refer to a top level template\'s view model observable', function() {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
+        ko.renderTemplate("someTemplate", ko.observable('value'), null, testNode);
+        expect(testNode.childNodes[0]).toContainText("true");
+    });
+
+    it('Data binding syntax should be able to use $rawData in binding value to refer to a data-bound template\'s view model observable', function() {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
+        testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+
+        viewModel = { someProp: ko.observable('value') };
+        ko.applyBindings(viewModel, testNode);
+
+        expect(testNode.childNodes[0].childNodes[0]).toContainText("true");
+    });
+
     it('Data binding syntax should defer evaluation of variables until the end of template rendering (so bindings can take independent subscriptions to them)', function () {
         ko.setTemplateEngine(new dummyTemplateEngine({
             someTemplate: "<input data-bind='value:message' />[js: message = 'goodbye'; undefined; ]"

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -386,19 +386,22 @@ describe('Templating', function() {
     });
 
     it('Data binding syntax should be able to use $rawData in binding value to refer to a top level template\'s view model observable', function() {
+        var data = ko.observable('value');
         ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
-        ko.renderTemplate("someTemplate", ko.observable('value'), null, testNode);
+        ko.renderTemplate("someTemplate", data, null, testNode);
         expect(testNode.childNodes[0]).toContainText("true");
+        expect(data.getSubscriptionsCount('change')).toEqual(1);    // only subscription is from the templating code
     });
 
     it('Data binding syntax should be able to use $rawData in binding value to refer to a data-bound template\'s view model observable', function() {
         ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "<div data-bind='text: ko.isObservable($rawData)'></div>" }));
         testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
 
-        viewModel = { someProp: ko.observable('value') };
+        var viewModel = { someProp: ko.observable('value') };
         ko.applyBindings(viewModel, testNode);
 
         expect(testNode.childNodes[0].childNodes[0]).toContainText("true");
+        expect(viewModel.someProp.getSubscriptionsCount('change')).toEqual(1);    // only subscription is from the templating code
     });
 
     it('Data binding syntax should defer evaluation of variables until the end of template rendering (so bindings can take independent subscriptions to them)', function () {

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -20,7 +20,7 @@
 
     // The ko.bindingContext constructor is only called directly to create the root context. For child
     // contexts, use bindingContext.createChildContext or bindingContext.extend.
-    ko.bindingContext = function(dataItemOrAccessor, parentContext, dataItemAlias, extendCallback) {
+    ko.bindingContext = function(dataItemOrAccessor, parentContext, dataItemAlias, extendCallback, options) {
 
         // The binding context object includes static properties for the current, parent, and root view models.
         // If a view model is actually stored in an observable, the corresponding binding context object, and
@@ -43,10 +43,7 @@
                 ko.utils.extend(self, parentContext);
 
                 // Because the above copy overwrites our own properties, we need to reset them.
-                // During the first execution, "subscribable" isn't set, so don't bother doing the update then.
-                if (subscribable) {
-                    self._subscribable = subscribable;
-                }
+                self._subscribable = subscribable;
             } else {
                 self['$parents'] = [];
                 self['$root'] = dataItem;
@@ -76,35 +73,43 @@
         var self = this,
             isFunc = typeof(dataItemOrAccessor) == "function" && !ko.isObservable(dataItemOrAccessor),
             nodes,
+            subscribable;
+
+        if (options && options['exportDependencies']) {
+            // The "exportDependencies" option means that the calling code will track any dependencies and re-create
+            // the binding context when they change.
+            updateContext();
+        } else {
             subscribable = ko.dependentObservable(updateContext, null, { disposeWhen: disposeWhen, disposeWhenNodeIsRemoved: true });
 
-        // At this point, the binding context has been initialized, and the "subscribable" computed observable is
-        // subscribed to any observables that were accessed in the process. If there is nothing to track, the
-        // computed will be inactive, and we can safely throw it away. If it's active, the computed is stored in
-        // the context object.
-        if (subscribable.isActive()) {
-            self._subscribable = subscribable;
+            // At this point, the binding context has been initialized, and the "subscribable" computed observable is
+            // subscribed to any observables that were accessed in the process. If there is nothing to track, the
+            // computed will be inactive, and we can safely throw it away. If it's active, the computed is stored in
+            // the context object.
+            if (subscribable.isActive()) {
+                self._subscribable = subscribable;
 
-            // Always notify because even if the model ($data) hasn't changed, other context properties might have changed
-            subscribable['equalityComparer'] = null;
+                // Always notify because even if the model ($data) hasn't changed, other context properties might have changed
+                subscribable['equalityComparer'] = null;
 
-            // We need to be able to dispose of this computed observable when it's no longer needed. This would be
-            // easy if we had a single node to watch, but binding contexts can be used by many different nodes, and
-            // we cannot assume that those nodes have any relation to each other. So instead we track any node that
-            // the context is attached to, and dispose the computed when all of those nodes have been cleaned.
+                // We need to be able to dispose of this computed observable when it's no longer needed. This would be
+                // easy if we had a single node to watch, but binding contexts can be used by many different nodes, and
+                // we cannot assume that those nodes have any relation to each other. So instead we track any node that
+                // the context is attached to, and dispose the computed when all of those nodes have been cleaned.
 
-            // Add properties to *subscribable* instead of *self* because any properties added to *self* may be overwritten on updates
-            nodes = [];
-            subscribable._addNode = function(node) {
-                nodes.push(node);
-                ko.utils.domNodeDisposal.addDisposeCallback(node, function(node) {
-                    ko.utils.arrayRemoveItem(nodes, node);
-                    if (!nodes.length) {
-                        subscribable.dispose();
-                        self._subscribable = subscribable = undefined;
-                    }
-                });
-            };
+                // Add properties to *subscribable* instead of *self* because any properties added to *self* may be overwritten on updates
+                nodes = [];
+                subscribable._addNode = function(node) {
+                    nodes.push(node);
+                    ko.utils.domNodeDisposal.addDisposeCallback(node, function(node) {
+                        ko.utils.arrayRemoveItem(nodes, node);
+                        if (!nodes.length) {
+                            subscribable.dispose();
+                            self._subscribable = subscribable = undefined;
+                        }
+                    });
+                };
+            }
         }
     }
 
@@ -113,7 +118,7 @@
     // But this does not mean that the $data value of the child context will also get updated. If the child
     // view model also depends on the parent view model, you must provide a function that returns the correct
     // view model on each update.
-    ko.bindingContext.prototype['createChildContext'] = function (dataItemOrAccessor, dataItemAlias, extendCallback) {
+    ko.bindingContext.prototype['createChildContext'] = function (dataItemOrAccessor, dataItemAlias, extendCallback, options) {
         return new ko.bindingContext(dataItemOrAccessor, this, dataItemAlias, function(self, parentContext) {
             // Extend the context hierarchy by setting the appropriate pointers
             self['$parentContext'] = parentContext;
@@ -122,7 +127,7 @@
             self['$parents'].unshift(self['$parent']);
             if (extendCallback)
                 extendCallback(self);
-        });
+        }, options);
     };
 
     // Extend the binding context with new custom properties. This doesn't change the context hierarchy.
@@ -137,6 +142,10 @@
             self['$rawData'] = parentContext['$rawData'];
             ko.utils.extend(self, typeof(properties) == "function" ? properties() : properties);
         });
+    };
+
+    ko.bindingContext.prototype.createStaticChildContext = function (dataItemOrAccessor, dataItemAlias) {
+        return this['createChildContext'](dataItemOrAccessor, dataItemAlias, null, { "exportDependencies": true });
     };
 
     // Returns the valueAccesor function for a binding value

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -20,7 +20,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
                         if (!isFirstRender) {
                             ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
                         }
-                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, dataValue) : bindingContext, element);
+                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, valueAccessor) : bindingContext, element);
                     } else {
                         ko.virtualElements.emptyNode(element);
                     }

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -5,7 +5,8 @@ function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
             var didDisplayOnLastUpdate,
                 savedNodes;
             ko.computed(function() {
-                var dataValue = ko.utils.unwrapObservable(valueAccessor()),
+                var rawValue = valueAccessor(),
+                    dataValue = ko.utils.unwrapObservable(rawValue),
                     shouldDisplay = !isNot !== !dataValue, // equivalent to isNot ? !dataValue : !!dataValue
                     isFirstRender = !savedNodes,
                     needsRefresh = isFirstRender || isWith || (shouldDisplay !== didDisplayOnLastUpdate);
@@ -20,7 +21,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
                         if (!isFirstRender) {
                             ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
                         }
-                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, valueAccessor) : bindingContext, element);
+                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, rawValue) : bindingContext, element);
                     } else {
                         ko.virtualElements.emptyNode(element);
                     }
@@ -40,6 +41,6 @@ makeWithIfBinding('if');
 makeWithIfBinding('ifnot', false /* isWith */, true /* isNot */);
 makeWithIfBinding('with', true /* isWith */, false /* isNot */,
     function(bindingContext, dataValue) {
-        return bindingContext['createChildContext'](dataValue);
+        return bindingContext.createStaticChildContext(dataValue);
     }
 );

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -282,6 +282,7 @@ var computedFn = {
             }
 
             state.latestValue = newValue;
+            if (DEBUG) computedObservable._latestValue = newValue;
 
             if (state.isSleeping) {
                 computedObservable.updateVersion();

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -210,7 +210,8 @@ var computedFn = {
     evaluateImmediate: function (notifyChange) {
         var computedObservable = this,
             state = computedObservable[computedState],
-            disposeWhen = state.disposeWhen;
+            disposeWhen = state.disposeWhen,
+            changed = false;
 
         if (state.isBeingEvaluated) {
             // If the evaluation of a ko.computed causes side effects, it's possible that it will trigger its own re-evaluation.
@@ -238,7 +239,7 @@ var computedFn = {
 
         state.isBeingEvaluated = true;
         try {
-            this.evaluateImmediate_CallReadWithDependencyDetection(notifyChange);
+            changed = this.evaluateImmediate_CallReadWithDependencyDetection(notifyChange);
         } finally {
             state.isBeingEvaluated = false;
         }
@@ -246,6 +247,8 @@ var computedFn = {
         if (!state.dependenciesCount) {
             computedObservable.dispose();
         }
+
+        return changed;
     },
     evaluateImmediate_CallReadWithDependencyDetection: function (notifyChange) {
         // This function is really just part of the evaluateImmediate logic. You would never call it from anywhere else.
@@ -253,7 +256,8 @@ var computedFn = {
         // which contributes to saving about 40% off the CPU overhead of computed evaluation (on V8 at least).
 
         var computedObservable = this,
-            state = computedObservable[computedState];
+            state = computedObservable[computedState],
+            changed = false;
 
         // Initially, we assume that none of the subscriptions are still being used (i.e., all are candidates for disposal).
         // Then, during evaluation, we cross off any that are in fact still being used.
@@ -289,11 +293,15 @@ var computedFn = {
             } else if (notifyChange) {
                 computedObservable["notifySubscribers"](state.latestValue);
             }
+
+            changed = true;
         }
 
         if (isInitial) {
             computedObservable["notifySubscribers"](state.latestValue, "awake");
         }
+
+        return changed;
     },
     evaluateImmediate_CallReadThenEndDependencyDetection: function (state, dependencyDetectionContext) {
         // This function is really part of the evaluateImmediate_CallReadWithDependencyDetection logic.
@@ -367,8 +375,9 @@ var pureComputedOverrides = {
                 state.dependencyTracking = null;
                 state.dependenciesCount = 0;
                 state.isStale = true;
-                computedObservable.evaluateImmediate();
-                computedObservable.updateVersion();
+                if (computedObservable.evaluateImmediate()) {
+                    computedObservable.updateVersion();
+                }
             } else {
                 // First put the dependencies in order
                 var dependeciesOrder = [];

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -368,6 +368,7 @@ var pureComputedOverrides = {
                 state.dependenciesCount = 0;
                 state.isStale = true;
                 computedObservable.evaluateImmediate();
+                computedObservable.updateVersion();
             } else {
                 // First put the dependencies in order
                 var dependeciesOrder = [];

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -15,6 +15,7 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         cachedDiff = null,
         arrayChangeSubscription,
         pendingNotifications = 0,
+        underlyingNotifySubscribersFunction,
         underlyingBeforeSubscriptionAddFunction = target.beforeSubscriptionAdd,
         underlyingAfterSubscriptionRemoveFunction = target.afterSubscriptionRemove;
 
@@ -31,6 +32,10 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         if (underlyingAfterSubscriptionRemoveFunction)
             underlyingAfterSubscriptionRemoveFunction.call(target, event);
         if (event === arrayChangeEventName && !target.hasSubscriptionsForEvent(arrayChangeEventName)) {
+            if (underlyingNotifySubscribersFunction) {
+                target['notifySubscribers'] = underlyingNotifySubscribersFunction;
+                underlyingNotifySubscribersFunction = undefined;
+            }
             arrayChangeSubscription.dispose();
             trackingChanges = false;
         }
@@ -45,7 +50,7 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
         trackingChanges = true;
 
         // Intercept "notifySubscribers" to track how many times it was called.
-        var underlyingNotifySubscribersFunction = target['notifySubscribers'];
+        underlyingNotifySubscribersFunction = target['notifySubscribers'];
         target['notifySubscribers'] = function(valueToNotify, event) {
             if (!event || event === defaultEvent) {
                 ++pendingNotifications;

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -142,9 +142,14 @@
             return ko.dependentObservable( // So the DOM is automatically updated when any dependency changes
                 function () {
                     // Ensure we've got a proper binding context to work with
-                    var bindingContext = (dataOrBindingContext && (dataOrBindingContext instanceof ko.bindingContext))
-                        ? dataOrBindingContext
-                        : new ko.bindingContext(ko.utils.unwrapObservable(dataOrBindingContext));
+                    var bindingContext;
+                    if (dataOrBindingContext instanceof ko.bindingContext) {
+                        bindingContext = dataOrBindingContext;
+                    } else {
+                        // Create dependency so that a new context is created when data updates
+                        ko.utils.unwrapObservable(dataOrBindingContext);
+                        bindingContext = new ko.bindingContext(dataOrBindingContext);
+                    }
 
                     var templateName = resolveTemplateName(template, bindingContext['$data'], bindingContext),
                         renderedNodesArray = executeTemplate(targetNodeOrNodeArray, renderMode, templateName, bindingContext, options);
@@ -245,7 +250,6 @@
         },
         'update': function (element, valueAccessor, allBindings, viewModel, bindingContext) {
             var value = valueAccessor(),
-                dataValue,
                 options = ko.utils.unwrapObservable(value),
                 shouldDisplay = true,
                 templateComputed = null,
@@ -263,7 +267,8 @@
                 if (shouldDisplay && 'ifnot' in options)
                     shouldDisplay = !ko.utils.unwrapObservable(options['ifnot']);
 
-                dataValue = ko.utils.unwrapObservable(options['data']);
+                // Create dependency on template view model to re-render when it mutates:
+                ko.utils.unwrapObservable(options['data']);
             }
 
             if ('foreach' in options) {
@@ -275,7 +280,7 @@
             } else {
                 // Render once for this single data point (or use the viewModel if no data was provided)
                 var innerBindingContext = ('data' in options) ?
-                    bindingContext['createChildContext'](dataValue, options['as']) :  // Given an explitit 'data' value, we create a child binding context for it
+                    bindingContext['createChildContext'](options['data'], options['as']) :  // Given an explitit 'data' value, we create a child binding context for it
                     bindingContext;                                                        // Given no explicit 'data' value, we retain the same binding context
                 templateComputed = ko.renderTemplate(templateName || element, innerBindingContext, options, element);
             }


### PR DESCRIPTION
I would like suggest to extend signature of the afterRender callback method to make a bit more informative while rendering foreach: {} constructs. Long story short on line 4988 i propose to add two additional arguments to the call so instead of current:
>>>   options["afterRender"] (addedNodesArray, arrayValue);
it would say something like following:
>>>   afterRender.call((arrayItemContext.$root || this), addedNodesArray, arrayValue, arrayItemContext, index);
in this case actual afterRender function is aware of the data-binding context