### PR TITLE
Fixed memory leak of previousContents when tracking array changes and disposing the subscription

### DIFF
--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -36,7 +36,8 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
                 target['notifySubscribers'] = underlyingNotifySubscribersFunction;
                 underlyingNotifySubscribersFunction = undefined;
             }
-            arrayChangeSubscription.dispose();
+            if (arrayChangeSubscription)
+	        arrayChangeSubscription.dispose();
             arrayChangeSubscription = null;
             trackingChanges = false;
         }

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -36,8 +36,9 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
                 target['notifySubscribers'] = underlyingNotifySubscribersFunction;
                 underlyingNotifySubscribersFunction = undefined;
             }
-            if (arrayChangeSubscription)
-	        arrayChangeSubscription.dispose();
+            if (arrayChangeSubscription) {
+                arrayChangeSubscription.dispose();
+            }
             arrayChangeSubscription = null;
             trackingChanges = false;
         }

--- a/src/subscribables/observableArray.changeTracking.js
+++ b/src/subscribables/observableArray.changeTracking.js
@@ -37,6 +37,7 @@ ko.extenders['trackArrayChanges'] = function(target, options) {
                 underlyingNotifySubscribersFunction = undefined;
             }
             arrayChangeSubscription.dispose();
+            arrayChangeSubscription = null;
             trackingChanges = false;
         }
     };


### PR DESCRIPTION
The observableArray did leak the last value held by the observable when
subscribing for array change events, and then disposing the subscription.

The vlaue was being held by the closure held by the
arrayChangeSubscription. Setting it to null allows the GC to collect the
closure and the previousContents variable.

This commit fixes #2216