### PR TITLE
value binding when valueAllowUnset is true

### DIFF
--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -572,6 +572,17 @@ describe('Binding: Value', function() {
                 expect(select.selectedIndex).toEqual(0);
             });
 
+            it('Should display the caption when the model value changes to undefined after having no selection', function() {
+                var observable = ko.observable('B');
+                testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], optionsCaption:\"Select...\", value:myObservable, valueAllowUnset:true'></select>";
+                ko.applyBindings({ myObservable: observable }, testNode);
+                var select = testNode.childNodes[0];
+
+                select.selectedIndex = -1;
+                observable(undefined);
+                expect(select.selectedIndex).toEqual(0);
+            });
+
             it('Should select no option value if no option value matches the current model property value', function() {
                 var observable = ko.observable();
                 testNode.innerHTML = "<select data-bind='options:[\"A\", \"B\"], value:myObservable, valueAllowUnset:true'></select>";

--- a/src/binding/defaultBindings/value.js
+++ b/src/binding/defaultBindings/value.js
@@ -89,9 +89,9 @@ ko.bindingHandlers['value'] = {
                     return;
                 }
 
-                var valueHasChanged = (newValue !== elementValue);
+                var valueHasChanged = newValue !== elementValue;
 
-                if (valueHasChanged) {
+                if (valueHasChanged || elementValue === undefined) {
                     if (tagName === "select") {
                         var allowUnset = allBindings.get('valueAllowUnset');
                         ko.selectExtensions.writeValue(element, newValue, allowUnset);


### PR DESCRIPTION
Assume you have a select element and use:

1. value binding to bind the selected option to an observable
2. optionsCaption binding to add an initial option with the value undefined
3. valueAllowUnset binding to allow the observable to take values that don't exist among the options

- If you programmatically set the observable to a value of an existent option, the value binding responds by selecting the option with the same value in the select element, as expected.
- If you programmatically set the observable to a value of an nonexistent option, the value and valueAllowUnset bindings respond by unselecting any option in the select element (visually being blank), as expected.
- If you programmatically set the observable to undefined, the value binding responds by selecting the option with the value specified by optionsCaption inconsistently - the behavior depends on the state of the select element.  If, when setting the observable to undefined, the select element has no option selected (because the observable has a value that is nonexistent among the options) then the value binding does NOT select the option with the value specified by optionsCaption.

Extending the example in http://knockoutjs.com/documentation/value-binding.html#using-valueallowunset-with-select-elements, https://jsfiddle.net/fastfasterfastest/1qyc6k8e/1/ demonstrates the issue.  If you select an existing country, then undefined, then the select element will have "Choose one..." selected, as expected.
However, if you select an non-existing country, then undefined, then the select element will NOT have "Choose one..." selected, but instead will be visually blank.

I think this is a bug.  The optionsCaption binding adds an option with the value undefined to the options and I think one should be able to consistently be able to select that option programmatically (by setting the observable's value to undefined).

(I am not well-versed enough in the knockout sources to suggest a fix, but it seems like the decision is made on line 4900 in knockout.debug.js where newValue (the current model value) is compared to the value of the current selected option of the select element.  In this case the selectedIndex of the select element is -1 and the value of the current selected option has therefore been returned as undefined.  I think, perhaps, extra care needs to be taken if newValue is undefined on that line, perhaps the test should be `if (valueHasChanged || (newValue === undefined))` ?)