### PR TITLE
Add function to allBindings to get _all_ the bindings as an object.

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -342,6 +342,10 @@
                 return key in bindings;
             };
 
+            allBindings['getAll'] = function(key) {
+                return bindings;
+            };
+
             // First put the bindings into the right order
             var orderedBindings = topologicalSortBindings(bindings);
 


### PR DESCRIPTION
When altering the below handler for inline editing I want to reproduce all the bindings from the target element to a new element created by the binding.

I do not see a way to retrieve _all_ bindings from the `allBindings` object, only individual bindings.
I also do not see a way to easily extend `allBindings` to include this feature or get all of the bindings held in the internal `bindings` object.

This PR would allow me to get all bindings from `allBindings`.

	ko.bindingHandlers.inline= {
		init: function(element, valueAccessor, allBindings) {

			var span = $(element);

			var input = $('<input />',{'type': 'text', 'style' : 'display:none', 'class': 'editable' });
			span.after(input);
			input.autosizeInput();

			var bindings = $.extend({}, allBindings.getAll());
			delete bindings['inline'];

			ko.applyBindingsToNode(input.get(0), $.extend(bindings, { value: valueAccessor() }));
			ko.applyBindingsToNode(span.get(0), $.extend(bindings, { text: valueAccessor() }));

			span.click(function(){
				input.width(span.width());
				span.hide();
				input.show();
				input.focus();
			});

			input.blur(function() {
				span.show();
				input.hide();
			});

			input.keypress(function(e){
				if (e.keyCode === 13) {
					span.show();
					input.hide();
				}
			});
		}
	};