### PR TITLE
Export ko.utils.cloneNodes

### DIFF
--- a/spec/utilsDomBehaviors.js
+++ b/spec/utilsDomBehaviors.js
@@ -93,3 +93,25 @@ describe('registerEventHandler', function() {
         expect(eventFired && !jQueryModified).toBe(true);
     });
 });
+
+describe('cloneNodes', function () {
+    beforeEach(jasmine.prepareTestNode);
+
+    it ('should return clones', function() {
+        var newNodes = ko.utils.cloneNodes([testNode]);
+        var isClone = !testNode.isSameNode(newNodes[0]) && testNode.isEqualNode(newNodes[0]);
+        expect(isClone).toBe(true);
+    });
+
+    it ('should clone deeply', function() {
+        var child = document.createElement('DIV');
+        testNode.appendChild(child);
+
+        var newNodes = ko.utils.cloneNodes([testNode]);
+        var newChild = newNodes[0].children[0];
+
+        var childIsClone = !child.isSameNode(newChild) && child.isEqualNode(newChild);
+
+        expect(childIsClone).toBe(true);
+    });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -610,6 +610,7 @@ ko.exportSymbol('utils.arrayIndexOf', ko.utils.arrayIndexOf);
 ko.exportSymbol('utils.arrayMap', ko.utils.arrayMap);
 ko.exportSymbol('utils.arrayPushAll', ko.utils.arrayPushAll);
 ko.exportSymbol('utils.arrayRemoveItem', ko.utils.arrayRemoveItem);
+ko.exportSymbol('utils.cloneNodes', ko.utils.cloneNodes);
 ko.exportSymbol('utils.extend', ko.utils.extend);
 ko.exportSymbol('utils.fieldsIncludedWithJsonPost', ko.utils.fieldsIncludedWithJsonPost);
 ko.exportSymbol('utils.getFormFields', ko.utils.getFormFields);


### PR DESCRIPTION
`ko.utils.cloneNodes()` is a pretty useful method, but is unexported; let's export it.