### PR TITLE
export ko.expressionRewriting.writeValueToProperty

### DIFF
--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -193,6 +193,7 @@ ko.exportSymbol('expressionRewriting.preProcessBindings', ko.expressionRewriting
 // undocumented feature that makes it relatively easy to upgrade to KO 3.0. However, this is still not an official
 // public API, and we reserve the right to remove it at any time if we create a real public property writers API.
 ko.exportSymbol('expressionRewriting._twoWayBindings', ko.expressionRewriting.twoWayBindings);
+ko.exportSymbol('expressionRewriting._writeValueToProperty', ko.expressionRewriting.writeValueToProperty);
 
 // For backward compatibility, define the following aliases. (Previously, these function names were misleading because
 // they referred to JSON specifically, even though they actually work with arbitrary JavaScript object literal expressions.)


### PR DESCRIPTION
it's a useful utility function that I use a lot throughout my project since working with knockout-es5. If it is not exported I basically need to copy it 1:1 which is not DRY.