### PR TITLE
observables notify a "spectate" event whenever their value changes.

### DIFF
--- a/spec/dependentObservableBehaviors.js
+++ b/spec/dependentObservableBehaviors.js
@@ -211,6 +211,19 @@ describe('Dependent Observable', function() {
         expect(notifiedValue).toEqual(3);
     });
 
+    it('Should notify "spectator" subscribers about changes', function () {
+        var observable = new ko.observable();
+        var computed = ko.computed(function () { return observable(); });
+        var notifiedValues = [];
+        computed.subscribe(function (value) {
+            notifiedValues.push(value);
+        }, null, "spectate");
+
+        observable('A');
+        observable('B');
+        expect(notifiedValues).toEqual([ 'A', 'B' ]);
+    });
+
     it('Should notify "beforeChange" subscribers before changes', function () {
         var notifiedValue;
         var observable = new ko.observable(1);

--- a/spec/observableBehaviors.js
+++ b/spec/observableBehaviors.js
@@ -100,10 +100,19 @@ describe('Observable', function() {
 
         instance('A');
         instance('B');
+        expect(notifiedValues).toEqual([ 'A', 'B' ]);
+    });
 
-        expect(notifiedValues.length).toEqual(2);
-        expect(notifiedValues[0]).toEqual('A');
-        expect(notifiedValues[1]).toEqual('B');
+    it('Should notify "spectator" subscribers about each new value', function () {
+        var instance = new ko.observable();
+        var notifiedValues = [];
+        instance.subscribe(function (value) {
+            notifiedValues.push(value);
+        }, null, "spectate");
+
+        instance('A');
+        instance('B');
+        expect(notifiedValues).toEqual([ 'A', 'B' ]);
     });
 
     it('Should be able to tell it that its value has mutated, at which point it notifies subscribers', function () {
@@ -288,11 +297,13 @@ describe('Observable', function() {
         };
         instance(456);
 
-        expect(interceptedNotifications.length).toEqual(2);
-        expect(interceptedNotifications[0].eventName).toEqual("beforeChange");
-        expect(interceptedNotifications[1].eventName).toEqual("None");
-        expect(interceptedNotifications[0].value).toEqual(123);
-        expect(interceptedNotifications[1].value).toEqual(456);
+        // This represents the current set of events that are generated for an observable. This set might
+        // expand in the future.
+        expect(interceptedNotifications).toEqual([
+            { eventName: 'beforeChange', value: 123 },
+            { eventName: 'spectate', value: 456 },
+            { eventName: 'None', value: 456 }
+        ]);
     });
 
     it('Should inherit any properties defined on ko.subscribable.fn or ko.observable.fn', function() {

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -81,6 +81,31 @@ describe('Pure Computed', function() {
         expect(timesEvaluated).toEqual(3);
     });
 
+    it('Should notify "spectator" subscribers whenever the value changes', function () {
+        var observable = new ko.observable('A');
+        var computed = ko.pureComputed(function () { return observable(); });
+        var notifiedValues = [];
+        computed.subscribe(function (value) {
+            notifiedValues.push(value);
+        }, null, "spectate");
+
+        expect(notifiedValues).toEqual([]);
+
+        // Reading the computed for the first time causes a notification
+        expect(computed()).toEqual('A');
+        expect(notifiedValues).toEqual(['A']);
+
+        // Reading it a second time doesn't
+        expect(computed()).toEqual('A');
+        expect(notifiedValues).toEqual(['A']);
+
+        // Changing the dependency doesn't, but reading the computed again does
+        observable('B');
+        expect(notifiedValues).toEqual(['A']);
+        expect(computed()).toEqual('B');
+        expect(notifiedValues).toEqual(['A', 'B']);
+    });
+
     it('Should not subscribe to dependencies while sleeping', function() {
         var data = ko.observable('A'),
             computed = ko.pureComputed(data);

--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -83,20 +83,25 @@ describe('Pure Computed', function() {
 
     it('Should notify "spectator" subscribers whenever the value changes', function () {
         var observable = new ko.observable('A');
-        var computed = ko.pureComputed(function () { return observable(); });
+        var computed = ko.pureComputed(observable);
+        var computed2 = ko.pureComputed(computed);
         var notifiedValues = [];
         computed.subscribe(function (value) {
             notifiedValues.push(value);
+            expect(computed()).toBe(value);
+            expect(computed2()).toBe(value);
         }, null, "spectate");
 
         expect(notifiedValues).toEqual([]);
 
         // Reading the computed for the first time causes a notification
         expect(computed()).toEqual('A');
+        expect(computed2()).toEqual('A');
         expect(notifiedValues).toEqual(['A']);
 
         // Reading it a second time doesn't
         expect(computed()).toEqual('A');
+        expect(computed2()).toEqual('A');
         expect(notifiedValues).toEqual(['A']);
 
         // Changing the dependency doesn't, but reading the computed again does

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -283,14 +283,16 @@ var computedFn = {
         if (computedObservable.isDifferent(state.latestValue, newValue)) {
             if (!state.isSleeping) {
                 computedObservable["notifySubscribers"](state.latestValue, "beforeChange");
+            } else {
+                computedObservable.updateVersion();
             }
 
             state.latestValue = newValue;
             if (DEBUG) computedObservable._latestValue = newValue;
 
-            if (state.isSleeping) {
-                computedObservable.updateVersion();
-            } else if (notifyChange) {
+            computedObservable["notifySubscribers"](state.latestValue, "spectate");
+
+            if (!state.isSleeping && notifyChange) {
                 computedObservable["notifySubscribers"](state.latestValue);
             }
 

--- a/src/subscribables/observable.js
+++ b/src/subscribables/observable.js
@@ -43,7 +43,10 @@ ko.observable = function (initialValue) {
 var observableFn = {
     'equalityComparer': valuesArePrimitiveAndEqual,
     peek: function() { return this[observableLatestValue]; },
-    valueHasMutated: function () { this['notifySubscribers'](this[observableLatestValue]); },
+    valueHasMutated: function () {
+        this['notifySubscribers'](this[observableLatestValue], 'spectate');
+        this['notifySubscribers'](this[observableLatestValue]);
+    },
     valueWillMutate: function () { this['notifySubscribers'](this[observableLatestValue], 'beforeChange'); }
 };
 


### PR DESCRIPTION
This is like the "change" event but is not delayed by rateLimit/deferred and will notify when a sleeping pure computed observable gets a new value (by being accessed). Subscribing to "spectate" will not awaken a sleeping pure computed either.

See #1735 and #1511