### PR TITLE
Add template literal parsing to expressionRewriting

### DIFF
--- a/spec/expressionRewritingBehaviors.js
+++ b/spec/expressionRewritingBehaviors.js
@@ -22,12 +22,24 @@ describe('Expression Rewriting', function() {
     });
 
     it('Should be able to parse object literals containing string literals', function() {
-        var result = ko.expressionRewriting.parseObjectLiteral("a: \"comma, colon: brace{ bracket[ apos' escapedQuot\\\" end\", b: 'escapedApos\\\' brace} bracket] quot\"'");
-        expect(result.length).toEqual(2);
+        var result = ko.expressionRewriting.parseObjectLiteral(
+          // double quotes
+          "a: \"comma, colon: brace{ bracket[ apos' backtick` escapedQuot\\\" end\"," +
+          // single quotes
+          "b: 'escapedApos\\\' backtick` brace} bracket] quot\"'," +
+          // template literals
+          "c: `escapedBacktick\\\` comma, colon: brace{ bracket[ apos', quot\"`"
+        );
+        expect(result.length).toEqual(3);
+        // double quotes
         expect(result[0].key).toEqual("a");
-        expect(result[0].value).toEqual("\"comma, colon: brace{ bracket[ apos' escapedQuot\\\" end\"");
+        expect(result[0].value).toEqual("\"comma, colon: brace{ bracket[ apos' backtick` escapedQuot\\\" end\"");
+        // single quotes
         expect(result[1].key).toEqual("b");
-        expect(result[1].value).toEqual("'escapedApos\\\' brace} bracket] quot\"'");
+        expect(result[1].value).toEqual("'escapedApos\\\' backtick` brace} bracket] quot\"'");
+        // template literals
+        expect(result[2].key).toEqual("c");
+        expect(result[2].value).toEqual("`escapedBacktick\\\` comma, colon: brace{ bracket[ apos', quot\"`");
     });
 
     it('Should be able to parse object literals containing child objects, arrays, function literals, and newlines', function() {

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -15,15 +15,16 @@ ko.expressionRewriting = (function () {
 
     // The following regular expressions will be used to split an object-literal string into tokens
 
-        // These two match strings, either with double quotes or single quotes
+        // These three match strings, either with double quotes or single quotes or template literals
     var stringDouble = '"(?:[^"\\\\]|\\\\.)*"',
         stringSingle = "'(?:[^'\\\\]|\\\\.)*'",
+        stringTemplate = "`(?:[^`\\\\]|\\\\.)*`",
         // Matches a regular expression (text enclosed by slashes), but will also match sets of divisions
         // as a regular expression (this is handled by the parsing loop below).
         stringRegexp = '/(?:[^/\\\\]|\\\\.)*/\w*',
         // These characters have special meaning to the parser and must not appear in the middle of a
         // token, except as part of a string.
-        specials = ',"\'{}()/:[\\]',
+        specials = ',"\'`{}()/:[\\]',
         // Match text (at least two characters) that does not contain any of the above special characters,
         // although some of the special characters are allowed to start it (all but the colon and comma).
         // The text can contain spaces, but leading or trailing spaces are skipped.
@@ -34,7 +35,7 @@ ko.expressionRewriting = (function () {
         oneNotSpace = '[^\\s]',
 
         // Create the actual regular expression by or-ing the above strings. The order is important.
-        bindingToken = RegExp(stringDouble + '|' + stringSingle + '|' + stringRegexp + '|' + everyThingElse + '|' + oneNotSpace, 'g'),
+        bindingToken = RegExp(stringDouble + '|' + stringSingle + '|' + stringTemplate + '|' + stringRegexp + '|' + everyThingElse + '|' + oneNotSpace, 'g'),
 
         // Match end of previous token to determine whether a slash is a division or regex.
         divisionLookBehind = /[\])"'A-Za-z0-9_$]+$/,


### PR DESCRIPTION
Currently, Knockout does not parse ES2015 [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) correctly. E.g., this does not work:

``` html
<div data-bind="a: `Hello, world!`"></div>
```

The reason it fails to parse should be obvious: the backtick is considered as part of an un-quoted string instead of string literal syntax, and so the comma in the middle gets picked up by the expression rewriter as an indication of a new binding attribute. Thus, the expression rewriter would parse the above as:

``` javascript
[
  { key: 'a', value: '`Hello' },
  { unknown: 'world!`' }
]
```

While it _should_ parse it as:

``` javascript
[
  { key: 'c', value: '`Hello, world!`' }
]
```

This PR augments the `expressionRewritingBehaviors#Should be able to parse object literals containing string literals` spec with a check for template literals, and augments the expressionRewriter with the ability to parse template literals correctly.

Let me know if I need to do anything else to get this merged in!
