### PR TITLE
Descendant bindings of if, with, etc. should have a dependency on the parent condition

### DIFF
--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -152,23 +152,50 @@ describe("Deferred bindings", function() {
     });
 
     it('Should update "if" binding before descendant bindings', function() {
-        // Based on example at http://stackoverflow.com/q/43341484/1287183
-        testNode.innerHTML = '<div data-bind="if: hasAddress()"><div data-bind="text: address().street"></div></div>';
+        // Based on example at https://github.com/knockout/knockout/pull/2226
+        testNode.innerHTML = '<div data-bind="if: hasAddress()"><span data-bind="text: streetNumber().toLowerCase()"></span> <span data-bind="text: street().toLowerCase()"></span></div>';
         var vm = {
-            address: ko.observable(),
-            hasAddress: ko.pureComputed(function () { return vm.address() != null; })
+            street: ko.observable(),
+            streetNumber: ko.observable(),
+            hasAddress: ko.pureComputed(function () { return vm.streetNumber() && vm.street(); })
         };
 
         ko.applyBindings(vm, testNode);
         jasmine.Clock.tick(1);
-        expect(testNode.childNodes[0]).toContainHtml('');
+        expect(testNode.childNodes[0]).toContainText('');
 
-        vm.address({street: '123 my street'});
+        vm.street('my street');
+        vm.streetNumber('123');
         jasmine.Clock.tick(1);
-        expect(testNode.childNodes[0]).toContainHtml('<div data-bind="text: address().street">123 my street</div>');
+        expect(testNode.childNodes[0]).toContainText('123 my street');
 
-        vm.address(null);
+        vm.street(null);
+        vm.streetNumber(null);
         jasmine.Clock.tick(1);
-        expect(testNode.childNodes[0]).toContainHtml('');
+        expect(testNode.childNodes[0]).toContainText('');
+    });
+
+    it('Should update "with" binding before descendant bindings', function() {
+        // Based on example at https://github.com/knockout/knockout/pull/2226
+        testNode.innerHTML = '<div data-bind="with: hasAddress()"><span data-bind="text: $parent.streetNumber().toLowerCase()"></span> <span data-bind="text: $parent.street().toLowerCase()"></span></div>';
+        var vm = {
+            street: ko.observable(),
+            streetNumber: ko.observable(),
+            hasAddress: ko.pureComputed(function () { return vm.streetNumber() && vm.street(); })
+        };
+
+        ko.applyBindings(vm, testNode);
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainText('');
+
+        vm.street('my street');
+        vm.streetNumber('123');
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainText('123 my street');
+
+        vm.street(null);
+        vm.streetNumber(null);
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainText('');
     });
 });

--- a/spec/asyncBindingBehaviors.js
+++ b/spec/asyncBindingBehaviors.js
@@ -198,4 +198,24 @@ describe("Deferred bindings", function() {
         jasmine.Clock.tick(1);
         expect(testNode.childNodes[0]).toContainText('');
     });
+
+    it('Should leave descendant nodes unchanged if the value is truthy and remains truthy when changed', function() {
+        var someItem = ko.observable(true);
+        testNode.innerHTML = "<div data-bind='if: someItem'><span data-bind='text: (++counter)'></span></div>";
+        var originalNode = testNode.childNodes[0].childNodes[0];
+
+        // Value is initially true, so nodes are retained
+        ko.applyBindings({ someItem: someItem, counter: 0 }, testNode);
+        expect(testNode.childNodes[0].childNodes[0].tagName.toLowerCase()).toEqual("span");
+        expect(testNode.childNodes[0].childNodes[0]).toEqual(originalNode);
+        expect(testNode).toContainText("1");
+
+        // Change the value to a different truthy value; see the previous SPAN remains
+        someItem('different truthy value');
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0].childNodes[0].tagName.toLowerCase()).toEqual("span");
+        expect(testNode.childNodes[0].childNodes[0]).toEqual(originalNode);
+        expect(testNode).toContainText("1");
+    });
+
 });

--- a/spec/defaultBindings/ifBehaviors.js
+++ b/spec/defaultBindings/ifBehaviors.js
@@ -21,18 +21,20 @@ describe('Binding: If', function() {
 
     it('Should leave descendant nodes unchanged if the value is truthy and remains truthy when changed', function() {
         var someItem = ko.observable(true);
-        testNode.innerHTML = "<div data-bind='if: someItem'><span></span></div>";
+        testNode.innerHTML = "<div data-bind='if: someItem'><span data-bind='text: (++counter)'></span></div>";
         var originalNode = testNode.childNodes[0].childNodes[0];
 
         // Value is initially true, so nodes are retained
-        ko.applyBindings({ someItem: someItem }, testNode);
+        ko.applyBindings({ someItem: someItem, counter: 0 }, testNode);
         expect(testNode.childNodes[0].childNodes[0].tagName.toLowerCase()).toEqual("span");
         expect(testNode.childNodes[0].childNodes[0]).toEqual(originalNode);
+        expect(testNode).toContainText("1");
 
         // Change the value to a different truthy value; see the previous SPAN remains
         someItem('different truthy value');
         expect(testNode.childNodes[0].childNodes[0].tagName.toLowerCase()).toEqual("span");
         expect(testNode.childNodes[0].childNodes[0]).toEqual(originalNode);
+        expect(testNode).toContainText("1");
     });
 
     it('Should toggle the presence and bindedness of descendant nodes according to the truthiness of the value', function() {

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -178,19 +178,25 @@ describe('Binding: With', function() {
     });
 
     it('Should provide access to an observable viewModel through $rawData', function() {
-        testNode.innerHTML = "<div data-bind='with: item'><input data-bind='value: $rawData'/></div>";
+        testNode.innerHTML = "<div data-bind='with: item'><input data-bind='value: $rawData'/><div data-bind='text: $data'></div></div>";
         var item = ko.observable('one');
         ko.applyBindings({ item: item }, testNode);
-        expect(item.getSubscriptionsCount('change')).toEqual(2);    // only subscriptions are the with and value bindings
+        expect(item.getSubscriptionsCount('change')).toEqual(3);    // subscriptions are the with and value bindings, and the binding context
         expect(testNode.childNodes[0]).toHaveValues(['one']);
+        expect(testNode.childNodes[0]).toContainText('one');
 
         // Should update observable when input is changed
         testNode.childNodes[0].childNodes[0].value = 'two';
         ko.utils.triggerEvent(testNode.childNodes[0].childNodes[0], "change");
         expect(item()).toEqual('two');
+        expect(testNode.childNodes[0]).toContainText('two');
 
         // Should update the input when the observable changes
         item('three');
         expect(testNode.childNodes[0]).toHaveValues(['three']);
+        expect(testNode.childNodes[0]).toContainText('three');
+
+        // subscription count is stable
+        expect(item.getSubscriptionsCount('change')).toEqual(3);
     });
 });

--- a/spec/lib/jasmine.extensions.js
+++ b/spec/lib/jasmine.extensions.js
@@ -77,7 +77,7 @@ jasmine.Matchers.prototype.toHaveTexts = function (expectedTexts) {
 };
 
 jasmine.Matchers.prototype.toHaveValues = function (expectedValues) {
-    var values = ko.utils.arrayMap(this.actual.childNodes, function (node) { return node.value; });
+    var values = ko.utils.arrayFilter(ko.utils.arrayMap(this.actual.childNodes, function (node) { return node.value; }), function (value) { return value !== undefined; });
     this.actual = values;   // Fix explanatory message
     return this.env.equals_(values, expectedValues);
 };

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -122,7 +122,6 @@
             }
         }
     }
-    ko.bindingContext.inheritParentVm = inheritParentVm;
 
     // Extend the binding context hierarchy with a new view model object. If the parent context is watching
     // any observables, the new child context will automatically get a dependency on the parent context.

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -24,7 +24,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot) {
                         isWith ?
                             bindingContext['createChildContext'](valueAccessor) :
                             ifCondition.isActive() ?
-                                new ko.bindingContext(ko.bindingContext.inheritParentVm, bindingContext, null, function() { ifCondition(); }) :
+                                bindingContext['extend'](function() { ifCondition(); return null; }) :
                                 bindingContext,
                         element);
                 } else {

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -1,34 +1,37 @@
 // Makes a binding like with or if
-function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
+function makeWithIfBinding(bindingKey, isWith, isNot) {
     ko.bindingHandlers[bindingKey] = {
         'init': function(element, valueAccessor, allBindings, viewModel, bindingContext) {
-            var didDisplayOnLastUpdate,
-                savedNodes;
+            var savedNodes;
+            var ifCondition = !isWith && ko.computed(function() {
+                return !isNot !== !ko.utils.unwrapObservable(valueAccessor());
+            }, null, { disposeWhenNodeIsRemoved: element });
+
             ko.computed(function() {
-                var rawValue = valueAccessor(),
-                    dataValue = ko.utils.unwrapObservable(rawValue),
-                    shouldDisplay = !isNot !== !dataValue, // equivalent to isNot ? !dataValue : !!dataValue
-                    isFirstRender = !savedNodes,
-                    needsRefresh = isFirstRender || isWith || (shouldDisplay !== didDisplayOnLastUpdate);
+                var shouldDisplay = isWith ? !!ko.utils.unwrapObservable(valueAccessor()) : ifCondition(),
+                    isFirstRender = !savedNodes;
 
-                if (needsRefresh) {
-                    // Save a copy of the inner nodes on the initial update, but only if we have dependencies.
-                    if (isFirstRender && ko.computedContext.getDependenciesCount()) {
-                        savedNodes = ko.utils.cloneNodes(ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
+                // Save a copy of the inner nodes on the initial update, but only if we have dependencies.
+                if (isFirstRender && ko.computedContext.getDependenciesCount()) {
+                    savedNodes = ko.utils.cloneNodes(ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
+                }
+
+                if (shouldDisplay) {
+                    if (!isFirstRender) {
+                        ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
                     }
-
-                    if (shouldDisplay) {
-                        if (!isFirstRender) {
-                            ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
-                        }
-                        ko.applyBindingsToDescendants(makeContextCallback ? makeContextCallback(bindingContext, rawValue) : bindingContext, element);
-                    } else {
-                        ko.virtualElements.emptyNode(element);
-                    }
-
-                    didDisplayOnLastUpdate = shouldDisplay;
+                    ko.applyBindingsToDescendants(
+                        isWith ?
+                            bindingContext['createChildContext'](valueAccessor) :
+                            ifCondition.isActive() ?
+                                new ko.bindingContext(ko.bindingContext.inheritParentVm, bindingContext, null, function() { ifCondition(); }) :
+                                bindingContext,
+                        element);
+                } else {
+                    ko.virtualElements.emptyNode(element);
                 }
             }, null, { disposeWhenNodeIsRemoved: element });
+
             return { 'controlsDescendantBindings': true };
         }
     };
@@ -39,8 +42,4 @@ function makeWithIfBinding(bindingKey, isWith, isNot, makeContextCallback) {
 // Construct the actual binding handlers
 makeWithIfBinding('if');
 makeWithIfBinding('ifnot', false /* isWith */, true /* isNot */);
-makeWithIfBinding('with', true /* isWith */, false /* isNot */,
-    function(bindingContext, dataValue) {
-        return bindingContext.createStaticChildContext(dataValue);
-    }
-);
+makeWithIfBinding('with', true /* isWith */);


### PR DESCRIPTION
… so that updates happen in the right order when using deferred updates.

See discussion in #2226