### PR TITLE
Improved extend function using MDN reference

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,13 +8,17 @@ ko.utils = (function () {
     }
 
     function extend(target, source) {
-        if (source) {
-            for(var prop in source) {
-                if(source.hasOwnProperty(prop)) {
-                    target[prop] = source[prop];
-                }
+        var descriptors = Object.keys(source).reduce(function(descriptors, key) {
+            descriptors[key] = Object.getOwnPropertyDescriptor(source, key);
+            return descriptors;
+        }, {});
+        Object.getOwnPropertySymbols(source).forEach(function(sym) {
+            var descriptor = Object.getOwnPropertyDescriptor(source, sym);
+            if (descriptor.enumerable) {
+                descriptors[sym] = descriptor;
             }
-        }
+        });
+        Object.defineProperties(target, descriptors);
         return target;
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,8 @@ ko.utils = (function () {
     }
 
     function extend(target, source) {
-        var descriptors = Object.keys(source).reduce(function(descriptors, key) {
+        if(source){
+            var descriptors = Object.keys(source).reduce(function(descriptors, key) {
             descriptors[key] = Object.getOwnPropertyDescriptor(source, key);
             return descriptors;
         }, {});
@@ -18,7 +19,7 @@ ko.utils = (function () {
                 descriptors[sym] = descriptor;
             }
         });
-        Object.defineProperties(target, descriptors);
+        Object.defineProperties(target, descriptors);}
         return target;
     }
 


### PR DESCRIPTION
Improved extend function to also copy accessors while copying the objects.
Source: [MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Copying_accessors)