### PR TITLE
add generic afterRender binding

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -583,4 +583,42 @@ describe('Binding attribute syntax', function() {
             expect(testNode).toContainHtml('<p>replaced</p><template>test</template><p>replaced</p>');
         });
     });
+
+    it('Should call an afterRender callback function after descendent elements are bound', function () {
+        var callbacks = 0,
+            callback = function (nodes, data) {
+                expect(nodes.length).toEqual(1);
+                expect(nodes[0]).toEqual(testNode.childNodes[0].childNodes[0]);
+                expect(data).toEqual(vm);
+                callbacks++;
+            },
+            vm = { callback: callback };
+
+        testNode.innerHTML = "<div data-bind='afterRender: callback'><span data-bind='text: \"Some Text\"'></span></div>";
+        ko.applyBindings(vm, testNode);
+        expect(callbacks).toEqual(1);
+    });
+
+    it('Should call an afterRender callback function when bound to a virtual element', function () {
+        var callbacks = 0,
+            callback = function (nodes, data) {
+                expect(nodes.length).toEqual(1);
+                expect(nodes[0]).toEqual(testNode.childNodes[1]);
+                expect(data).toEqual(vm);
+                callbacks++;
+            },
+            vm = { callback: callback };
+
+        testNode.innerHTML = "<!-- ko afterRender: callback --><span data-bind='text: \"Some Text\"'></span><!-- /ko -->";
+        ko.applyBindings(vm, testNode);
+        expect(callbacks).toEqual(1);
+    });
+
+    it('Should not call an afterRender callback function when there are no descendant nodes', function () {
+        var callbacks = 0;
+
+        testNode.innerHTML = "<div data-bind='afterRender: callback'></span></div>";
+        ko.applyBindings({ callback: function () { callbacks++; } }, testNode);
+        expect(callbacks).toEqual(0);
+    });
 });

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -621,4 +621,9 @@ describe('Binding attribute syntax', function() {
         ko.applyBindings({ callback: function () { callbacks++; } }, testNode);
         expect(callbacks).toEqual(0);
     });
+
+    it('Should ignore (and not throw an error) for a null afterRender callback', function () {
+        testNode.innerHTML = "<div data-bind='afterRender: null'><span data-bind='text: \"Some Text\"'></span></div>";
+        ko.applyBindings({}, testNode);
+    });
 });

--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -584,7 +584,7 @@ describe('Binding attribute syntax', function() {
         });
     });
 
-    it('Should call an afterRender callback function after descendent elements are bound', function () {
+    it('Should call a childrenComplete callback function after descendent elements are bound', function () {
         var callbacks = 0,
             callback = function (nodes, data) {
                 expect(nodes.length).toEqual(1);
@@ -594,12 +594,12 @@ describe('Binding attribute syntax', function() {
             },
             vm = { callback: callback };
 
-        testNode.innerHTML = "<div data-bind='afterRender: callback'><span data-bind='text: \"Some Text\"'></span></div>";
+        testNode.innerHTML = "<div data-bind='childrenComplete: callback'><span data-bind='text: \"Some Text\"'></span></div>";
         ko.applyBindings(vm, testNode);
         expect(callbacks).toEqual(1);
     });
 
-    it('Should call an afterRender callback function when bound to a virtual element', function () {
+    it('Should call a childrenComplete callback function when bound to a virtual element', function () {
         var callbacks = 0,
             callback = function (nodes, data) {
                 expect(nodes.length).toEqual(1);
@@ -609,21 +609,36 @@ describe('Binding attribute syntax', function() {
             },
             vm = { callback: callback };
 
-        testNode.innerHTML = "<!-- ko afterRender: callback --><span data-bind='text: \"Some Text\"'></span><!-- /ko -->";
+        testNode.innerHTML = "<!-- ko childrenComplete: callback --><span data-bind='text: \"Some Text\"'></span><!-- /ko -->";
         ko.applyBindings(vm, testNode);
         expect(callbacks).toEqual(1);
     });
 
-    it('Should not call an afterRender callback function when there are no descendant nodes', function () {
+    it('Should not call a childrenComplete callback function when there are no descendant nodes', function () {
         var callbacks = 0;
 
-        testNode.innerHTML = "<div data-bind='afterRender: callback'></span></div>";
+        testNode.innerHTML = "<div data-bind='childrenComplete: callback'></div>";
         ko.applyBindings({ callback: function () { callbacks++; } }, testNode);
         expect(callbacks).toEqual(0);
     });
 
-    it('Should ignore (and not throw an error) for a null afterRender callback', function () {
-        testNode.innerHTML = "<div data-bind='afterRender: null'><span data-bind='text: \"Some Text\"'></span></div>";
+    it('Should ignore (and not throw an error) for a null childrenComplete callback', function () {
+        testNode.innerHTML = "<div data-bind='childrenComplete: null'><span data-bind='text: \"Some Text\"'></span></div>";
         ko.applyBindings({}, testNode);
+    });
+
+    it('Should call childrenComplete callback registered with ko.subscribeToBindingEvent', function () {
+        var callbacks = 0,
+            vm = {};
+
+        ko.subscribeToBindingEvent(testNode, "childrenComplete", function (node) {
+            callbacks++;
+            expect(node).toEqual(testNode);
+            expect(ko.dataFor(node)).toEqual(vm);
+        });
+
+        testNode.innerHTML = "<div></div>";
+        ko.applyBindings(vm, testNode);
+        expect(callbacks).toEqual(1);
     });
 });

--- a/spec/bindingDependencyBehaviors.js
+++ b/spec/bindingDependencyBehaviors.js
@@ -250,6 +250,45 @@ describe('Binding dependencies', function() {
         expect(testNode).toContainText('new value');
     });
 
+    it('Should not cause updates if an observable accessed in an afterRender callback is changed', function () {
+        ko.bindingHandlers.test = {
+            init: function() {
+                return { controlsDescendantBindings: true };
+            },
+            update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+                ko.utils.unwrapObservable(valueAccessor());
+                element.innerHTML = "<span data-bind='text: childprop'></span>";
+                ko.applyBindingsToDescendants(bindingContext, element);
+            }
+        };
+
+        var callbackObservable = ko.observable(1),
+            bindingObservable = ko.observable(1),
+            callbacks = 0,
+            vm = {
+                childprop: 'child',
+                bindingObservable: bindingObservable,
+                callback: function () { callbackObservable(); callbacks++; }
+            };
+
+        testNode.innerHTML = "<div data-bind='test: bindingObservable, afterRender: callback'></div>";
+        ko.applyBindings(vm, testNode);
+        expect(callbacks).toEqual(1);
+
+        // Change the childprop which is not an observable so should not change the bound element
+        vm.childprop = 'new child';
+        expect(testNode.childNodes[0]).toContainText('child');
+
+        // Update callback observable and check that the binding wasn't updated
+        callbackObservable(2);
+        expect(testNode.childNodes[0]).toContainText('child');
+
+        // Update the bound observable and verify that the binding is now updated
+        bindingObservable(2);
+        expect(testNode.childNodes[0]).toContainText('new child');
+        expect(callbacks).toEqual(2);
+    });
+
     describe('Observable view models', function() {
         it('Should update bindings (including callbacks)', function() {
             var vm = ko.observable(), clickedVM;

--- a/spec/bindingDependencyBehaviors.js
+++ b/spec/bindingDependencyBehaviors.js
@@ -250,7 +250,7 @@ describe('Binding dependencies', function() {
         expect(testNode).toContainText('new value');
     });
 
-    it('Should not cause updates if an observable accessed in an afterRender callback is changed', function () {
+    it('Should not cause updates if an observable accessed in a childrenComplete callback is changed', function () {
         ko.bindingHandlers.test = {
             init: function() {
                 return { controlsDescendantBindings: true };
@@ -271,7 +271,7 @@ describe('Binding dependencies', function() {
                 callback: function () { callbackObservable(); callbacks++; }
             };
 
-        testNode.innerHTML = "<div data-bind='test: bindingObservable, afterRender: callback'></div>";
+        testNode.innerHTML = "<div data-bind='test: bindingObservable, childrenComplete: callback'></div>";
         ko.applyBindings(vm, testNode);
         expect(callbacks).toEqual(1);
 
@@ -289,7 +289,7 @@ describe('Binding dependencies', function() {
         expect(callbacks).toEqual(2);
     });
 
-    it('Should always use the latest value of an afterRender callback', function () {
+    it('Should always use the latest value of a childrenComplete callback', function () {
         ko.bindingHandlers.test = {
             init: function() {
                 return { controlsDescendantBindings: true };
@@ -308,7 +308,7 @@ describe('Binding dependencies', function() {
                 callback: callbackSpy1
             };
 
-        testNode.innerHTML = "<div data-bind='test: observable, afterRender: callback'></div>";
+        testNode.innerHTML = "<div data-bind='test: observable, childrenComplete: callback'></div>";
         ko.applyBindings(vm, testNode);
         expect(callbackSpy1).toHaveBeenCalled();
 

--- a/spec/components/componentBindingBehaviors.js
+++ b/spec/components/componentBindingBehaviors.js
@@ -651,8 +651,8 @@ describe('Components: Component binding', function() {
         expect(testNode).toContainText('Hello! Your param is 456 Goodbye.');
     });
 
-    it('Should call an afterRender callback function', function () {
-        testNode.innerHTML = '<div data-bind="component: testComponentBindingValue, afterRender: callback"></div>';
+    it('Should call a childrenComplete callback function', function () {
+        testNode.innerHTML = '<div data-bind="component: testComponentBindingValue, childrenComplete: callback"></div>';
         ko.components.register(testComponentName, { template: '<div data-bind="text: myvalue"></div>' });
         testComponentParams.myvalue = 'some parameter value';
 

--- a/spec/components/componentBindingBehaviors.js
+++ b/spec/components/componentBindingBehaviors.js
@@ -651,6 +651,27 @@ describe('Components: Component binding', function() {
         expect(testNode).toContainText('Hello! Your param is 456 Goodbye.');
     });
 
+    it('Should call an afterRender callback function', function () {
+        testNode.innerHTML = '<div data-bind="component: testComponentBindingValue, afterRender: callback"></div>';
+        ko.components.register(testComponentName, { template: '<div data-bind="text: myvalue"></div>' });
+        testComponentParams.myvalue = 'some parameter value';
+
+        var callbacks = 0;
+        outerViewModel.callback = function (nodes, data) {
+            expect(nodes.length).toEqual(1);
+            expect(nodes[0]).toEqual(testNode.childNodes[0].childNodes[0]);
+            expect(data).toEqual(testComponentParams);
+            callbacks++;
+        };
+
+        ko.applyBindings(outerViewModel, testNode);
+        expect(callbacks).toEqual(0);
+
+        jasmine.Clock.tick(1);
+        expect(testNode.childNodes[0]).toContainHtml('<div data-bind="text: myvalue">some parameter value</div>');
+        expect(callbacks).toEqual(1);
+    });
+
     describe('Does not automatically subscribe to any observables you evaluate during createViewModel or a viewmodel constructor', function() {
         // This clarifies that, if a developer wants to react when some observable parameter
         // changes, then it's their responsibility to subscribe to it or use a computed.

--- a/spec/components/customElementBehaviors.js
+++ b/spec/components/customElementBehaviors.js
@@ -508,4 +508,24 @@ describe('Components: Custom elements', function() {
           + '</li>'
         );
     });
+
+    it('Should call an afterRender callback function', function () {
+        ko.components.register('test-component', { template: 'custom element'});
+        testNode.innerHTML = '<test-component data-bind="afterRender: callback"></test-component>';
+
+        var callbacks = 0,
+            viewModel = {
+                callback: function (nodes, data) {
+                    expect(nodes.length).toEqual(1);
+                    expect(nodes[0]).toEqual(testNode.childNodes[0].childNodes[0]);
+                    expect(data).toEqual(undefined);
+                    callbacks++;
+                }
+            };
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+
+        jasmine.Clock.tick(1);
+        expect(testNode).toContainHtml('<test-component data-bind="afterrender: callback">custom element</test-component>');
+    });
 });

--- a/spec/defaultBindings/ifBehaviors.js
+++ b/spec/defaultBindings/ifBehaviors.js
@@ -97,22 +97,7 @@ describe('Binding: If', function() {
         expect(testNode).toContainHtml("hello <!-- ko if: condition1 -->first is true<!-- ko if: condition2 -->both are true<!-- /ko --><!-- /ko -->");
     });
 
-    it('Should call an afterRender callback function and not cause updates if an observable accessed in the callback is changed', function () {
-        testNode.innerHTML = "<div data-bind='if: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
-        var callbackObservable = ko.observable(1),
-            callbacks = 0;
-        var viewModel = { condition: ko.observable(true), someText: "hello", callback: function() { callbackObservable(); callbacks++; } };
-        ko.applyBindings(viewModel, testNode);
-        expect(callbacks).toEqual(1);
-        expect(testNode.childNodes[0]).toContainText('hello');
-
-        viewModel.someText = "bello";
-        // Update callback observable and check that the binding wasn't updated
-        callbackObservable(2);
-        expect(testNode.childNodes[0]).toContainText('hello');
-    });
-
-    it('Should not call an afterRender callback function when data gets cleared', function () {
+    it('Should call an afterRender callback function', function () {
         testNode.innerHTML = "<div data-bind='if: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
         var someItem = ko.observable({ childprop: 'child' }),
             callbacks = 0;
@@ -128,51 +113,5 @@ describe('Binding: If', function() {
         viewModel.condition(true);
         expect(callbacks).toEqual(2);
         expect(testNode.childNodes[0]).toContainText('hello');
-    });
-
-    it('Should call an afterRender callback, passing all of the rendered nodes, accounting for node preprocessing and virtual element bindings', function () {
-        // Set up a binding provider that converts text nodes to expressions
-        var originalBindingProvider = ko.bindingProvider.instance,
-            preprocessingBindingProvider = function () { };
-        preprocessingBindingProvider.prototype = originalBindingProvider;
-        ko.bindingProvider.instance = new preprocessingBindingProvider();
-        ko.bindingProvider.instance.preprocessNode = function (node) {
-            if (node.nodeType === 3 && node.data.charAt(0) === "$") {
-                var newNodes = [
-                    document.createComment('ko text: ' + node.data),
-                    document.createComment('/ko')
-                ];
-                for (var i = 0; i < newNodes.length; i++) {
-                    node.parentNode.insertBefore(newNodes[i], node);
-                }
-                node.parentNode.removeChild(node);
-                return newNodes;
-            }
-        };
-
-        // Now perform a with binding, and see that afterRender gets the output from the preprocessor and bindings
-        testNode.innerHTML = "<div data-bind='if: condition, afterRender: callback'><span>[</span>$data.someText<span>]</span></div>";
-        var callbacks = 0;
-        var viewModel = {
-            condition: ko.observable(true),
-            someText: "hello",
-            callback: function (nodes, data) {
-                expect(nodes.length).toBe(5);
-                expect(nodes[0]).toContainText('[');    // <span>[</span>
-                expect(nodes[1].nodeType).toBe(8);      // <!-- ko text: $data.childprop -->
-                expect(nodes[2].nodeType).toBe(3);      // text node inserted by text binding
-                expect(nodes[3].nodeType).toBe(8);      // <!-- /ko -->
-                expect(nodes[4]).toContainText(']');    // <span>]</span>
-                expect(data).toBe(viewModel);
-                callbacks++;
-            }
-        };
-
-        ko.applyBindings(viewModel, testNode);
-
-        expect(testNode.childNodes[0]).toContainText('[hello]');
-        expect(callbacks).toBe(1);
-
-        ko.bindingProvider.instance = originalBindingProvider;
     });
 });

--- a/spec/defaultBindings/ifBehaviors.js
+++ b/spec/defaultBindings/ifBehaviors.js
@@ -97,8 +97,8 @@ describe('Binding: If', function() {
         expect(testNode).toContainHtml("hello <!-- ko if: condition1 -->first is true<!-- ko if: condition2 -->both are true<!-- /ko --><!-- /ko -->");
     });
 
-    it('Should call an afterRender callback function', function () {
-        testNode.innerHTML = "<div data-bind='if: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
+    it('Should call a childrenComplete callback function', function () {
+        testNode.innerHTML = "<div data-bind='if: condition, childrenComplete: callback'><span data-bind='text: someText'></span></div>";
         var someItem = ko.observable({ childprop: 'child' }),
             callbacks = 0;
         var viewModel = { condition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };

--- a/spec/defaultBindings/ifnotBehaviors.js
+++ b/spec/defaultBindings/ifnotBehaviors.js
@@ -63,23 +63,8 @@ describe('Binding: Ifnot', function() {
         expect(ko.contextFor(testNode.childNodes[0].childNodes[1]).$parents.length).toEqual(0);
     });
 
-    it('Should call an afterRender callback function and not cause updates if an observable accessed in the callback is changed', function () {
+    it('Should call an afterRender callback function', function () {
         testNode.innerHTML = "<div data-bind='ifnot: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
-        var callbackObservable = ko.observable(1),
-            callbacks = 0;
-        var viewModel = { condition: ko.observable(false), someText: "hello", callback: function() { callbackObservable(); callbacks++; } };
-        ko.applyBindings(viewModel, testNode);
-        expect(callbacks).toEqual(1);
-        expect(testNode.childNodes[0]).toContainText('hello');
-
-        viewModel.someText = "bello";
-        // Update callback observable and check that the binding wasn't updated
-        callbackObservable(2);
-        expect(testNode.childNodes[0]).toContainText('hello');
-    });
-
-    it('Should not call an afterRender callback function when data gets cleared', function () {
-      testNode.innerHTML = "<div data-bind='ifnot: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
         var someItem = ko.observable({ childprop: 'child' }),
             callbacks = 0;
         var viewModel = { condition: ko.observable(false), someText: "hello", callback: function () { callbacks++; } };
@@ -94,51 +79,5 @@ describe('Binding: Ifnot', function() {
         viewModel.condition(false);
         expect(callbacks).toEqual(2);
         expect(testNode.childNodes[0]).toContainText('hello');
-    });
-
-    it('Should call an afterRender callback, passing all of the rendered nodes, accounting for node preprocessing and virtual element bindings', function () {
-        // Set up a binding provider that converts text nodes to expressions
-        var originalBindingProvider = ko.bindingProvider.instance,
-            preprocessingBindingProvider = function () { };
-        preprocessingBindingProvider.prototype = originalBindingProvider;
-        ko.bindingProvider.instance = new preprocessingBindingProvider();
-        ko.bindingProvider.instance.preprocessNode = function (node) {
-            if (node.nodeType === 3 && node.data.charAt(0) === "$") {
-                var newNodes = [
-                    document.createComment('ko text: ' + node.data),
-                    document.createComment('/ko')
-                ];
-                for (var i = 0; i < newNodes.length; i++) {
-                    node.parentNode.insertBefore(newNodes[i], node);
-                }
-                node.parentNode.removeChild(node);
-                return newNodes;
-            }
-        };
-
-        // Now perform a with binding, and see that afterRender gets the output from the preprocessor and bindings
-        testNode.innerHTML = "<div data-bind='ifnot: condition, afterRender: callback'><span>[</span>$data.someText<span>]</span></div>";
-        var callbacks = 0;
-        var viewModel = {
-            condition: ko.observable(false),
-            someText: "hello",
-            callback: function (nodes, data) {
-                expect(nodes.length).toBe(5);
-                expect(nodes[0]).toContainText('[');    // <span>[</span>
-                expect(nodes[1].nodeType).toBe(8);      // <!-- ko text: $data.childprop -->
-                expect(nodes[2].nodeType).toBe(3);      // text node inserted by text binding
-                expect(nodes[3].nodeType).toBe(8);      // <!-- /ko -->
-                expect(nodes[4]).toContainText(']');    // <span>]</span>
-                expect(data).toBe(viewModel);
-                callbacks++;
-            }
-        };
-
-        ko.applyBindings(viewModel, testNode);
-
-        expect(testNode.childNodes[0]).toContainText('[hello]');
-        expect(callbacks).toBe(1);
-
-        ko.bindingProvider.instance = originalBindingProvider;
     });
 });

--- a/spec/defaultBindings/ifnotBehaviors.js
+++ b/spec/defaultBindings/ifnotBehaviors.js
@@ -63,8 +63,8 @@ describe('Binding: Ifnot', function() {
         expect(ko.contextFor(testNode.childNodes[0].childNodes[1]).$parents.length).toEqual(0);
     });
 
-    it('Should call an afterRender callback function', function () {
-        testNode.innerHTML = "<div data-bind='ifnot: condition, afterRender: callback'><span data-bind='text: someText'></span></div>";
+    it('Should call a childrenComplete callback function', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: condition, childrenComplete: callback'><span data-bind='text: someText'></span></div>";
         var someItem = ko.observable({ childprop: 'child' }),
             callbacks = 0;
         var viewModel = { condition: ko.observable(false), someText: "hello", callback: function () { callbacks++; } };

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -225,8 +225,8 @@ describe('Binding: With', function() {
         expect(testNode).toContainText("Total: 25");
     });
 
-    it('Should call an afterRender callback function', function () {
-        testNode.innerHTML = "<div data-bind='with: someItem, afterRender: callback'><span data-bind='text: childprop'></span></div>";
+    it('Should call a childrenComplete callback function', function () {
+        testNode.innerHTML = "<div data-bind='with: someItem, childrenComplete: callback'><span data-bind='text: childprop'></span></div>";
         var someItem = ko.observable({ childprop: 'child' }),
             callbacks = 0;
         ko.applyBindings({ someItem: someItem, callback: function () { callbacks++; } }, testNode);

--- a/spec/nodePreprocessingBehaviors.js
+++ b/spec/nodePreprocessingBehaviors.js
@@ -104,7 +104,7 @@ describe('Node preprocessing', function() {
         expect(testNode).toContainText('BetaBetaGammaGamma');
     });
 
-    it('Should call an afterRender callback, passing all of the rendered nodes, accounting for node preprocessing and virtual element bindings', function () {
+    it('Should call a childrenComplete callback, passing all of the rendered nodes, accounting for node preprocessing and virtual element bindings', function () {
         // Set up a binding provider that converts text nodes to expressions
         ko.bindingProvider.instance.preprocessNode = function (node) {
             if (node.nodeType === 3 && node.data.charAt(0) === "$") {
@@ -120,7 +120,7 @@ describe('Node preprocessing', function() {
             }
         };
 
-        // Now perform bindings, and see that afterRender gets the output from the preprocessor and bindings
+        // Now perform bindings, and see that childrenComplete gets the output from the preprocessor and bindings
         var callbacks = 0,
             vm = {
                 childprop: 'child property',
@@ -136,7 +136,7 @@ describe('Node preprocessing', function() {
                 }
             };
 
-        testNode.innerHTML = "<div data-bind='afterRender: callback'><span>[</span>$data.childprop<span>]</span></div>";
+        testNode.innerHTML = "<div data-bind='childrenComplete: callback'><span>[</span>$data.childprop<span>]</span></div>";
         ko.applyBindings(vm, testNode);
         expect(testNode.childNodes[0]).toContainText('[child property]');
         expect(callbacks).toBe(1);

--- a/spec/nodePreprocessingBehaviors.js
+++ b/spec/nodePreprocessingBehaviors.js
@@ -103,4 +103,42 @@ describe('Node preprocessing', function() {
         items.push('Gamma');
         expect(testNode).toContainText('BetaBetaGammaGamma');
     });
+
+    it('Should call an afterRender callback, passing all of the rendered nodes, accounting for node preprocessing and virtual element bindings', function () {
+        // Set up a binding provider that converts text nodes to expressions
+        ko.bindingProvider.instance.preprocessNode = function (node) {
+            if (node.nodeType === 3 && node.data.charAt(0) === "$") {
+                var newNodes = [
+                    document.createComment('ko text: ' + node.data),
+                    document.createComment('/ko')
+                ];
+                for (var i = 0; i < newNodes.length; i++) {
+                    node.parentNode.insertBefore(newNodes[i], node);
+                }
+                node.parentNode.removeChild(node);
+                return newNodes;
+            }
+        };
+
+        // Now perform bindings, and see that afterRender gets the output from the preprocessor and bindings
+        var callbacks = 0,
+            vm = {
+                childprop: 'child property',
+                callback: function (nodes, data) {
+                    expect(nodes.length).toBe(5);
+                    expect(nodes[0]).toContainText('[');    // <span>[</span>
+                    expect(nodes[1].nodeType).toBe(8);      // <!-- ko text: $data.childprop -->
+                    expect(nodes[2].nodeType).toBe(3);      // text node inserted by text binding
+                    expect(nodes[3].nodeType).toBe(8);      // <!-- /ko -->
+                    expect(nodes[4]).toContainText(']');    // <span>]</span>
+                    expect(data).toBe(vm);
+                    callbacks++;
+                }
+            };
+
+        testNode.innerHTML = "<div data-bind='afterRender: callback'><span>[</span>$data.childprop<span>]</span></div>";
+        ko.applyBindings(vm, testNode);
+        expect(testNode.childNodes[0]).toContainText('[child property]');
+        expect(callbacks).toBe(1);
+    });
 });

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -238,6 +238,20 @@ describe('Templating', function() {
         expect(testNode.childNodes[0].innerHTML).toEqual("result = 456");
     });
 
+    it('Should call a generic childrenComplete callback function', function () {
+        ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+        testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someItem }, childrenComplete: callback'></div>";
+        var someItem = ko.observable({ childProp: 'child' }),
+            callbacks = 0;
+        ko.applyBindings({ someItem: someItem, callback: function () { callbacks++; } }, testNode);
+        expect(callbacks).toEqual(1);
+        expect(testNode.childNodes[0]).toContainText('result = child');
+
+        someItem({ childProp: "new child" });
+        expect(callbacks).toEqual(2);
+        expect(testNode.childNodes[0]).toContainText('result = new child');
+    });
+
     it('Should stop tracking inner observables immediately when the container node is removed from the document', function() {
         var innerObservable = ko.observable("some value");
         ko.setTemplateEngine(new dummyTemplateEngine({ someTemplate: "result = [js: childProp()]" }));

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -235,12 +235,15 @@
 
             var afterRender = ko.utils.domData.get(elementOrVirtualElement, afterRenderCallbackDomDataKey);
             if (afterRender) {
-                var nodes = ko.virtualElements.childNodes(elementOrVirtualElement);
-                if (nodes.length) {
-                    ko.dependencyDetection.ignore(function () {
-                        evaluateValueAccessor(afterRender)(nodes, ko.dataFor(nodes[0]));
-                    });
-                }
+                ko.dependencyDetection.ignore(function () {
+                    afterRender = evaluateValueAccessor(afterRender);
+                    if (afterRender) {
+                        var nodes = ko.virtualElements.childNodes(elementOrVirtualElement);
+                        if (nodes.length) {
+                            afterRender(nodes, ko.dataFor(nodes[0]));
+                        }
+                    }
+                });
             }
         }
     }

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -10,27 +10,24 @@ function makeWithIfBinding(bindingKey, isWith, isNot) {
             ko.computed(function() {
                 var rawWithValue = isWith && ko.utils.unwrapObservable(valueAccessor()),
                     shouldDisplay = isWith ? !!rawWithValue : ifCondition(),
-                    isFirstRender = !savedNodes,
-                    renderNodes;
+                    isFirstRender = !savedNodes;
 
                 // Save a copy of the inner nodes on the initial update, but only if we have dependencies.
                 if (isFirstRender && ko.computedContext.getDependenciesCount()) {
-                    savedNodes = ko.utils.cloneNodes(renderNodes = ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
+                    savedNodes = ko.utils.cloneNodes(ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
                 }
 
                 if (shouldDisplay) {
                     if (!isFirstRender) {
-                        ko.virtualElements.setDomNodeChildren(element, renderNodes = ko.utils.cloneNodes(savedNodes));
+                        ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes));
                     }
-                    var newContext = isWith ?
+                    ko.applyBindingsToDescendants(
+                        isWith ?
                             bindingContext['createChildContext'](typeof rawWithValue == "function" ? rawWithValue : valueAccessor) :
                             ifCondition.isActive() ?
                                 bindingContext['extend'](function() { ifCondition(); return null; }) :
-                                bindingContext;
-                    ko.applyBindingsToDescendants(newContext, element);
-                    if (allBindings.has('afterRender')) {
-                        ko.dependencyDetection.ignore(allBindings.get('afterRender'), null, [renderNodes || ko.virtualElements.childNodes(element), newContext['$data']]);
-                    }
+                                bindingContext,
+                        element);
                 } else {
                     ko.virtualElements.emptyNode(element);
                 }

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -106,8 +106,12 @@
 
         if (haveAddedNodesToParent) {
             activateBindingsOnContinuousNodeArray(renderedNodesArray, bindingContext);
-            if (options['afterRender'])
+            if (options['afterRender']) {
                 ko.dependencyDetection.ignore(options['afterRender'], null, [renderedNodesArray, bindingContext['$data']]);
+            }
+            if (renderMode == "replaceChildren") {
+                ko.notifyBindingEvent(targetNodeOrNodeArray, ko.bindingEvent.childrenComplete);
+            }
         }
 
         return renderedNodesArray;
@@ -205,7 +209,7 @@
             // Call setDomNodeChildrenFromArrayMapping, ignoring any observables unwrapped within (most likely from a callback function).
             // If the array items are observables, though, they will be unwrapped in executeTemplateForArrayItem and managed within setDomNodeChildrenFromArrayMapping.
             ko.dependencyDetection.ignore(ko.utils.setDomNodeChildrenFromArrayMapping, null, [targetNode, filteredArray, executeTemplateForArrayItem, options, activateBindingsCallback]);
-
+            ko.notifyBindingEvent(targetNode, ko.bindingEvent.childrenComplete);
         }, null, { disposeWhenNodeIsRemoved: targetNode });
     };
 


### PR DESCRIPTION
 that works with any binding that calls `ko.applyBindingsToDescendants` or with just normal binding processing (more tests to come).