### PR TITLE
ko.utils.domData storage scheme requires explicit cleanup

### DIFF
--- a/src/utils.domData.js
+++ b/src/utils.domData.js
@@ -4,33 +4,37 @@ ko.utils.domData = new (function () {
     var dataStoreKeyExpandoPropertyName = "__ko__" + (new Date).getTime();
     var dataStore = {};
 
-    function getAll(node, createIfNotFound) {
-        var dataStoreKey = node[dataStoreKeyExpandoPropertyName];
-        var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null") && dataStore[dataStoreKey];
-        if (!hasExistingDataStore) {
-            if (!createIfNotFound)
-                return undefined;
-            dataStoreKey = node[dataStoreKeyExpandoPropertyName] = "ko" + uniqueId++;
-            dataStore[dataStoreKey] = {};
-        }
-        return dataStore[dataStoreKey];
-    }
-
-    return {
-        get: function (node, key) {
-            var allDataForNode = getAll(node, false);
-            return allDataForNode === undefined ? undefined : allDataForNode[key];
-        },
-        set: function (node, key, value) {
-            if (value === undefined) {
-                // Make sure we don't actually create a new domData key if we are actually deleting a value
-                if (getAll(node, false) === undefined)
-                    return;
+    var getDataForNode, clear;
+    if (window['WeakMap']) {
+        getDataForNode = function (node, createIfNotFound) {
+            var ownerDoc = node.ownerDocument,
+                dataStore = ownerDoc[dataStoreKeyExpandoPropertyName] || (ownerDoc[dataStoreKeyExpandoPropertyName] = new ownerDoc.defaultView['WeakMap']());
+            if (dataStore['has'](node)) {
+                return dataStore.get(node);
             }
-            var allDataForNode = getAll(node, true);
-            allDataForNode[key] = value;
-        },
-        clear: function (node) {
+            if (createIfNotFound) {
+                var dataForNode = {};
+                dataStore.set(node, dataForNode);
+                return dataForNode;
+            }
+        };
+        clear = function (node) {
+            var dataStore = node.ownerDocument[dataStoreKeyExpandoPropertyName];
+            return dataStore ? dataStore['delete'](node) : false;
+        };
+    } else {
+        getDataForNode = function (node, createIfNotFound) {
+            var dataStoreKey = node[dataStoreKeyExpandoPropertyName];
+            var hasExistingDataStore = dataStoreKey && (dataStoreKey !== "null") && dataStore[dataStoreKey];
+            if (!hasExistingDataStore) {
+                if (!createIfNotFound)
+                    return undefined;
+                dataStoreKey = node[dataStoreKeyExpandoPropertyName] = "ko" + uniqueId++;
+                dataStore[dataStoreKey] = {};
+            }
+            return dataStore[dataStoreKey];
+        };
+        clear = function (node) {
             var dataStoreKey = node[dataStoreKeyExpandoPropertyName];
             if (dataStoreKey) {
                 delete dataStore[dataStoreKey];
@@ -38,7 +42,20 @@ ko.utils.domData = new (function () {
                 return true; // Exposing "did clean" flag purely so specs can infer whether things have been cleaned up as intended
             }
             return false;
+        };
+    }
+
+    return {
+        get: function (node, key) {
+            var dataForNode = getDataForNode(node, false);
+            return dataForNode && dataForNode[key];
         },
+        set: function (node, key, value) {
+            // Make sure we don't actually create a new domData key if we are actually deleting a value
+            var dataForNode = getDataForNode(node, value !== undefined /* createIfNotFound */);
+            dataForNode && (dataForNode[key] = value);
+        },
+        clear: clear,
 
         nextKey: function () {
             return (uniqueId++) + dataStoreKeyExpandoPropertyName;

--- a/src/utils.domData.js
+++ b/src/utils.domData.js
@@ -5,22 +5,20 @@ ko.utils.domData = new (function () {
     var dataStore = {};
 
     var getDataForNode, clear;
-    if (window['WeakMap']) {
+    if (!ko.utils.ieVersion) {
         getDataForNode = function (node, createIfNotFound) {
-            var ownerDoc = node.ownerDocument,
-                dataStore = ownerDoc[dataStoreKeyExpandoPropertyName] || (ownerDoc[dataStoreKeyExpandoPropertyName] = new ownerDoc.defaultView['WeakMap']());
-            if (dataStore['has'](node)) {
-                return dataStore.get(node);
+            var dataForNode = node[dataStoreKeyExpandoPropertyName];
+            if (!dataForNode && createIfNotFound) {
+                dataForNode = node[dataStoreKeyExpandoPropertyName] = {};
             }
-            if (createIfNotFound) {
-                var dataForNode = {};
-                dataStore.set(node, dataForNode);
-                return dataForNode;
-            }
+            return dataForNode;
         };
         clear = function (node) {
-            var dataStore = node.ownerDocument[dataStoreKeyExpandoPropertyName];
-            return dataStore ? dataStore['delete'](node) : false;
+            if (node[dataStoreKeyExpandoPropertyName]) {
+                delete node[dataStoreKeyExpandoPropertyName];
+                return true;
+            }
+            return false;
         };
     } else {
         getDataForNode = function (node, createIfNotFound) {


### PR DESCRIPTION
This problem has been previously brought up in the rejected Issue #1695. Our case idifferent, however: we have no way of ensuring that the explicit ko.cleanNode() is always invoked for the removed element. 
Also note that jQuery has switched to storing data on the expando - https://github.com/jquery/jquery/issues/1734. And they had long been advocating for the same data storage solution as Knockout's...

Or use case is as follows:
1. We rely on custom element support (part of the web component spec) to activate our composite component (see https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement)
2. We are using Knockout to manage the composite component's template. 
3. The template will only reference observables stored with the element's properties. No external observables will be used. This means that the custom element should be garbage-collectable when it is removed. 
4. Custom elements are designed to rely on garbage collection for their cleanup, and we cannot require our users to call the explicit cleanup method. 

Unfortunately, Knockout's domData maintains references to to all DOM nodes where bindings were applied, so all DOM nodes within the Knockout template remains in memory heap.

Here is a jsFiddle that demonstrates the issue: https://jsfiddle.net/mstarets/4nfsebec/5/. It needs to be run in Chrome (otherwise you will need to include the Custom Element polyfill). After you run the page, click on 'Create Custom Element button, then on 'Remove Custom Element' button. Repeat this sequence 2-3 times. Open Developer Tools, go to the 'Profiles' tab and take a heap snapshot. Note that there are several hundred of HTMLButtonElements that have been leaked. Now uncomment the line calling clearDataForButtons() and repeat the same test. Note that the button elements are no longer leaked.
