### PR TITLE
Add the optionsSort binding

### DIFF
--- a/spec/defaultBindings/optionsBehaviors.js
+++ b/spec/defaultBindings/optionsBehaviors.js
@@ -68,6 +68,17 @@ describe('Binding: Options', function() {
         expect(testNode.childNodes[0]).toHaveValues(["bob", "frank"]);
     });
 
+    it('Given the optionsSort binding, should sort options by text alphabetically', function() {
+        var modelValues = new ko.observableArray([
+            { name: 'frank' },
+            { name: 'Al' },
+            { name: 'aaron' }
+        ]);
+        testNode.innerHTML = "<select data-bind='options: myValues, optionsText: \"name\", optionsSort: true'></select>";
+        ko.applyBindings({ myValues: modelValues }, testNode);
+        expect(testNode.childNodes[0]).toHaveTexts(["aaron", "Al", "frank"]);
+    });
+
     it('Should update the SELECT node\'s options if the model changes', function () {
         var observable = new ko.observableArray(["A", "B", "C"]);
         testNode.innerHTML = "<select data-bind='options:myValues'><option>should be deleted</option></select>";

--- a/src/binding/defaultBindings/options.js
+++ b/src/binding/defaultBindings/options.js
@@ -45,6 +45,19 @@ ko.bindingHandlers['options'] = {
                 return includeDestroyed || item === undefined || item === null || !ko.utils.unwrapObservable(item['_destroy']);
             });
 
+            if (allBindings.get('optionsSort')) {
+                filteredArray.sort(function (a, b) {
+                    var aText = optionText(a);
+                    var bText = optionText(b);
+                    var language = (navigator.language || navigator.userLanguage);
+                    return aText.toString().localeCompare(bText.toString(), language, { 'sensitivity': 'base' });
+
+                    function optionText(item) {
+                        return applyToObject(item, allBindings.get('optionsText'), item) || '';
+                    };
+                });
+            }
+
             // If caption is included, add it to the array
             if (allBindings['has']('optionsCaption')) {
                 captionValue = ko.utils.unwrapObservable(allBindings.get('optionsCaption'));


### PR DESCRIPTION
By including the `optionsSort` binding with the `options` binding, the dropdown list will show its items sorted by text alphabetically, ignorant of case.