### PR TITLE
Changes to make knockout more CSP compliant

### DIFF
--- a/build/fragments/extern-pre.js
+++ b/build/fragments/extern-pre.js
@@ -1,7 +1,7 @@
 (function(undefined){
     // (0, eval)('this') is a robust way of getting a reference to the global object
     // For details, see http://stackoverflow.com/questions/14119988/return-this-0-evalthis/14120023#14120023
-    var window = this || (0, eval)('this'),
+    var window = this || Function.apply(this, ['return this']).apply(this),
         document = window['document'],
         navigator = window['navigator'],
         jQueryInstance = window["jQuery"],

--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -66,7 +66,7 @@
         // Example result: with(sc1) { with(sc0) { return (expression) } }
         var rewrittenBindings = ko.expressionRewriting.preProcessBindings(bindingsString, options),
             functionBody = "with($context){with($data||{}){return{" + rewrittenBindings + "}}}";
-        return new Function("$context", "$element", functionBody);
+        return Function.apply(this, ["$context", "$element", functionBody]);
     }
 })();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -522,7 +522,6 @@ ko.utils = (function () {
                 if (jsonString) {
                     if (JSON && JSON.parse) // Use native parsing where available
                         return JSON.parse(jsonString);
-                    return (new Function("return " + jsonString))(); // Fallback on less safe parsing for older browsers
                 }
             }
             return null;


### PR DESCRIPTION
Used native JSON parsing as almost every modern browser supports it.
Replaced instance of `new Function` with `Function.apply`