### PR TITLE
Add functionnalities to switch between templateEngine and set custom binding attribute name

### DIFF
--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -1,15 +1,16 @@
 (function() {
     var defaultBindingAttributeName = "data-bind";
-
-    ko.bindingProvider = function() {
+    
+    ko.bindingProvider = function(bindingAttributeName) {
         this.bindingCache = {};
+        this.bindingAttributeName = bindingAttributeName || defaultBindingAttributeName;
     };
 
     ko.utils.extend(ko.bindingProvider.prototype, {
         'nodeHasBindings': function(node) {
             switch (node.nodeType) {
                 case 1: // Element
-                    return node.getAttribute(defaultBindingAttributeName) != null
+                    return node.getAttribute(this.bindingAttributeName) != null
                         || ko.components['getComponentNameForNode'](node);
                 case 8: // Comment node
                     return ko.virtualElements.hasBindingValue(node);
@@ -33,7 +34,7 @@
         // It's not part of the interface definition for a general binding provider.
         'getBindingsString': function(node, bindingContext) {
             switch (node.nodeType) {
-                case 1: return node.getAttribute(defaultBindingAttributeName);   // Element
+                case 1: return node.getAttribute(this.bindingAttributeName);   // Element
                 case 8: return ko.virtualElements.virtualNodeBindingValue(node); // Comment node
                 default: return null;
             }
@@ -49,7 +50,12 @@
                 ex.message = "Unable to parse bindings.\nBindings value: " + bindingsString + "\nMessage: " + ex.message;
                 throw ex;
             }
+        },
+        
+        'setBindingAttributeName': function(attrName) {
+        	this.bindingAttributeName = attrName;
         }
+        
     });
 
     ko.bindingProvider['instance'] = new ko.bindingProvider();

--- a/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
+++ b/src/templating/jquery.tmpl/jqueryTmplTemplateEngine.js
@@ -61,6 +61,8 @@
             document.write("<script type='text/html' id='" + templateName + "'>" + templateMarkup + "<" + "/script>");
         };
 
+        this['contentType'] = "text/jquery-tmpl";
+        
         if (jQueryTmplVersion > 0) {
             jQueryInstance['tmpl']['tag']['ko_code'] = {
                 open: "__.push($1 || '');"
@@ -77,8 +79,11 @@
 
     // Use this one by default *only if jquery.tmpl is referenced*
     var jqueryTmplTemplateEngineInstance = new ko.jqueryTmplTemplateEngine();
-    if (jqueryTmplTemplateEngineInstance.jQueryTmplVersion > 0)
+    if (jqueryTmplTemplateEngineInstance.jQueryTmplVersion > 0) {
         ko.setTemplateEngine(jqueryTmplTemplateEngineInstance);
+        ko.setTemplateEngineContentType(jqueryTmplTemplateEngineInstance.contentType, jqueryTmplTemplateEngineInstance);
+        ko.jqueryTmplTemplateEngine.instance = jqueryTmplTemplateEngineInstance;
+    }
 
     ko.exportSymbol('jqueryTmplTemplateEngine', ko.jqueryTmplTemplateEngine);
 })();

--- a/src/templating/native/nativeTemplateEngine.js
+++ b/src/templating/native/nativeTemplateEngine.js
@@ -17,7 +17,10 @@ ko.nativeTemplateEngine.prototype['renderTemplateSource'] = function (templateSo
     }
 };
 
+ko.nativeTemplateEngine.prototype['contentType'] = "text/ko-template";
+
 ko.nativeTemplateEngine.instance = new ko.nativeTemplateEngine();
 ko.setTemplateEngine(ko.nativeTemplateEngine.instance);
+ko.setTemplateEngineContentType(ko.nativeTemplateEngine.instance.contentType, ko.nativeTemplateEngine.instance);
 
 ko.exportSymbol('nativeTemplateEngine', ko.nativeTemplateEngine);

--- a/src/templating/templateRewriting.js
+++ b/src/templating/templateRewriting.js
@@ -1,6 +1,9 @@
 
 ko.templateRewriting = (function () {
-    var memoizeDataBindingAttributeSyntaxRegex = /(<([a-z]+\d*)(?:\s+(?!data-bind\s*=\s*)[a-z0-9\-]+(?:=(?:\"[^\"]*\"|\'[^\']*\'|[^>]*))?)*\s+)data-bind\s*=\s*(["'])([\s\S]*?)\3/gi;
+    
+    var bindingAttrName = ko.bindingProvider.bindingAttributeName;
+	
+    var memoizeDataBindingAttributeSyntaxRegex = new RegExp("(<([a-z]+\d*)(?:\s+(?!" + bindingAttrName + "\s*=\s*)[a-z0-9\-]+(?:=(?:\"[^\"]*\"|\'[^\']*\'|[^>]*))?)*\s+)" + bindingAttrName + "\s*=\s*([\"'])([\s\S]*?)\3", "gi");
     var memoizeVirtualContainerBindingSyntaxRegex = /<!--\s*ko\b\s*([\s\S]*?)\s*-->/g;
 
     function validateDataBindValuesForRewriting(keyValueArray) {


### PR DESCRIPTION
Hi,

Here two functionnalities with minor changes.

- Use multi-templateEngine

As it is only possible to have only one templateEngine, i've add a functionnality to define which templateEngine using a contentType description.

`<script id="template-test" type="text/ko-template">
// use native templating
</script>`

`<script id="template-test" type="text/jquery-tmpl">
// use jquery-tmpl
</script>`

`<script id="template-test" type="text/custom-tmpl">
// use a custom templateEngine with "text/custom-tmpl" as contentType
</script>`

The way to set the global templateEngine is still the same (as jquery-tmpl autoset if exists)

- Personnalize data binding attribute name

As default knockout binding attribute name is 'data-bind', i've add a way to modify it and use another attribute name, through bindingProvider method

`ko.bindingProvider.instance.setBindingAttributeName('data-app');`

`
<input data-app="..." />
`

I'm waiting for your feedback !
