### PR TITLE
Update isComputed evaluation

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -1,6 +1,6 @@
 var computedState = ko.utils.createSymbolOrString('_state');
 
-ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget, options) {
+ko.originalComputed = ko.computed = ko.dependentObservable = function (evaluatorFunctionOrOptions, evaluatorFunctionTarget, options) {
     if (typeof evaluatorFunctionOrOptions === "object") {
         // Single-parameter syntax - everything is on this "options" param
         options = evaluatorFunctionOrOptions;
@@ -448,7 +448,7 @@ ko.computed[protoProp] = ko.observable;
 computedFn[protoProp] = ko.computed;
 
 ko.isComputed = function (instance) {
-    return ko.hasPrototype(instance, ko.computed);
+    return ko.hasPrototype(instance, ko.originalComputed);
 };
 
 ko.isPureComputed = function (instance) {


### PR DESCRIPTION
When knockout.mapping is used, it replaces ko.computed with its own definition of ko.computed, and ends up causing isComputed to return incorrect results (ie true for computed observables). This patch introduces a new ko.originalComputed variable that should not be overwritten/reassigned, and is used in the evaluation of isComputed.