### PR TITLE
Create composer.json for instalation with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "knockout/knockout",
+  "description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
+  "type": "component",
+  "homepage": "http://knockoutjs.com/",
+  "authors": [
+    {
+      "name": "Knockout.js",
+      "url": "http://knockoutjs.com"
+    }
+  ],
+  "require": {
+    "robloach/component-installer": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "dist/knockout.js"
+      ],
+      "files": [
+        "dist/knockout.debug.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The installation is much simpler with Composer and https://github.com/RobLoach/component-installer

After merged you can test it:
```
composer config repositories.knockout-knockout vcs "https://github.com/knockout/knockout"
composer info knockout/knockout --all
```

Composer creates a "components" folder that contains the "knockout" whith all files spec in "files" of composer.json.
You can then register the "package" at https://packagist.org In this way the installation would be simpler:
`composer require knockout/knockout`