### PR TITLE
Pure computed briefly serves stale value, when there are no subscriptions to it and when deferUpdates is on.

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -989,7 +989,7 @@ describe('Deferred', function() {
         });
 
         it('Should *not* delay update of dependent deferred computed observable', function () {
-            var data = ko.observable('A'),
+            var data = ko.observable('A').extend({deferred:true}),
                 timesEvaluated = 0,
                 computed1 = ko.computed(function () { return data() + 'X'; }).extend({deferred:true}),
                 computed2 = ko.computed(function () { timesEvaluated++; return computed1() + 'Y'; }).extend({deferred:true}),
@@ -1008,6 +1008,24 @@ describe('Deferred', function() {
             expect(computed2()).toEqual('BXY');
             expect(timesEvaluated).toEqual(2);      // Verify that the computed wasn't evaluated again unnecessarily
             expect(notifySpy.argsForCall).toEqual([ ['BXY'] ]);
+        });
+
+        it('Should *not* delay update of dependent deferred pure computed observable', function () {
+            var data = ko.observable('A').extend({deferred:true}),
+                timesEvaluated = 0,
+                computed1 = ko.pureComputed(function () { return data() + 'X'; }).extend({deferred:true}),
+                computed2 = ko.pureComputed(function () { timesEvaluated++; return computed1() + 'Y'; }).extend({deferred:true});
+
+            expect(computed2()).toEqual('AXY');
+            expect(timesEvaluated).toEqual(1);
+
+            data('B');
+            expect(computed2()).toEqual('BXY');
+            expect(timesEvaluated).toEqual(2);
+
+            jasmine.Clock.tick(1);
+            expect(computed2()).toEqual('BXY');
+            expect(timesEvaluated).toEqual(2);      // Verify that the computed wasn't evaluated again unnecessarily
         });
 
         it('Should *not* delay update of dependent rate-limited computed observable', function() {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -162,7 +162,7 @@ var computedFn = {
         for (id in dependencyTracking) {
             if (Object.prototype.hasOwnProperty.call(dependencyTracking, id)) {
                 dependency = dependencyTracking[id];
-                if (dependency._target.hasChanged(dependency._version)) {
+                if ((this._evalDelayed && dependency._target._notificationIsPending) || dependency._target.hasChanged(dependency._version)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Steps:
1. `git clone https://github.com/d-ph/bug-reproduction-knockout-pure-computed.git`
2. `cd bug-reproduction-knockout-pure-computed`
3. `bower install`
4. Open the `index.html` in Chrome
5. Open dev tools. Go to the Console tab.
6. Run: `knockoutBugReproduction.pageNumber$(3)`

Result:
```
Computed: pageNumber: 3 listener1LocalVarPageNumberPlusTwenty: 0
Listener 1: pageNumber: 3 pageNumberPlusTen: 13 listener1LocalVarPageNumberPlusTwenty: 0
Listener 2: pageNumber: 5 pageNumberPlusTen: 13 listener1LocalVarPageNumberPlusTwenty: 23
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 23
Listener 3: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 23
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 23
Listener 1: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 23
Listener 2: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 25
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 25
Listener 3: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 25
```
Expected result:
```
Computed: pageNumber: 3 listener1LocalVarPageNumberPlusTwenty: 0
Listener 1: pageNumber: 3 pageNumberPlusTen: 13 listener1LocalVarPageNumberPlusTwenty: 0
Listener 2: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 23
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 23
Listener 3: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 23
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 23
Listener 1: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 23
Listener 2: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 25
Computed: pageNumber: 5 listener1LocalVarPageNumberPlusTwenty: 25
Listener 3: pageNumber: 5 pageNumberPlusTen: 15 listener1LocalVarPageNumberPlusTwenty: 25
```
More info:
The third line of the output shows, that for a brief moment, the `pageNumberPlusTen` observable yielded 13 instead of 15. This is not the case, when the `ko.options.deferUpdates` is `false`, or when there is at least one subscriber to that observable (you can test it, by uncommenting `knockout-bug-reproduction.js:44-46`). There is also no issue, if `ko.computed` is used instead of `ko.pureComputed`.

I think, that computed observables should yield the latest values no matter what. I believe the update is scheduled due to `deferUpdates` being on, and that's why the value is correct later.

For now, I'm using `ko.computed`s as a workaround.