### PR TITLE
A way to extend default binding context

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -29,7 +29,7 @@ describe('Binding attribute syntax', function() {
                 didInit = true;
             }
         };
-        testNode.innerHTML = "<div id='testElement' data-bind='test:123'></div>";
+        testNode.innerHTML = "<div id='testElement' data-bind='test'></div>";
         ko.applyBindings(suppliedViewModel);
         expect(didInit).toEqual(true);
     });
@@ -44,14 +44,29 @@ describe('Binding attribute syntax', function() {
                 didInit = true;
             }
         };
-        testNode.innerHTML = "<div id='testElement' data-bind='test:123'></div>";
+        testNode.innerHTML = "<div id='testElement' data-bind='test'></div>";
 
         var shouldNotMatchNode = document.createElement("DIV");
-        shouldNotMatchNode.innerHTML = "<div id='shouldNotMatchThisElement' data-bind='test:123'></div>";
+        shouldNotMatchNode.innerHTML = "<div id='shouldNotMatchThisElement' data-bind='test'></div>";
         document.body.appendChild(shouldNotMatchNode);
         this.after(function () { document.body.removeChild(shouldNotMatchNode); });
 
         ko.applyBindings(suppliedViewModel, testNode);
+        expect(didInit).toEqual(true);
+    });
+
+    it('applyBindings should accept three parameters and use the third parameter as a callback for modifying the root context', function() {
+        var didInit = false;
+        ko.bindingHandlers.test = {
+            init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+                expect(bindingContext.extraValue).toEqual("extra");
+                didInit = true;
+            }
+        };
+        testNode.innerHTML = "<div id='testElement' data-bind='test'></div>";
+        ko.applyBindings(null, testNode, function(context) {
+            context.extraValue = "extra";
+        });
         expect(didInit).toEqual(true);
     });
 

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -399,10 +399,10 @@
         return bindingInfo && bindingInfo.context;
     }
 
-    function getBindingContext(viewModelOrBindingContext) {
+    function getBindingContext(viewModelOrBindingContext, extendContextCallback) {
         return viewModelOrBindingContext && (viewModelOrBindingContext instanceof ko.bindingContext)
             ? viewModelOrBindingContext
-            : new ko.bindingContext(viewModelOrBindingContext);
+            : new ko.bindingContext(viewModelOrBindingContext, undefined, undefined, extendContextCallback);
     }
 
     ko.applyBindingAccessorsToNode = function (node, bindings, viewModelOrBindingContext) {
@@ -421,7 +421,7 @@
             applyBindingsToDescendantsInternal(getBindingContext(viewModelOrBindingContext), rootNode, true);
     };
 
-    ko.applyBindings = function (viewModelOrBindingContext, rootNode) {
+    ko.applyBindings = function (viewModelOrBindingContext, rootNode, extendContextCallback) {
         // If jQuery is loaded after Knockout, we won't initially have access to it. So save it here.
         if (!jQueryInstance && window['jQuery']) {
             jQueryInstance = window['jQuery'];
@@ -437,7 +437,7 @@
             throw Error("ko.applyBindings: first parameter should be your view model; second parameter should be a DOM node");
         }
 
-        applyBindingsToNodeAndDescendantsInternal(getBindingContext(viewModelOrBindingContext), rootNode, true);
+        applyBindingsToNodeAndDescendantsInternal(getBindingContext(viewModelOrBindingContext, extendContextCallback), rootNode, true);
     };
 
     // Retrieving binding context from arbitrary nodes


### PR DESCRIPTION
Say, for instance, I have binding expressions depending on a library other then `ko` (e.g. `lodash`).

I wish I could just do this:

``` js
ko.applyBindings(viewModel, element, {
    _: require('lodash')
});
```

to make `_` available in `data-bind` expressions.

Currently available options are:
1. Export dependency as a property on view model then use `let` binding to extend binding context

``` js
ko.applyBindings({
    lodash: require('lodash'),
    actualModel: model
}, element);
```

``` html
<!-- ko let: { _: lodash }, with: actualModel -->
<!-- view... -->
<!-- /ko -->
```

This just bloats the code.
2. Export via browser globals `window._ = require('lodash');`. This is just terrible.
3. Use `ko.bindingContext`:

``` js
var ctx = new ko.bindingContext(viewModel).extend({ _ : require('lodash') });
ko.applyBindings(ctx, element);
```

This is bad too, since we now depend on `ko` internals (can we make `bindingContext` a part of public API?)
