### PR TITLE
deferred updates: only notify computed changed if it was evaluated

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -317,6 +317,9 @@ var computedFn = {
             if (!state.isSleeping && notifyChange) {
                 computedObservable["notifySubscribers"](state.latestValue);
             }
+            if (computedObservable._recordUpdate) {
+                computedObservable._recordUpdate();
+            }
         }
 
         if (isInitial) {
@@ -376,7 +379,7 @@ var computedFn = {
 
             // Pass the observable to the "limit" code, which will evaluate it when
             // it's time to do the notification.
-            this._limitChange(this);
+            this._limitChange(this, !isChange /* isDirty */);
         };
     },
     dispose: function () {


### PR DESCRIPTION
Currently, if a computed has a non-primitive value, it will always notify a change if it was marked as dirty. It should only notify a change if it was actually recalculated. Thus it's not sufficient to base the notify decision solely on the value, as is currently done.