### PR TITLE
Improve foreach performance by using arrayChange event

### DIFF
--- a/spec/defaultBindings/foreachBehaviors.js
+++ b/spec/defaultBindings/foreachBehaviors.js
@@ -61,7 +61,7 @@ describe('Binding: Foreach', function() {
 
 
     it('Should add and remove nodes to match changes in the bound array', function() {
-        testNode.innerHTML = "<div data-bind='foreach: someItems'><span data-bind='text: childProp'></span></div>";
+        testNode.innerHTML = "<div data-bind='foreach: { data: someItems, includeDestroyed: false }'><span data-bind='text: childProp'></span></div>";
         var someItems = ko.observableArray([
             { childProp: 'first child' },
             { childProp: 'second child' }
@@ -156,8 +156,8 @@ describe('Binding: Foreach', function() {
         var afterAddCallbackData = [], beforeRemoveCallbackData = [];
         ko.applyBindings({
             someItems: someItems,
-            myAfterAdd: function(elem, index, value) { afterAddCallbackData.push({ elem: elem, value: value, currentParentClone: elem.parentNode.cloneNode(true) }) },
-            myBeforeRemove: function(elem, index, value) { beforeRemoveCallbackData.push({ elem: elem, value: value, currentParentClone: elem.parentNode.cloneNode(true) }) }
+            myAfterAdd: function(elem, index, value) { afterAddCallbackData.push({ elem: elem, index: index, value: value, currentParentClone: elem.parentNode.cloneNode(true) }) },
+            myBeforeRemove: function(elem, index, value) { beforeRemoveCallbackData.push({ elem: elem, index: index, value: value, currentParentClone: elem.parentNode.cloneNode(true) }) }
         }, testNode);
 
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: $data">first child</span>');
@@ -167,6 +167,7 @@ describe('Binding: Foreach', function() {
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: $data">first child</span><span data-bind="text: $data">added child</span>');
         expect(afterAddCallbackData.length).toEqual(1);
         expect(afterAddCallbackData[0].elem).toEqual(testNode.childNodes[0].childNodes[1]);
+        expect(afterAddCallbackData[0].index).toEqual(0);
         expect(afterAddCallbackData[0].value).toEqual("added child");
         expect(afterAddCallbackData[0].currentParentClone).toContainHtml('<span data-bind="text: $data">first child</span><span data-bind="text: $data">added child</span>');
 
@@ -174,6 +175,7 @@ describe('Binding: Foreach', function() {
         someItems.shift();
         expect(beforeRemoveCallbackData.length).toEqual(1);
         expect(beforeRemoveCallbackData[0].elem).toContainText("first child");
+        expect(beforeRemoveCallbackData[0].index).toEqual(0);
         expect(beforeRemoveCallbackData[0].value).toEqual("first child");
         // Note that when using "beforeRemove", we *don't* remove the node from the doc - it's up to the beforeRemove callback to do it. So, check it's still there.
         expect(beforeRemoveCallbackData[0].currentParentClone).toContainHtml('<span data-bind="text: $data">first child</span><span data-bind="text: $data">added child</span>');
@@ -184,6 +186,7 @@ describe('Binding: Foreach', function() {
         someItems.shift();
         expect(beforeRemoveCallbackData.length).toEqual(1);
         expect(beforeRemoveCallbackData[0].elem).toContainText("added child");
+        expect(beforeRemoveCallbackData[0].index).toEqual(0);
         expect(beforeRemoveCallbackData[0].value).toEqual("added child");
         // Neither item has yet been removed and both are still in their original locations
         expect(beforeRemoveCallbackData[0].currentParentClone).toContainHtml('<span data-bind="text: $data">first child</span><span data-bind="text: $data">added child</span>');
@@ -196,6 +199,7 @@ describe('Binding: Foreach', function() {
         expect(testNode.childNodes[0]).toContainHtml('<span data-bind="text: $data">added child</span>');
         expect(afterAddCallbackData.length).toEqual(1);
         expect(afterAddCallbackData[0].elem).toEqual(testNode.childNodes[0].childNodes[0]);
+        expect(afterAddCallbackData[0].index).toEqual(0);
         expect(afterAddCallbackData[0].value).toEqual("added child");
         expect(afterAddCallbackData[0].currentParentClone).toContainHtml('<span data-bind="text: $data">added child</span>');
     });

--- a/spec/observableArrayBehaviors.js
+++ b/spec/observableArrayBehaviors.js
@@ -16,6 +16,23 @@ describe('Observable Array', function() {
         expect(ko.isObservable(testObservableArray)).toEqual(true);
     });
 
+    it('Should advertise as observable array', function () {
+        expect(ko.isObservableArray(ko.observableArray())).toEqual(true);
+    });
+
+    it('ko.isObservableArray should return false for non-observable array values', function () {
+        ko.utils.arrayForEach([
+            undefined,
+            null,
+            "x",
+            {},
+            function() {},
+            ko.observable([]),
+        ], function (value) {
+            expect(ko.isObservableArray(value)).toEqual(false);
+        });
+    });
+
     it('Should initialize to empty array if you pass no args to constructor', function() {
         var instance = new ko.observableArray();
         expect(instance().length).toEqual(0);

--- a/spec/templatingBehaviors.js
+++ b/spec/templatingBehaviors.js
@@ -815,10 +815,10 @@ describe('Templating', function() {
             expect(innerObservable.getSubscriptionsCount()).toEqual(0);
         });
 
-        it('Should omit any items whose \'_destroy\' flag is set (unwrapping the flag if it is observable)', function() {
+        it('Should omit any items whose \'_destroy\' flag is set (unwrapping the flag if it is observable) if includeDestroyed is false', function() {
             var myArray = new ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp : 3 }, { someProp: 4, _destroy: ko.observable(false) }]);
             ko.setTemplateEngine(new dummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
-            testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+            testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection, includeDestroyed: false }'></div>";
 
             ko.applyBindings({ myCollection: myArray }, testNode);
             expect(testNode.childNodes[0]).toContainHtml("<div>someprop=1</div><div>someprop=3</div><div>someprop=4</div>");
@@ -831,6 +831,18 @@ describe('Templating', function() {
 
             ko.applyBindings({ myCollection: myArray }, testNode);
             expect(testNode.childNodes[0]).toContainHtml("<div>someprop=1</div><div>someprop=2</div><div>someprop=3</div>");
+        });
+
+        it('Should omit any items whose \'_destroy\' flag is set if foreachHidesDestroyed is set', function() {
+            this.restoreAfter(ko.options, 'foreachHidesDestroyed');
+            ko.options.foreachHidesDestroyed = true;
+
+            var myArray = new ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp : 3 }, { someProp: 4, _destroy: false }]);
+            ko.setTemplateEngine(new dummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
+            testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+            ko.applyBindings({ myCollection: myArray }, testNode);
+            expect(testNode.childNodes[0]).toContainHtml("<div>someprop=1</div><div>someprop=3</div><div>someprop=4</div>");
         });
 
         it('Should be able to render a different template for each array entry by passing a function as template name, with the array entry\'s binding context available as a second parameter', function() {

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,8 @@
 ko.options = {
     'deferUpdates': false,
     'useOnlyNativeEvents': false,
-    'noChildContextWithAs': false
+    'noChildContextWithAs': false,
+    'foreachHidesDestroyed': false
 };
 
 //ko.exportSymbol('options', ko.options);   // 'options' isn't minified

--- a/src/subscribables/observableArray.js
+++ b/src/subscribables/observableArray.js
@@ -132,4 +132,11 @@ ko.utils.arrayForEach(["slice"], function (methodName) {
     };
 });
 
+ko.isObservableArray = function (instance) {
+    return ko.isObservable(instance)
+        && typeof instance["remove"] == "function"
+        && typeof instance["push"] == "function";
+};
+
 ko.exportSymbol('observableArray', ko.observableArray);
+ko.exportSymbol('isObservableArray', ko.isObservableArray);

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -183,7 +183,7 @@
 
             var templateName = resolveTemplateName(template, arrayValue, arrayItemContext);
             return executeTemplate(targetNode, "ignoreTargetNode", templateName, arrayItemContext, options);
-        }
+        };
 
         // This will be called whenever setDomNodeChildrenFromArrayMapping has added nodes to targetNode
         var activateBindingsCallback = function(arrayValue, addedNodesArray, index) {
@@ -196,21 +196,40 @@
             arrayItemContext = null;
         };
 
-        return ko.dependentObservable(function () {
-            var unwrappedArray = ko.utils.unwrapObservable(arrayOrObservableArray) || [];
-            if (typeof unwrappedArray.length == "undefined") // Coerce single value into array
-                unwrappedArray = [unwrappedArray];
-
-            // Filter out any entries marked as destroyed
-            var filteredArray = ko.utils.arrayFilter(unwrappedArray, function(item) {
-                return options['includeDestroyed'] || item === undefined || item === null || !ko.utils.unwrapObservable(item['_destroy']);
-            });
-
+        var setDomNodeChildrenFromArrayMapping = function (newArray, changeList) {
             // Call setDomNodeChildrenFromArrayMapping, ignoring any observables unwrapped within (most likely from a callback function).
             // If the array items are observables, though, they will be unwrapped in executeTemplateForArrayItem and managed within setDomNodeChildrenFromArrayMapping.
-            ko.dependencyDetection.ignore(ko.utils.setDomNodeChildrenFromArrayMapping, null, [targetNode, filteredArray, executeTemplateForArrayItem, options, activateBindingsCallback]);
+            ko.dependencyDetection.ignore(ko.utils.setDomNodeChildrenFromArrayMapping, null, [targetNode, newArray, executeTemplateForArrayItem, options, activateBindingsCallback, changeList]);
             ko.bindingEvent.notify(targetNode, ko.bindingEvent.childrenComplete);
-        }, null, { disposeWhenNodeIsRemoved: targetNode });
+        };
+
+        var shouldHideDestroyed = (options['includeDestroyed'] === false) || (ko.options['foreachHidesDestroyed'] && !options['includeDestroyed']);
+
+        if (!shouldHideDestroyed && !options['beforeRemove'] && ko.isObservableArray(arrayOrObservableArray)) {
+            setDomNodeChildrenFromArrayMapping(arrayOrObservableArray.peek());
+
+            var subscription = arrayOrObservableArray.subscribe(function (changeList) {
+                setDomNodeChildrenFromArrayMapping(arrayOrObservableArray(), changeList);
+            }, null, "arrayChange");
+            subscription.disposeWhenNodeIsRemoved(targetNode);
+
+            return subscription;
+        } else {
+            return ko.dependentObservable(function () {
+                var unwrappedArray = ko.utils.unwrapObservable(arrayOrObservableArray) || [];
+                if (typeof unwrappedArray.length == "undefined") // Coerce single value into array
+                    unwrappedArray = [unwrappedArray];
+
+                if (shouldHideDestroyed) {
+                    // Filter out any entries marked as destroyed
+                    unwrappedArray = ko.utils.arrayFilter(unwrappedArray, function(item) {
+                        return item === undefined || item === null || !ko.utils.unwrapObservable(item['_destroy']);
+                    });
+                }
+                setDomNodeChildrenFromArrayMapping(unwrappedArray);
+
+            }, null, { disposeWhenNodeIsRemoved: targetNode });
+        }
     };
 
     var templateComputedDomDataKey = ko.utils.domData.nextKey();
@@ -218,7 +237,7 @@
         var oldComputed = ko.utils.domData.get(element, templateComputedDomDataKey);
         if (oldComputed && (typeof(oldComputed.dispose) == 'function'))
             oldComputed.dispose();
-        ko.utils.domData.set(element, templateComputedDomDataKey, (newComputed && newComputed.isActive()) ? newComputed : undefined);
+        ko.utils.domData.set(element, templateComputedDomDataKey, (newComputed && (!newComputed.isActive || newComputed.isActive())) ? newComputed : undefined);
     }
 
     var cleanContainerDomDataKey = ko.utils.domData.nextKey();


### PR DESCRIPTION
Currently, the `foreach` binding has to compare the old and new arrays on each update. Using the `arrayChange` event will provide a performance improvement when using a known operation like `push` with large arrays.

Unfortunately, in order to gain this benefit, we'll need to change the default behavior of `foreach` to consider `includeDestroyed` as `true`.

My question is: How many are using the `destroy`/`destroyAll` methods?