### PR TITLE
Select element doesn't update properly when combined with if binding

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -360,6 +360,11 @@ describe('Binding: Value', function() {
             observable("");
             expect(testNode.childNodes[0].selectedIndex).toEqual(0);
 
+            // Also check that the selection doesn't change later (see https://github.com/knockout/knockout/issues/2218)
+            waits(10);
+            runs(function() {
+                expect(testNode.childNodes[0].selectedIndex).toEqual(0);
+            });
         });
 
         it('Should display the caption when the model value changes to undefined, null, or \"\" when options specified directly', function() {

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -94,20 +94,11 @@ ko.bindingHandlers['value'] = {
                 if (valueHasChanged) {
                     if (tagName === "select") {
                         var allowUnset = allBindings.get('valueAllowUnset');
-                        var applyValueAction = function () {
-                            ko.selectExtensions.writeValue(element, newValue, allowUnset);
-                        };
-                        applyValueAction();
-
+                        ko.selectExtensions.writeValue(element, newValue, allowUnset);
                         if (!allowUnset && newValue !== ko.selectExtensions.readValue(element)) {
                             // If you try to set a model value that can't be represented in an already-populated dropdown, reject that change,
                             // because you're not allowed to have a model value that disagrees with a visible UI selection.
                             ko.dependencyDetection.ignore(ko.utils.triggerEvent, null, [element, "change"]);
-                        } else {
-                            // Workaround for IE6 bug: It won't reliably apply values to SELECT nodes during the same execution thread
-                            // right after you've changed the set of OPTION nodes on it. So for that node type, we'll schedule a second thread
-                            // to apply the value as well.
-                            ko.utils.setTimeout(applyValueAction, 0);
                         }
                     } else {
                         ko.selectExtensions.writeValue(element, newValue);

--- a/src/binding/selectExtensions.js
+++ b/src/binding/selectExtensions.js
@@ -55,6 +55,14 @@
                     }
                     if (allowUnset || selection >= 0 || (value === undefined && element.size > 1)) {
                         element.selectedIndex = selection;
+                        if (ko.utils.ieVersion === 6) {
+                            // Workaround for IE6 bug: It won't reliably apply values to SELECT nodes during the same execution thread
+                            // right after you've changed the set of OPTION nodes on it. So for that node type, we'll schedule a second thread
+                            // to apply the value as well.
+                            ko.utils.setTimeout(function () {
+                                element.selectedIndex = selection;
+                            }, 0);
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
Given the following code:

```html
<div data-bind="ifnot: hidden">
  <select data-bind="options: letters, value: letter, optionsCaption: 'Select a letter'"></select>
  <button data-bind="click: hide">hide</button>
</div>

<button data-bind="click: reset">reset</button>
```

```javascript
  this.hidden = ko.observable(false);
  this.letters = ['a', 'b', 'c'];
  this.letter = ko.observable();
  
  this.reset = function() {
    this.hidden(false);
    this.letter(null);
  };
  
  this.hide = function() {
    this.hidden(true);
  };
```

If you select an option, click hide, then click reset, the select element still shows the option you had selected. Well, it actually will show the placeholder text for a fraction of a second, and then go back to the value you had previously selected. The actual value of the observable will correctly be cleared out, but the select element will show that option as being selected.

Using the `visible` binding instead of `if` will avoid the issue, as will adding `allowValueUnset: true`.

Here is an example: http://codepen.io/caseyjacobson/pen/wJQBpZ