### PR TITLE
Added bindingInfo to binding exception

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -391,6 +391,7 @@
                         );
                     }
                 } catch (ex) {
+                    ex.bindingInfo = { context: bindingContext, node: node };
                     ex.message = "Unable to process binding \"" + bindingKey + ": " + bindings[bindingKey] + "\"\nMessage: " + ex.message;
                     throw ex;
                 }


### PR DESCRIPTION
Added DOM element node and binding context info to 'unable to process binding' exception.
With this change we can retrieve more info in exception management:

For example: viewmodel constructor and failing dom element node.
ko.onError = function(e){
	console.log({ viewModel : e.bindingInfo.context["$component"].constructor , node :   e.bindingInfo.node });
}