### PR TITLE
Dynamically displayed component being rendered more than once

### DIFF
--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -31,7 +31,7 @@ function limitNotifySubscribers(value, event) {
 
 var ko_subscribable_fn = {
     init: function(instance) {
-        instance._subscriptions = {};
+        instance._subscriptions = { "change": [] };
         instance._versionNumber = 1;
     },
 
@@ -63,9 +63,10 @@ var ko_subscribable_fn = {
             this.updateVersion();
         }
         if (this.hasSubscriptionsForEvent(event)) {
+            var subs = event === defaultEvent && this._changeSubscriptions || this._subscriptions[event].slice(0);
             try {
                 ko.dependencyDetection.begin(); // Begin suppressing dependency detection (by setting the top frame to undefined)
-                for (var a = this._subscriptions[event].slice(0), i = 0, subscription; subscription = a[i]; ++i) {
+                for (var i = 0, subscription; subscription = subs[i]; ++i) {
                     // In case a subscription was disposed during the arrayForEach cycle, check
                     // for isDisposed on each subscription before invoking its callback
                     if (!subscription.isDisposed)
@@ -113,6 +114,7 @@ var ko_subscribable_fn = {
         });
 
         self._limitChange = function(value) {
+            self._changeSubscriptions = self._subscriptions[defaultEvent].slice(0);
             self._notificationIsPending = ignoreBeforeChange = true;
             pendingValue = value;
             finish();


### PR DESCRIPTION
I've been battling this one for a few weeks, and just now got confirmation that someone else was able to reproduce this and I wasn't just going crazy.

The issue arises when I am dynamically displaying a component based on some logic - in this case, I'm parsing the route and grabbing a parameter. When the component is looking at an observable to determine the name, it's being loaded twice in the `getComponent` call and thus my constructor is called twice. If I bind the same form with a literal string, the component only renders once.

Here's an example (it has the same issue even without the outer `if` binding):
```
<!-- WORKS, renders only once -->
<div data-bind='if: currentFormComponent() != null'>
    <div data-bind='component: {name: "my-component", params: { route: pageParams.route }}'></div>
</div>

<!-- Renders twice (currentFormComponent is an observable and is set to "my-component" as above) -->
<div data-bind='if: currentFormComponent() != null'>
    <div data-bind='component: {name: currentFormComponent, params: { route: pageParams.route }}'></div>
</div>
```