### PR TITLE
Fix side effects on awake callback

### DIFF
--- a/spec/pureComputedBehaviors.js
+++ b/spec/pureComputedBehaviors.js
@@ -382,6 +382,27 @@ describe('Pure Computed', function() {
         expect(timesEvaluated).toEqual(2);
     });
 
+    it('Should wake with the correct value when a chained pure computed has side effects for its awake event', function () {
+
+        var observableToUpdateOnAwake = ko.observable(null),
+            computed1 = ko.pureComputed(observableToUpdateOnAwake),
+            computed2 = ko.pureComputed(computed1);
+
+        computed1.subscribe(function () {
+            observableToUpdateOnAwake('foo');
+        }, null, 'awake');
+
+        // Reading from the computed before subscribing caused the subscription to
+        // ignore side-effects from the awake callback of chained pure computeds
+        computed2();
+
+        computed2.subscribe(function () {
+        });
+
+        expect(computed2()).toEqual('foo');
+
+    });
+
     describe('Should maintain order of subscriptions', function () {
         var data, dataPureComputed;
 

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -436,6 +436,16 @@ var pureComputedOverrides = {
                     state.dependencyTracking[id] = subscription;
                 });
             }
+
+            // Repeat check since waking dependencies may have triggered effects
+            if (computedObservable.haveDependenciesChanged()) {
+                state.dependencyTracking = null;
+                state.dependenciesCount = 0;
+                if (computedObservable.evaluateImmediate()) {
+                    computedObservable.updateVersion();
+                }
+            }
+
             if (!state.isDisposed) {     // test since evaluating could trigger disposal
                 computedObservable["notifySubscribers"](state.latestValue, "awake");
             }


### PR DESCRIPTION
We are starting to use pure computed asleep / awake events a lot more to implicitly optimise resource consumption and have stumbled across this bug:

> If a pure computed in a chain of pure computeds has a subscription to its awake event which causes side effects that update its value, it is possible for listeners to get into a bad state. 
> 
> This only happens if the pure computed in question is invoked before being subscribed to.

Added specs to capture this case, and a possible solution by checking if dependencies have changed one more time after setting up subscriptions to them.