### PR TITLE
checked binding (3.5.0-pre)

### DIFF
--- a/spec/defaultBindings/checkedBehaviors.js
+++ b/spec/defaultBindings/checkedBehaviors.js
@@ -392,69 +392,74 @@ describe('Binding: Checked', function() {
                 expect(testNode.childNodes[0]).toHaveCheckedStates([false, true]);
             });
 
-            it('Should use that value as the checkbox\'s value when not bound to an array', function () {
-                var myobservable = ko.observable('random value');
-                testNode.innerHTML = "<input type='checkbox' data-bind='checked:someProp, " + binding + ":true' />" +
-                    "<input type='checkbox' data-bind='checked:someProp, " + binding + ":false' />";
-                ko.applyBindings({ someProp: myobservable }, testNode);
+            if (binding == "checkedValue") {
+                // When bound to a checkbox, the "checkedValue" binding will affect a non-array
+                // "checked" binding, but "value" won't.
 
-                expect(myobservable()).toEqual('random value');
+                it('Should use that value as the checkbox\'s value when not bound to an array', function () {
+                    var myobservable = ko.observable('random value');
+                    testNode.innerHTML = "<input type='checkbox' data-bind='checked:someProp, " + binding + ":true' />" +
+                        "<input type='checkbox' data-bind='checked:someProp, " + binding + ":false' />";
+                    ko.applyBindings({ someProp: myobservable }, testNode);
 
-                // Check initial state: both are unchecked because neither has a matching value
-                expect(testNode).toHaveCheckedStates([false, false]);
+                    expect(myobservable()).toEqual('random value');
 
-                // Update observable; verify element states
-                myobservable(false);
-                expect(testNode).toHaveCheckedStates([false, true]);
-                myobservable(true);
-                expect(testNode).toHaveCheckedStates([true, false]);
+                    // Check initial state: both are unchecked because neither has a matching value
+                    expect(testNode).toHaveCheckedStates([false, false]);
 
-                // "check" a box; verify observable and elements
-                testNode.childNodes[1].click();
-                expect(myobservable()).toEqual(false);
-                expect(testNode).toHaveCheckedStates([false, true]);
+                    // Update observable; verify element states
+                    myobservable(false);
+                    expect(testNode).toHaveCheckedStates([false, true]);
+                    myobservable(true);
+                    expect(testNode).toHaveCheckedStates([true, false]);
 
-                // "uncheck" a box; verify observable and elements
-                testNode.childNodes[1].click();
-                expect(myobservable()).toEqual(undefined);
-                expect(testNode).toHaveCheckedStates([false, false]);
-            });
+                    // "check" a box; verify observable and elements
+                    testNode.childNodes[1].click();
+                    expect(myobservable()).toEqual(false);
+                    expect(testNode).toHaveCheckedStates([false, true]);
 
-            it('Should be able to use observables as value of checkboxes when not bound to an array', function() {
-                var object1 = {id:ko.observable(1)},
-                    object2 = {id:ko.observable(2)},
-                    model = { value: ko.observable(1), choices: [object1, object2] };
-                testNode.innerHTML = "<div data-bind='foreach: choices'><input type='checkbox' data-bind='" + binding + ":id, checked:$parent.value' /></div>";
-                ko.applyBindings(model, testNode);
+                    // "uncheck" a box; verify observable and elements
+                    testNode.childNodes[1].click();
+                    expect(myobservable()).toEqual(undefined);
+                    expect(testNode).toHaveCheckedStates([false, false]);
+                });
 
-                expect(model.value()).toEqual(1);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
+                it('Should be able to use observables as value of checkboxes when not bound to an array', function() {
+                    var object1 = {id:ko.observable(1)},
+                        object2 = {id:ko.observable(2)},
+                        model = { value: ko.observable(1), choices: [object1, object2] };
+                    testNode.innerHTML = "<div data-bind='foreach: choices'><input type='checkbox' data-bind='" + binding + ":id, checked:$parent.value' /></div>";
+                    ko.applyBindings(model, testNode);
 
-                // Update the value observable of the checked item; should update the selected values and leave checked values unchanged
-                object1.id(3);
-                expect(model.value()).toEqual(3);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
+                    expect(model.value()).toEqual(1);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
 
-                // Update the value observable of the unchecked item; should do nothing
-                object2.id(4);
-                expect(model.value()).toEqual(3);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
+                    // Update the value observable of the checked item; should update the selected values and leave checked values unchanged
+                    object1.id(3);
+                    expect(model.value()).toEqual(3);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
 
-                // Update the value observable of the unchecked item to the current model value; should set to checked
-                object2.id(3);
-                expect(model.value()).toEqual(3);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([true, true]);
+                    // Update the value observable of the unchecked item; should do nothing
+                    object2.id(4);
+                    expect(model.value()).toEqual(3);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([true, false]);
 
-                // Update the value again; should leave checked and replace selected value (other button should be unchecked)
-                object2.id(4);
-                expect(model.value()).toEqual(4);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([false, true]);
+                    // Update the value observable of the unchecked item to the current model value; should set to checked
+                    object2.id(3);
+                    expect(model.value()).toEqual(3);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([true, true]);
 
-                // Revert to original value; should update selected value
-                object2.id(2);
-                expect(model.value()).toEqual(2);
-                expect(testNode.childNodes[0]).toHaveCheckedStates([false, true]);
-            });
+                    // Update the value again; should leave checked and replace selected value (other button should be unchecked)
+                    object2.id(4);
+                    expect(model.value()).toEqual(4);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([false, true]);
+
+                    // Revert to original value; should update selected value
+                    object2.id(2);
+                    expect(model.value()).toEqual(2);
+                    expect(testNode.childNodes[0]).toHaveCheckedStates([false, true]);
+                });
+            }
 
             it('Should ignore \'undefined\' value for checkbox', function () {
                 var myobservable = new ko.observable(true);

--- a/src/binding/defaultBindings/checked.js
+++ b/src/binding/defaultBindings/checked.js
@@ -7,11 +7,13 @@ ko.bindingHandlers['checked'] = {
             // Treat "value" like "checkedValue" when it is included with "checked" binding
             if (allBindings['has']('checkedValue')) {
                 return ko.utils.unwrapObservable(allBindings.get('checkedValue'));
-            } else if (allBindings['has']('value')) {
-                return ko.utils.unwrapObservable(allBindings.get('value'));
+            } else if (useElementValue) {
+                if (allBindings['has']('value')) {
+                    return ko.utils.unwrapObservable(allBindings.get('value'));
+                } else {
+                    return element.value;
+                }
             }
-
-            return useElementValue ? element.value : undefined;
         });
 
         function updateModel() {


### PR DESCRIPTION
Note - this report is about 3.5.0-pre.

The checked binding appears to be broken in 3.5.0-pre, see http://jsfiddle.net/fastfasterfastest/qyrb146o/1/
It seems so elementary so I don't know if I am having a mind block, it's possible, but the behavior is as expected with 3.4.2.  I am seeing the behavior in a private build from the current state of affairs, but the fiddle is using one of @mbest's builds he made available in another issue a while ago.

The input element does not get checked when the checked binding's value is set to `true`.  It does get checked if the checked binding's value is set to same as value binding's value.

If you change to http://knockoutjs.com/downloads/knockout-3.4.2.js the input element gets checked when the checked binding's value is set to `true`, as expected.

Added: https://github.com/knockout/knockout/pull/1899 seems to be the reason/cause.  Should the discussion be carried on there?