### PR TITLE
Hide or don't minify extra internal properties on binding context

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -229,6 +229,19 @@ describe('Binding attribute syntax', function() {
         expect(testNode).toContainText("my value");
     });
 
+    it('Binding context should hide or not minify extra internal properties', function () {
+        testNode.innerHTML = "<div data-bind='with: $data'><div></div></div>";
+        ko.applyBindings({}, testNode);
+
+        var allowedProperties = ['$parents', '$root', 'ko', '$rawData', '$data', '$parentContext', '$parent'];
+        if (ko.utils.createSymbolOrString('') === '') {
+            allowedProperties.push('_subscribable');
+        }
+        ko.utils.objectForEach(ko.contextFor(testNode.childNodes[0].childNodes[0]), function (prop) {
+            expect(allowedProperties).toContain(prop);
+        });
+    });
+
     it('Should be able to retrieve the binding context associated with any node', function() {
         testNode.innerHTML = "<div><div data-bind='text: name'></div></div>";
         ko.applyBindings({ name: 'Bert' }, testNode.childNodes[0]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -611,6 +611,7 @@ ko.exportSymbol('utils.arrayMap', ko.utils.arrayMap);
 ko.exportSymbol('utils.arrayPushAll', ko.utils.arrayPushAll);
 ko.exportSymbol('utils.arrayRemoveItem', ko.utils.arrayRemoveItem);
 ko.exportSymbol('utils.cloneNodes', ko.utils.cloneNodes);
+ko.exportSymbol('utils.createSymbolOrString', ko.utils.createSymbolOrString);
 ko.exportSymbol('utils.extend', ko.utils.extend);
 ko.exportSymbol('utils.fieldsIncludedWithJsonPost', ko.utils.fieldsIncludedWithJsonPost);
 ko.exportSymbol('utils.getFormFields', ko.utils.getFormFields);


### PR DESCRIPTION
It is possible for properties such as `_subscribable` to be created on a
binding context, which, after minification, could be renamed to any
arbitrary character. In most cases this is not an issue, except when a
global variable with the same name exists, however rare the case may be.
This causes the global variable to be shadowed in all bindings, which is
especially problematic in the case of, say, `$`, which breaks jquery.

To fix this, either hide such properties with a Symbol, or simply don't
minify them so that the name is constant and predictable.

Fixes https://github.com/knockout/knockout/issues/2294