### PR TITLE
Add the 'symbol' primitive type checks to ko.toJS mapping function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - 4.0

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
   "homepage": "http://knockoutjs.com/",
   "version": "3.5.0-pre",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "license": "MIT",
   "author": "The Knockout.js team",
   "main": "build/output/knockout-latest.debug.js",

--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -43,6 +43,15 @@ describe('Mapping helpers', function() {
         expect(result.b.b2[1]).toEqual('X');
     });
 
+    it('ko.toJS should unwrap symbol primitives', function() {
+        var symbol = Symbol();
+        var result = ko.toJS({
+            symbol: ko.observable(symbol)
+        });
+
+        expect(result.symbol).toEqual(symbol);
+    });
+
     it('ko.toJS should unwrap observable arrays and things inside them', function() {
         var data = ko.observableArray(['a', 1, { someProp : ko.observable('Hey') }]);
         var result = ko.toJS(data);

--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -39,6 +39,7 @@
                 case "number":
                 case "string":
                 case "function":
+                case "symbol":
                     outputProperties[indexer] = propertyValue;
                     break;
                 case "object":


### PR DESCRIPTION
Previously, symbol properties were being getting stripped from objects.

I've added one passing test to check this behaviour.