### PR TITLE
Computed observable memory leak fix

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -83,9 +83,10 @@ describe('Dependent Observable', function() {
     it('Should use options.owner as "this" when invoking the "write" callback, and can pass multiple parameters', function() {
         var invokedWriteWithArgs, invokedWriteWithThis;
         var someOwner = {};
+        var observable = ko.observable();
         var instance = ko.computed({
-            read: function() {},
-            write: function() { invokedWriteWithArgs = Array.prototype.slice.call(arguments, 0); invokedWriteWithThis = this; },
+            read: function() {return observable()},
+            write: function() {observable(null); invokedWriteWithArgs = Array.prototype.slice.call(arguments, 0); invokedWriteWithThis = this; },
             owner: someOwner
         });
 
@@ -99,9 +100,10 @@ describe('Dependent Observable', function() {
 
     it('Should use the second arg (evaluatorFunctionTarget) for "this" when calling read/write if no options.owner was given', function() {
         var expectedThis = {}, actualReadThis, actualWriteThis;
+        var observable = ko.observable();
         var instance = ko.computed({
-            read: function() { actualReadThis = this },
-            write: function() { actualWriteThis = this }
+            read: function() { actualReadThis = this; return observable(); },
+            write: function() { actualWriteThis = this; observable(null); }
         }, expectedThis);
 
         instance("force invocation of write");

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -362,6 +362,8 @@ var computedFn = {
         state.isSleeping = false;
         state.disposeWhenNodeIsRemoved = null;
         state.evaluatorFunctionTarget = null;
+        if (DEBUG)
+          this["_options"].owner = null;
     }
 };
 

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -362,8 +362,12 @@ var computedFn = {
         state.isSleeping = false;
         state.disposeWhenNodeIsRemoved = null;
         state.evaluatorFunctionTarget = null;
-        if (DEBUG)
+        state.readFunction = null;
+        if (DEBUG) {
           this["_options"].owner = null;
+          this["_options"].read = null;
+          this["_options"].write = null;
+        }
     }
 };
 

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -361,6 +361,7 @@ var computedFn = {
         state.isStale = false;
         state.isSleeping = false;
         state.disposeWhenNodeIsRemoved = null;
+        state.evaluatorFunctionTarget = null;
     }
 };
 


### PR DESCRIPTION
The dispose method of `ko.computed` should release a link to the owner (vel `evaluatorFunctionTarget`).
