### PR TITLE
Array Remove and Observable Cascading

### DIFF
--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -193,6 +193,20 @@ describe('Observable Array', function() {
         expect(notifiedValues).toEqual([[x]]);
     });
 
+    it ('Should throw an exception if matching array item moved or removed during "remove"', function () {
+        testObservableArray(["Alpha", "Beta", "Gamma"]);
+        notifiedValues = [];
+        expect(function () {
+            testObservableArray.remove(function (value) {
+                if (value == "Beta") {
+                    testObservableArray.splice(0, 1);
+                    return true;
+                }
+            });
+        }).toThrow();
+        expect(testObservableArray()).toEqual(["Beta", "Gamma"]);
+    });
+
     it('Should notify subscribers on replace', function () {
         testObservableArray(["Alpha", "Beta", "Gamma"]);
         notifiedValues = [];
@@ -283,6 +297,26 @@ describe('Observable Array', function() {
 
         // Verify that reverse and sort notified their changes
         expect(notifiedValues).toEqual([ [3, 2, 1], [1, 2, 3] ]);
+    });
+
+    it('Should return a new sorted array from "sorted"', function() {
+        // set some unsorted values so we can see that the new array is sorted
+        testObservableArray([ 5, 7, 3, 1 ]);
+        notifiedValues = [];
+
+        var newArray = testObservableArray.sorted();
+        expect(newArray).toEqual([ 1, 3, 5, 7 ]);
+        expect(newArray).not.toBe(testObservableArray());
+
+        expect(notifiedValues).toEqual([]);
+    });
+
+    it('Should return a new reversed array from "reversed"', function() {
+        var newArray = testObservableArray.reversed();
+        expect(newArray).toEqual([ 3, 2, 1 ]);
+        expect(newArray).not.toBe(testObservableArray());
+
+        expect(notifiedValues).toEqual([]);
     });
 
     it('Should inherit any properties defined on ko.subscribable.fn, ko.observable.fn, or ko.observableArray.fn', function() {

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -20,6 +20,9 @@ ko.observableArray['fn'] = {
                 if (removedValues.length === 0) {
                     this.valueWillMutate();
                 }
+                if (underlyingArray[i] !== value) {
+                    throw Error("Array modified during remove; cannot remove item");
+                }
                 removedValues.push(value);
                 underlyingArray.splice(i, 1);
                 i--;
@@ -56,7 +59,7 @@ ko.observableArray['fn'] = {
         for (var i = underlyingArray.length - 1; i >= 0; i--) {
             var value = underlyingArray[i];
             if (predicate(value))
-                underlyingArray[i]["_destroy"] = true;
+                value["_destroy"] = true;
         }
         this.valueHasMutated();
     },
@@ -86,6 +89,14 @@ ko.observableArray['fn'] = {
             this.peek()[index] = newItem;
             this.valueHasMutated();
         }
+    },
+
+    'sorted': function (compareFunction) {
+        return this().slice(0).sort(compareFunction);
+    },
+
+    'reversed': function () {
+        return this().slice(0).reverse();
     }
 };
 


### PR DESCRIPTION
This may not be a bug per se, but it's an edge case that I'd like to submit for consideration.  The essential parts of our case were:

 - Stored objects in a KO array
 - Displayed them in a specific order
 - Occasionally, removed some objects in response to server-side events

... and the essential parts of our (typescript) implementation were:

```
    public regularTasks:KnockoutObservableArray<TaskComponent>;

    public taskUpdateEvent = (data:any):void => {
        if (data['type'] == 'DELETE') {
            this.regularTasks.remove((item) => {
                // This function manages many-to-many relationships.
                // Its return value indicates that the object has no more relations.
                return item.checkForDeletion(data)
            });
    };

    // referenced by HTML code
    public _regularTasksSorted = () => {
        return this.regularTasks().sort(
            function(a:any,b:any):number{
                // The key is that this is computed from the many-to-many relationships.
                // A simple example would be a count of related objects.
                return a.priority()-b.priority()
            }
        );
    };
```

I was troubleshooting a bizarre issue where the wrong items were being removed, exemplified by debug sequences like:

```
initial:
 - generic_commit
 - assess
analyzing for removal: generic_commit
... not eligible for removal
analyzing for removal: assess
... removing
removed:
 - assess
retained:
 - assess
```

After much pain, I figured out that the sort function was to blame.  If I sort and return a **copy** of the array (i.e. `concat` or `slice`), the problem disappeared.  This leads me to believe that the `remove` function is using indexes that are corrupted by the sort.  Presumably this could be reproduced by a trivial example where the remove function deliberately changes indexes.

Certainly a "safer" (if less performant) option would be to track these relationships (in `remove`) using an object reference.