### PR TITLE
When using 'as' option with 'foreach' don't create child context

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -138,7 +138,16 @@
     // view model also depends on the parent view model, you must provide a function that returns the correct
     // view model on each update.
     ko.bindingContext.prototype['createChildContext'] = function (dataItemOrAccessor, dataItemAlias, extendCallback, options) {
-        return new ko.bindingContext(dataItemOrAccessor, this, dataItemAlias, function(self, parentContext) {
+        if (dataItemAlias && ko.options['noChildContextWithAs']) {
+            var isFunc = typeof(dataItemOrAccessor) == "function" && !ko.isObservable(dataItemOrAccessor);
+            return new ko.bindingContext(inheritParentVm, this, null, function (self) {
+                if (extendCallback)
+                    extendCallback(self);
+                self[dataItemAlias] = isFunc ? dataItemOrAccessor() : dataItemOrAccessor;
+            });
+        }
+
+        return new ko.bindingContext(dataItemOrAccessor, this, dataItemAlias, function (self, parentContext) {
             // Extend the context hierarchy by setting the appropriate pointers
             self['$parentContext'] = parentContext;
             self['$parent'] = parentContext['$data'];

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,8 @@
 // For any options that may affect various areas of Knockout and aren't directly associated with data binding.
 ko.options = {
     'deferUpdates': false,
-    'useOnlyNativeEvents': false
+    'useOnlyNativeEvents': false,
+    'noChildContextWithAs': false
 };
 
 //ko.exportSymbol('options', ko.options);   // 'options' isn't minified


### PR DESCRIPTION
We added the `as` option to `foreach` in version 2.2.0 (#606), which allows you to give a custom name to the data item. Currently this still creates a child context, with `$data` also pointing the the data item, and requires the need to use `$parent` to access the outer context.

We can provide more flexibility by maintaining the same context when `as` is given. With this change, you would then have to use the name given with `as` to access the array items. Since this is a breaking change, I'm suggesting we include it in the upcoming 3.0.0 version.
