### PR TITLE
Added predicate object match for arrayFirst like lodash find()

### DIFF
--- a/spec/utilsBehaviors.js
+++ b/spec/utilsBehaviors.js
@@ -148,6 +148,48 @@ describe('arrayFirst', function () {
         expect(matchD.calls[1].args).toEqual(["b", 1]);
         expect(matchD.calls[2].args).toEqual(["c", 2]);
     });
+
+    it('Should match no non-objects with object match', function () {
+        var result = ko.utils.arrayFirst(["a", "b", "c"], { a: 2 });
+
+        expect(result).toBe(null);
+    });
+
+    it('Should match objects with when all keys in predicate object matches', function () {
+        var obj = { a: 2 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2 });
+        expect(result).toBe(obj);
+
+        obj = { a: 2, b: 3 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2 });
+        expect(result).toBe(obj);
+
+        obj = { a: 2 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2, b: 3 });
+        expect(result).toBe(null);
+
+        obj = { a: 2, b: 4 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2, b: 3 });
+        expect(result).toBe(null);
+
+        obj = { a: 2, b: 3 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2, b: 3 });
+        expect(result).toBe(obj);
+    });
+
+    it('Should match first objects when predicate is empty object', function () {
+        obj = { a: 2 };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { });
+
+        expect(result).toBe(obj);
+    });
+
+    it('Should unwrap array item values prior to matching with predicate object', function () {
+        obj = { a: ko['observable'](2) };
+        var result = ko.utils.arrayFirst(["a", "b", obj], { a: 2 });
+
+        expect(result).toBe(obj);
+    });
 });
 
 describe('arrayGetDistinctValues', function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,9 +112,25 @@ ko.utils = (function () {
         },
 
         arrayFirst: function (array, predicate, predicateOwner) {
-            for (var i = 0, j = array.length; i < j; i++)
-                if (predicate.call(predicateOwner, array[i], i))
-                    return array[i];
+            if (typeof predicate === 'function') {
+                for (var i = 0, j = array.length; i < j; i++)
+                    if (predicate.call(predicateOwner, array[i], i))
+                        return array[i];
+            } else if (typeof predicate === 'object') {
+                for (var i = 0, j = array.length; i < j; i++) {
+                    if (typeof array[i] === 'object') {
+                        var allTrue = true;
+                        var key;
+                        for (key in predicate) {
+                            if (predicate.hasOwnProperty(key))
+                                allTrue = allTrue && predicate[key] === ko['unwrap'](array[i][key]);
+                            if (!allTrue) break;
+                        }
+
+                        if (allTrue) return array[i];
+                    }
+                }
+            }
             return null;
         },
 


### PR DESCRIPTION
E.g. 

```
ko.utils.arrayFirst(this.categories(), { id: 4 });
```

This is useful for determining of new data should be added to an array.

Specs, updated.