### PR TITLE
deferUpdates conflict with 'if' binding

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -187,7 +187,7 @@ var computedFn = {
         }
     },
     subscribeToDependency: function (target) {
-        if (target._deferUpdates && !this[computedState].disposeWhenNodeIsRemoved) {
+        if (target._deferUpdates) {
             var dirtySub = target.subscribe(this.markDirty, this, 'dirty'),
                 changeSub = target.subscribe(this.respondToChange, this);
             return {


### PR DESCRIPTION
As described at http://stackoverflow.com/q/43341484/1287183 by Simon_Weaver:

I very often use the `if` binding in knockout to hide something, with the added bonus that I don't need to worry about null reference errors inside the `if`. In this example if `address()` is null then the whole block is removed so you avoid having to deal with null checking for every property. This would not be the case had I used the `visible` binding.

	<div data-bind="if: address()">
		You live at:
		<p data-bind="text: address().street.toUpperCase()"></p>			
	</div>

This is the simplest case above - and yes I would generally use this pattern with the `<!-- ko -->` comment syntax.

What is actually causing me problems is when I use a more complex `computed` value and enable the `ko.options.deferUpdates` option :

	<div data-bind="if: hasAddress()">
		You live at:
		<p data-bind="text: address().street.toUpperCase()"></p>			
	</div>

The simplest implementation of this `computed` observable might be something like this : 

    this.hasAddress = ko.computed(function () { return _this.address() != null; }); 

This all works great until I do the following:

1) set `ko.options.deferUpdates = true` before creating the observables.
2) `address()` will start off as null and everything is fine 
3) set `address()` to `{ street: '123 My Street' }`. Again everything works fine.
4) reset `address()` to null. I get a null error because `address().street` is null :-( 

Here is a fiddle to illustrate the problem : https://jsfiddle.net/g5gvfb7x/2/

It seems that unfortunately due to the order in which the micro-tasks runs it tries to recalculate the `text` binding before the `if` binding and so you still get a null error that normally wouldn't occur.