### PR TITLE
Checking if state exists when disposing

### DIFF
--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -384,7 +384,7 @@ var computedFn = {
     },
     dispose: function () {
         var state = this[computedState];
-		if (typeof(state) === "undefined") {
+	    if (typeof(state) === "undefined") {
             return;
         }
         if (!state.isSleeping && state.dependencyTracking) {

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -384,6 +384,9 @@ var computedFn = {
     },
     dispose: function () {
         var state = this[computedState];
+		if (typeof(state) === "undefined") {
+            return;
+        }
         if (!state.isSleeping && state.dependencyTracking) {
             ko.utils.objectForEach(state.dependencyTracking, function (id, dependency) {
                 if (dependency.dispose)

--- a/src/subscribables/dependentObservable.js
+++ b/src/subscribables/dependentObservable.js
@@ -384,7 +384,7 @@ var computedFn = {
     },
     dispose: function () {
         var state = this[computedState];
-	    if (typeof(state) === "undefined") {
+        if (typeof(state) === "undefined") {
             return;
         }
         if (!state.isSleeping && state.dependencyTracking) {


### PR DESCRIPTION
I've encountered cases where we call
`bindingContext.createChildContext(viewModel);`
and when dispose function is called internally, state is not found

This probably doesn't fix the problem, but it fixes the symptoms. Feel free to investigate more, because my knowledge of the internal workings of Knockout is limited. The error seems to be introduced in version 3.4.0.

