### PR TITLE
Convert function declaration inside if statement into expression

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -339,9 +339,9 @@
                 };
 
             // Use of allBindings as a function is maintained for backwards compatibility, but its use is deprecated
-            function allBindings() {
+            var allBindings = function() {
                 return ko.utils.objectMap(bindingsUpdater ? bindingsUpdater() : bindings, evaluateValueAccessor);
-            }
+            };
             // The following is the 3.x allBindings API
             allBindings['get'] = function(key) {
                 return bindings[key] && evaluateValueAccessor(getValueAccessor(key));


### PR DESCRIPTION
In strict mode, function declarations are only allowed at the top level of the corresponding scope. The changes in this PR should make knockout bundle-able with other strict mode code.
