### PR TITLE
Add toString method to subscribable so it doesn't error out

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -218,6 +218,11 @@ describe('Rate-limited', function() {
             jasmine.Clock.tick(250);
             expect(notifySpy).toHaveBeenCalledWith('b');
         });
+
+        it('Should return "[object Object]" with .toString', function() {
+          // Issue #2252: make sure .toString method does not throw error
+          expect(new ko.subscribable().toString()).toBe('[object Object]')
+        });
     });
 
     describe('Observable', function() {

--- a/src/subscribables/subscribable.js
+++ b/src/subscribables/subscribable.js
@@ -163,6 +163,10 @@ var ko_subscribable_fn = {
         return !this['equalityComparer'] || !this['equalityComparer'](oldValue, newValue);
     },
 
+    toString: function() {
+      return '[object Object]'
+    },
+
     extend: applyExtenders
 };
 


### PR DESCRIPTION
from issue #2252 
Simply returns the expected string "[object Object]"