### PR TITLE
Remove hidden dev dependency on Java

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.0",
-    "closure-compiler": "~0.2.1"
+    "google-closure-compiler-js": "^20161201.0.0"
   }
 }


### PR DESCRIPTION
Since Java wasn't listed as something I should need to install to build knockout, I've tweaked the build file and dev dependencies to remove the hidden Java dependency. It might be nice to improve the errors/warnings to know which file they originally came from, but right now it's just feature equivalent.