### PR TITLE
Add typescript types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 *
 !build/output/knockout-latest.js
 !build/output/knockout-latest.debug.js
+!build/types/knockout.d.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: node_js
+
+before_install:
+  - npm install -g typescript
+  

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,10 @@ module.exports = function(grunt) {
         test: {
             phantomjs: 'spec/runner.phantom.js',
             node: 'spec/runner.node.js'
+        },
+        testtypes: {
+            global: "spec/types/global",
+            module: "spec/types/module"
         }
     });
 
@@ -151,6 +155,24 @@ module.exports = function(grunt) {
         );
     });
 
+    grunt.registerMultiTask('testtypes', 'Run types tests', function () {
+        var done = this.async(),
+            target = this.target;
+
+        grunt.util.spawn({ cmd: "tsc", args: ["-p", this.data] },
+            function (error, result, code) {
+                grunt.log.writeln(result.stdout);
+
+                if (error)
+                    grunt.log.error(result.stderr);
+                else
+                    grunt.log.ok("Knockout TypeScript " + target + " types validated!");
+
+                done(!error);
+            }
+        );
+    });
+
     grunt.registerTask('dist', function() {
         var version = grunt.config('pkg.version'),
             buildConfig = grunt.config('build'),
@@ -170,5 +192,5 @@ module.exports = function(grunt) {
     });
 
     // Default task.
-    grunt.registerTask('default', ['clean', 'checktrailingspaces', 'build', 'test']);
+    grunt.registerTask('default', ['clean', 'checktrailingspaces', 'build', 'test', 'testtypes']);
 };

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -1,0 +1,915 @@
+// Type definitions for Knockout v3.4.0
+// Project: http://knockoutjs.com
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT>
+
+export as namespace ko;
+
+//#region subscribables/subscribable.js
+
+export type SubscriptionCallback<T = any> = (val: T) => void;
+export type MaybeSubscribable<T = any> = T | Subscribable<T>;
+
+export class subscription<T = any> {
+    constructor(target: Subscribable<T>, callback: SubscriptionCallback<T>, disposeCallback: () => void);
+
+    dispose(): void;
+}
+
+export interface SubscribableFunctions<T = any> extends Function {
+    notifySubscribers(): void;
+    notifySubscribers(valueToWrite: T): void;
+    notifySubscribers(valueToWrite: T, event: string): void;
+
+    subscribe(callback: SubscriptionCallback<T>): subscription<T>;
+    subscribe(callback: SubscriptionCallback<T>, callbackTarget: any): subscription<T>;
+    subscribe(callback: SubscriptionCallback<T>, callbackTarget: any, event: string): subscription<T>;
+
+    extend(requestedExtenders: Object): this;
+    extend<T extends Subscribable<any>>(requestedExtenders: Object): T;
+
+    getSubscriptionsCount(): number;
+    getSubscriptionsCount(event: string): number;
+}
+
+export interface Subscribable<T = any> extends SubscribableFunctions<T> { }
+
+export const subscribable: {
+    new <T = any>(): Subscribable<T>;
+    fn: SubscribableFunctions;
+};
+
+export function isSubscribable<T = any>(instance: any): instance is Subscribable<T>;
+
+//#endregion
+
+//#region subscribables/observable.js
+
+export type MaybeObservable<T = any> = T | Observable<T>;
+
+export interface ObservableFunctions<T = any> extends Subscribable<T> {
+    equalityComparer(a: T, b: T): boolean;
+    peek(): T;
+    valueHasMutated(): void;
+    valueWillMutate(): void;
+}
+
+export interface Observable<T = any> extends ObservableFunctions<T> {
+    (): T;
+    (value: T): this;
+}
+
+export function observable<T = any>(): Observable<T>;
+export function observable<T = any>(initialValue: T): Observable<T>;
+export module observable {
+    export const fn: ObservableFunctions;
+}
+
+export function isObservable<T = any>(instance: any): instance is Observable<T>;
+
+export function isWriteableObservable<T = any>(instance: any): instance is Observable<T>;
+export function isWritableObservable<T = any>(instance: any): instance is Observable<T>;
+
+//#endregion
+
+//#region subscribables/observableArray.js
+
+export type MaybeObservableArray<T = any> = T[] | ObservableArray<T>;
+
+export interface ObservableArrayFunctions<T = any> extends ObservableFunctions<T[]> {
+    // General Array functions
+    indexOf(searchElement: T, fromIndex?: number): number;
+
+    slice(start: number): T[];
+    slice(start: number, end?: number): T[];
+
+    splice(start: number): T[];
+    splice(start: number, deleteCount: number, ...items: T[]): T[];
+
+    pop(): T;
+    push(...items: T[]): void;
+
+    shift(): T;
+    unshift(...items: T[]): number;
+
+    reverse(): T[];
+
+    sort(): void;
+    sort(compareFunction: (left: T, right: T) => number): void;
+
+    // Ko specific
+    replace(oldItem: T, newItem: T): void;
+
+    remove(item: T): T[];
+    remove(removeFunction: (item: T) => boolean): T[];
+
+    removeAll(): T[];
+    removeAll(items: T[]): T[];
+
+    destroy(item: T): void;
+    destroy(destroyFunction: (item: T) => boolean): void;
+
+    destroyAll(): void;
+    destroyAll(items: T[]): void;
+}
+
+export interface ObservableArray<T = any> extends Observable<T[]>, ObservableArrayFunctions<T> {
+    (value: T[] | null | undefined): this;
+}
+
+export function observableArray<T = any>(): ObservableArray<T>;
+export function observableArray<T = any>(initialValue: T[]): ObservableArray<T>;
+export module observableArray {
+    export const fn: ObservableArrayFunctions;
+}
+
+//#endregion
+
+//#region subscribables/dependendObservable.js
+
+export type ComputedReadFunction<T = any> = Subscribable<T> | Observable<T> | Computed<T> | (() => T);
+export type ComputedWriteFunction<T = any> = (val: T) => void;
+export type MaybeComputed<T = any> = T | Computed<T>;
+
+export interface ComputedFunctions<T = any> extends Subscribable<T> {
+    equalityComparer(a: T, b: T): boolean;
+    peek(): T;
+    dispose(): void;
+    isActive(): boolean;
+    getDependenciesCount(): number;
+}
+
+export interface Computed<T = any> extends ComputedFunctions<T> {
+    (): T;
+    (value: T): this;
+}
+
+export interface PureComputed<T = any> extends Computed<T> { }
+
+export interface ComputedOptions<T = any> {
+    read?: ComputedReadFunction<T>,
+    write?: ComputedWriteFunction<T>,
+    owner?: any;
+    pure?: boolean;
+    deferEvaluation?: boolean;
+    disposeWhenNodeIsRemoved?: boolean;
+    disposeWhen?: () => boolean;
+}
+
+export function computed<T = any>(options: ComputedOptions<T>): Computed<T>;
+export function computed<T = any>(evaluator: ComputedReadFunction<T>): Computed<T>;
+export function computed<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any): Computed<T>;
+export function computed<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any, options: ComputedOptions<T>): Computed<T>;
+export module computed {
+    export const fn: ComputedFunctions<any>;
+}
+
+export function pureComputed<T = any>(options: ComputedOptions<T>): PureComputed<T>;
+export function pureComputed<T = any>(evaluator: ComputedReadFunction<T>): PureComputed<T>;
+export function pureComputed<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any): PureComputed<T>;
+export function pureComputed<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any, options: ComputedOptions<T>): PureComputed<T>;
+
+export function dependentObservable<T = any>(options: ComputedOptions<T>): Computed<T>;
+export function dependentObservable<T = any>(evaluator: ComputedReadFunction<T>): Computed<T>;
+export function dependentObservable<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any): Computed<T>;
+export function dependentObservable<T = any>(evaluator: ComputedReadFunction<T>, evaluatorTarget: any, options: ComputedOptions<T>): Computed<T>;
+export module dependentObservable {
+    export const fn: ComputedFunctions;
+}
+
+export function isComputed<T = any>(instance: any): instance is Computed<T>;
+export function isPureComputed<T = any>(instance: any): instance is PureComputed<T>;
+
+//#endregion
+
+//#region subscribables/dependencyDetection.js
+
+export interface ComputedContext {
+    getDependenciesCount(): number;
+    isInitial(): boolean;
+}
+
+export const computedContext: ComputedContext;
+export const dependencyDetection: ComputedContext;
+
+export function ignoreDependencies(callback: Function): void;
+export function ignoreDependencies(callback: Function, callbackTarget: any): void;
+export function ignoreDependencies(callback: Function, callbackTarget: any, callbackArgs: any[]): void;
+
+//#endregion
+
+//#region subscribables/extenders.js
+
+export interface Extender<T extends Subscribable = any> {
+    (target: T, options?: any): T;
+}
+
+export interface Extenders {
+    [name: string]: Extender;
+
+    trackArrayChanges: Extender<ObservableArray>;
+    throttle: Extender<Observable>;
+    rateLimit: Extender<Subscribable>;
+    deferred: Extender<Subscribable>;
+    notify: Extender<Subscribable>;
+}
+
+export const extenders: Extenders;
+
+//#endregion
+
+//#region subscribables/mappingHelpers.js
+
+export function toJS(rootObject: any): any;
+export function toJSON(rootObject: any): any;
+export function toJSON(rootObject: any, replacer: Function): any;
+export function toJSON(rootObject: any, replacer: Function, space: number): any;
+
+//#endregion
+
+//#region binding/bindingAttributeSyntax.js
+
+interface AllBindingsAccessor {
+    (): any;
+
+    get(name: string): any;
+    get<T>(name: string): T;
+
+    has(name: string): boolean;
+}
+export type BindingHandlerControlsDescendant = { controlsDescendantBindings: boolean; }
+export type BindingHandlerAddBinding = (name: string, value: any) => void;
+export interface BindingHandler {
+    after?: string[];
+    init?: (element: any, valueAccessor: () => any, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>) => void | BindingHandlerControlsDescendant;
+    update?: (element: any, valueAccessor: () => any, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>) => void;
+    options?: any;
+    preprocess?: (value: any, name: string, addBinding?: BindingHandlerAddBinding) => void;
+}
+
+export interface BindingHandlers {
+    [name: string]: BindingHandler;
+}
+
+export interface BindingContext<T = any> {
+    ko: any; // typeof ko;
+
+    [name: string]: any;
+
+    $parent: any;
+    $parents: any[];
+    $root: any;
+    $data: T;
+    $rawData: T | Observable<T>;
+    $index?: Observable<number>;
+    $parentContext?: BindingContext<any>;
+
+    $component?: any;
+
+    extend(properties: any): any;
+
+    createChildContext<T>(dataItem: T): BindingContext<T>;
+    createChildContext<T>(dataItem: T, dataItemAlias: string): BindingContext<T>;
+    createChildContext<T>(dataItem: T, dataItemAlias: string, extendCallback: BindingContextExtendCallback<T>): BindingContext<T>;
+
+    createChildContext<T>(accessor: () => T): BindingContext<T>;
+    createChildContext<T>(dataItem: () => T, dataItemAlias: string): BindingContext<T>;
+    createChildContext<T>(dataItem: () => T, dataItemAlias: string, extendCallback: BindingContextExtendCallback<T>): BindingContext<T>;
+}
+
+export function applyBindings<T = any>(bindingContext: T | BindingContext<T>): void;
+export function applyBindings<T = any>(bindingContext: T | BindingContext<T>, rootNode: Node | null): void;
+export function applyBindings<T = any>(bindingContext: T | BindingContext<T>, rootNode: Node | null, extendCallback: BindingContextExtendCallback<T>): void;
+
+export function applyBindingsToDescendants<T = any>(bindingContext: T | BindingContext<T>): void;
+export function applyBindingsToDescendants<T = any>(bindingContext: T | BindingContext<T>, rootNode: Node): void;
+
+export function applyBindingsToNode<T = any>(node: Node, bindings: Object | (() => Object), viewModel: T | BindingContext<T>): void;
+export function applyBindingAccessorsToNode<T = any>(node: Node, bindings: Object | (() => Object), viewModel: T | BindingContext<T>): void;
+
+export function dataFor<T = any>(node: Node): T;
+export function contextFor<T = any>(node: Node): BindingContext<T>;
+
+export const bindingHandlers: BindingHandlers;
+export function getBindingHandler(handler: string): BindingHandler;
+
+export type BindingContextExtendCallback<T = any> = (self: BindingContext<T>, parentContext: BindingContext<T> | null, dataItem: T) => void;
+
+//#endregion
+
+//#region binding/bindingProvider.js
+
+export type BindingAccessors = { [name: string]: Function; };
+
+export interface BindingOptions {
+    valueAccessors?: boolean;
+    bindingParams?: boolean;
+}
+
+export interface IBindingProvider {
+    nodeHasBindings(node: Node): boolean;
+    getBindings(node: Node, bindingContext: BindingContext<any>): Object;
+    getBindingAccessors(node: Node, bindingContext: BindingContext<any>): BindingAccessors;
+}
+
+export class bindingProvider implements IBindingProvider {
+    nodeHasBindings(node: Node): boolean;
+
+    getBindings(node: Node, bindingContext: BindingContext<any>): Object;
+    getBindingAccessors(node: Node, bindingContext: BindingContext<any>): BindingAccessors;
+
+    getBindingsString(node: Node): string;
+    getBindingsString(node: Node, bindingContext: BindingContext<any>): string;
+
+    parseBindingsString(bindingsString: string, bindingContext: BindingContext<any>, node: Node): Object;
+    parseBindingsString(bindingsString: string, bindingContext: BindingContext<any>, node: Node, options: BindingOptions): Object | BindingAccessors;
+
+    static instance: IBindingProvider;
+}
+
+//#endregion
+
+//#region binding/expressionRewriting.js
+export module expressionRewriting {
+    export interface KeyValue {
+        key?: string;
+        value?: string;
+        unknown?: string;
+    }
+
+    export const bindingRewriteValidators: any[];
+
+    export function parseObjectLiteral(objectLiteralString: string): KeyValue[];
+
+    export function preProcessBindings(bindingsString: string): string;
+    export function preProcessBindings(bindingsString: string, bindingOptions: BindingOptions): string;
+    export function preProcessBindings(keyValueArray: KeyValue[]): string;
+    export function preProcessBindings(keyValueArray: KeyValue[], bindingOptions: BindingOptions): string;
+
+    export const _twoWayBindings: Object;
+}
+
+export module jsonExpressionRewriting {
+    export interface KeyValue {
+        key?: string;
+        value?: string;
+        unknown?: string;
+    }
+
+    export function insertPropertyAccessorsIntoJson(bindingsString: string): string;
+    export function insertPropertyAccessorsIntoJson(bindingsString: string, bindingOptions: BindingOptions): string;
+    export function insertPropertyAccessorsIntoJson(keyValueArray: KeyValue[]): string;
+    export function insertPropertyAccessorsIntoJson(keyValueArray: KeyValue[], bindingOptions: BindingOptions): string;
+}
+
+//#endregion
+
+//#region binding/selectExtensions.js
+
+export module selectExtensions {
+    export function readValue(element: HTMLElement): any;
+
+    export function writeValue(element: HTMLElement): void;
+    export function writeValue(element: HTMLElement, value: any): void;
+    export function writeValue(element: HTMLElement, value: any, allowUnset: boolean): void;
+}
+
+//#endregion
+
+//#region binding/defaultBindings/
+
+export interface BindingHandlers {
+    // Controlling text and appearance
+    visible: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    text: {
+        init(): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<string>): void;
+    };
+    html: {
+        init(): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<string>): void;
+    };
+    class: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<string>): void;
+    };
+    css: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<string | Object>): void;
+    };
+    style: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<Object>): void;
+    };
+    attr: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<Object>): void;
+    };
+
+    // Control Flow
+    foreach: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<any[] | Object>): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<any[] | Object>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    if: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<any>): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    ifnot: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<any>): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    with: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<any>): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+
+    // Working with form fields
+    event: {
+        init(element: HTMLElement, valueAccessor: () => Object, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    click: {
+        init(element: HTMLElement, valueAccessor: () => Function, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    submit: {
+        init(element: HTMLElement, valueAccessor: () => Function, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+    enable: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    disable: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    value: {
+        after: string[];
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+        update(...args: any[]): void; // Keep for backwards compatibility with code that may have wrapped value binding
+    };
+    textInput: {
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<string>, allBindingsAccessor: AllBindingsAccessor): void;
+    };
+    textinput: {
+        preprocess(value: any, name: string, addBinding?: BindingHandlerAddBinding): void;
+    };
+    hasfocus: {
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    hasFocus: {
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    checked: {
+        after: string[];
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+    };
+    checkedValue: {
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    options: {
+        init(element: HTMLElement): BindingHandlerControlsDescendant;
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+    };
+    selectedOptions: {
+        after: string[];
+        init(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor): void;
+        update(element: HTMLElement, valueAccessor: () => MaybeSubscribable<any>): void;
+    };
+    uniqueName: {
+        init(element: HTMLElement, valueAccessor: () => boolean): void;
+    };
+
+    let: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<any>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): BindingHandlerControlsDescendant;
+    };
+}
+
+export interface VirtualElementsAllowedBindings {
+    foreach: boolean;
+    if: boolean;
+    ifnot: boolean;
+    with: boolean;
+    let: boolean;
+}
+
+//#endregion
+
+//#region binding/editDetection/compareArrays.js
+
+export module utils {
+    export interface ArrayChange<T = any> {
+        status: string;
+        value: T;
+        index: number;
+        moved?: number;
+    }
+
+    export interface CompareArraysOptions {
+        dontLimitMoves?: boolean;
+        sparse?: boolean;
+    }
+
+    export function compareArrays<T = any>(a: T[], b: T[]): Array<ArrayChange<T>>;
+    export function compareArrays<T = any>(a: T[], b: T[], dontLimitMoves: boolean): Array<ArrayChange<T>>;
+    export function compareArrays<T = any>(a: T[], b: T[], options: CompareArraysOptions): Array<ArrayChange<T>>;
+}
+
+//#endregion
+
+//#region binding/editDetection/arrayToDomNodeChildren.js
+
+export module utils {
+    export type MappingFunction<T = any> = (valueToMap: T, index: number, nodes: Node[]) => Node[];
+    export type MappingAfterAddFunction<T = any> = (arrayEntry: T, nodes: Node[], index: Observable<number>) => Node[];
+    export type MappingHookFunction<T = any> = (nodes: Node[], index: number, arrayEntry: T) => void;
+
+    export interface MappingOptions<T = any> {
+        dontLimitMoves?: boolean;
+        beforeMove?: MappingHookFunction<T>;
+        beforeRemove?: MappingHookFunction<T>;
+        afterAdd?: MappingHookFunction<T>;
+        afterMove?: MappingHookFunction<T>;
+        afterRemove?: MappingHookFunction<T>;
+    }
+
+    export function setDomNodeChildrenFromArrayMapping<T = any>(domNode: Node, array: T[], mapping: MappingFunction<T>): void;
+    export function setDomNodeChildrenFromArrayMapping<T = any>(domNode: Node, array: T[], mapping: MappingFunction<T>, options: MappingOptions<T>): void;
+    export function setDomNodeChildrenFromArrayMapping<T = any>(domNode: Node, array: T[], mapping: MappingFunction<T>, options: MappingOptions<T>, callbackAfterAddingNodes: MappingAfterAddFunction<T>): void;
+}
+
+//#endregion
+
+//#region templating/templating.js
+
+export interface TemplateOptions<T = any> {
+    afterRender?: (elements: Node[], dataItem: T) => void;
+    templateEngine?: templateEngine;
+}
+
+export interface TemplateForeachOptions<T = any> extends TemplateOptions<T[]>, utils.MappingOptions<T> {
+    as?: string;
+    includeDestroyed?: boolean;
+}
+
+export interface BindingTemplateOptions extends TemplateOptions, utils.MappingOptions {
+    name?: string | ((val: any) => string);
+    nodes?: Node[];
+
+    if?: boolean;
+    ifnot?: boolean;
+
+    data?: any;
+    foreach?: any[];
+
+    as?: string;
+    includeDestroyed?: boolean;
+}
+
+export interface BindingHandlers {
+    template: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<string | BindingTemplateOptions>): BindingHandlerControlsDescendant;
+        update(element: Node, valueAccessor: () => MaybeSubscribable<string | BindingTemplateOptions>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): void;
+    };
+}
+export interface VirtualElementsAllowedBindings {
+    template: boolean;
+}
+
+export function renderTemplate(template: string | Node | (() => string | Node)): string;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined): string;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined): string;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined, targetNodeOrNodeArray: Node | Node[]): Computed<void>;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined, targetNodeOrNodeArray: Node | Node[], renderMode: string): Computed<void>;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined, targetNodeOrNodeArray: Node | Node[], renderMode: "replaceChildren"): Computed<void>;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined, targetNodeOrNodeArray: Node | Node[], renderMode: "replaceNode"): Computed<void>;
+export function renderTemplate<T = any>(template: string | Node | (() => string | Node), dataOrBindingContext: T | BindingContext<T> | null | undefined, options: TemplateOptions<T> | null | undefined, targetNodeOrNodeArray: Node | Node[], renderMode: "ignoreTargetNode"): Computed<void>;
+
+export function setTemplateEngine(templateEngine: templateEngine | undefined): void;
+
+//#endregion
+
+//#region templating/templateEngine.js
+
+export abstract class templateEngine {
+    allowTemplateRewriting: boolean;
+
+    abstract renderTemplateSource(templateSource: TemplateSource, bindingContext: BindingContext<any>, options: TemplateOptions<any>, templateDocument?: Document): Node[];
+    createJavaScriptEvaluatorBlock(script: string): string;
+
+    makeTemplateSource(template: string | Node, templateDocument?: Document): TemplateSource;
+
+    renderTemplate(template: string | Node, bindingContext: BindingContext<any>, options: TemplateOptions<any>, templateDocument?: Document): Node[];
+
+    isTemplateRewritten(template: string | Node, templateDocument?: Document): boolean;
+
+    rewriteTemplate(template: string | Node, rewriterCallback: (val: string) => string, templateDocument?: Document): void;
+}
+
+//#endregion
+
+//#region templating/templateSources.js
+
+export interface TemplateSource {
+    text(): string;
+    text(valueToWrite: string): void;
+
+    data(key: string): any;
+    data<T>(key: string): T;
+    data<T>(key: string, valueToWrite: T): void;
+
+    nodes?: {
+        (): Node;
+        (valueToWrite: Node): void;
+    };
+}
+
+export module templateSources {
+    export class domElement implements TemplateSource {
+        domElement: Node;
+
+        constructor(element: Node);
+
+        text(): string;
+        text(valueToWrite: string): void;
+
+        data(key: string): any;
+        data<T>(key: string): T;
+        data<T>(key: string, valueToWrite: T): void;
+
+        nodes(): Node;
+        nodes(valueToWrite: Node): void;
+    }
+
+    export class anonymousTemplate extends domElement {
+        constructor(element: Node);
+    }
+}
+
+//#endregion
+
+//#region templating/native/nativeTemplateEngine.js
+
+export class nativeTemplateEngine extends templateEngine {
+    renderTemplateSource(templateSource: TemplateSource, bindingContext: BindingContext<any>, options: TemplateOptions<any>, templateDocument?: Document): Node[];
+
+    static instance: nativeTemplateEngine;
+}
+
+//#endregion
+
+//#region templating/jquery.tmpl/jqueryTmplTemplateEngine.js
+
+export class jqueryTmplTemplateEngine extends templateEngine {
+    jQueryTmplVersion: number;
+
+    renderTemplateSource(templateSource: TemplateSource, bindingContext: BindingContext<any>, options: TemplateOptions<any>, templateDocument?: Document): Node[];
+    addTemplate(templateName: string, templateMarkup: string): void;
+
+    static instance: nativeTemplateEngine;
+}
+
+//#endregion
+
+//#region components/componentBinding.js
+
+export interface BindingHandlers {
+    component: {
+        init(element: Node, valueAccessor: () => MaybeSubscribable<{ name: any; params: any; }>, allBindingsAccessor: AllBindingsAccessor, viewModel: any, bindingContext: BindingContext<any>): BindingHandlerControlsDescendant;
+    };
+}
+export interface VirtualElementsAllowedBindings {
+    component: boolean;
+}
+
+//#endregion
+
+//#region components/customElements.js
+
+export module components {
+    export function getComponentNameForNode(node: Node): string;
+}
+
+//#endregion
+
+//#region components/defaultLoader.js
+
+export module components {
+    export interface ViewModelParams {
+        [name: string]: any;
+    }
+
+    export interface ComponentInfo {
+        element: Node;
+        templateNodes: Node[];
+    }
+
+    export interface Component {
+        viewModel: any;
+        template: Node[];
+    }
+
+    export interface ViewModelStatic {
+        instance: any;
+    }
+    export interface ViewModelConstructor {
+        new(params?: ViewModelParams): any;
+    }
+    export interface ViewModelFactory {
+        createViewModel(params: ViewModelParams, componentInfo: ComponentInfo): any;
+    }
+    export interface TemplateElement {
+        element: string | Node;
+    }
+
+    export type ViewModelConfig = ViewModelStatic | ViewModelParams | ViewModelFactory;
+    export type TemplateConfig = string | Node[] | DocumentFragment | TemplateElement;
+    export interface RequireConfig {
+        require: string;
+    }
+    export interface Config {
+        require?: string;
+        viewModel?: RequireConfig | ViewModelConfig;
+        template?: RequireConfig | TemplateConfig;
+        synchronous?: boolean;
+    }
+
+    export function register(componentName: string, config: Config): void;
+    export function unregister(componentName: string): void;
+    export function isRegistered(componentName: string): boolean;
+
+    export interface Loader {
+        getConfig(componentName: string, callback: (config: Config) => void): void;
+        loadComponent(componentName: string, config: Config, callback: (component: Component) => void): void;
+        loadTemplate(componentName: string, config: TemplateConfig, callback: (template: Node[]) => void): void;
+        loadViewModel(componentName: string, config: ViewModelConfig, callback: (viewModel: any) => void): void;
+    }
+
+    export const defaultLoader: Loader;
+    export const loaders: Loader[];
+}
+
+//#endregion
+
+//#region components/loaderRegistry.js
+
+export module components {
+    export function get(componentName: string, callback: (definition: Component, config: Config) => void): string;
+    export function clearCachedDefinition(componentName: string): void;
+}
+
+//#endregion
+
+//#region virtualElements.js
+
+export interface VirtualElementsAllowedBindings {
+    [name: string]: boolean;
+}
+
+export module virtualElements {
+    export const allowedBindings: VirtualElementsAllowedBindings;
+
+    export function childNodes(node: Node): Node[];
+    export function emptyNode(node: Node): void;
+    export function firstChild(node: Node): Node;
+    export function insertAfter(node: Node, nodeToInsert: Node, insertAfterNode: Node): void;
+    export function nextSibling(node: Node): Node;
+    export function prepend(node: Node, nodeToPrepend: Node): void;
+    export function setDomNodeChildren(node: Node, childNodes: Node[]): void;
+}
+
+//#endregion
+
+//#region memoization.js
+
+export module memoization {
+    export function memoize(callback: (val: any) => void): Node[];
+    export function unmemoize(memoId: string, callbackParams: any[]): void;
+    export function unmemoizeDomNodeAndDescendants(domNode: Node, extraCallbackParamsArray: any[]): void;
+    export function parseMemoText(memoText: string): string;
+}
+
+//#endregion
+
+//#region options.js
+
+export interface Options {
+    deferUpdates: boolean;
+    useOnlyNativeEvents: boolean;
+}
+
+export const options: Options;
+
+//#endregion
+
+//#region tasks.js
+
+export module tasks {
+    export var scheduler: (callback: () => any) => void;
+
+    export function schedule(callback: () => any): number;
+    export function cancel(handle: number): void;
+
+    export function runEarly(): void;
+}
+
+//#endregion
+
+//#region utils.js
+
+export module utils {
+    export interface PostJsonOptions {
+        params?: Object;
+        includeFields?: string[];
+        submitter?: (form: HTMLFormElement) => void;
+    }
+
+    export function addOrRemoveItem<T = any>(array: MaybeObservableArray<T>, value: T, included?: boolean): T[];
+
+    export function arrayForEach<T = any>(array: T[], action: (item: T, index: number) => void): void;
+    export function arrayFirst<T = any>(array: T[], predicate: (item: T, index: number) => boolean): T;
+    export function arrayFirst<T = any>(array: T[], predicate: (item: T, index: number) => boolean, predicateOwner: any): T;
+    export function arrayFilter<T = any>(array: T[], predicate: (item: T, index: number) => boolean): T[];
+    export function arrayGetDistinctValues<T = any>(array: T[]): T[];
+    export function arrayIndexOf<T = any>(array: MaybeObservableArray<T>, item: T): number;
+    export function arrayMap<T = any, U = any>(array: T[], mapping: (item: T, index: number) => U): U[];
+    export function arrayPushAll<T = any>(array: MaybeObservableArray<T>, valuesToPush: T[]): T[];
+    export function arrayRemoveItem<T = any>(array: MaybeObservableArray<T>, itemToRemove: T): void;
+
+    export function extend<T = any, U = any>(target: T, source: U): T & U;
+
+    export const fieldsIncludedWithJsonPost: Array<string | RegExp>;
+
+    export function getFormFields(form: HTMLFormElement, fieldName: string | RegExp): any[];
+
+    export function objectForEach(obj: Object, action: (key: string, value: any) => void): void;
+    export function objectForEach<T = any>(obj: { [key: string]: T }, action: (key: string, value: T) => void): void;
+
+    export function peekObservable<T = any>(value: MaybeSubscribable<T>): T;
+
+    export function postJson(urlOrForm: string | HTMLFormElement, data: MaybeSubscribable<Object>): void;
+    export function postJson(urlOrForm: string | HTMLFormElement, data: MaybeSubscribable<Object>, options: PostJsonOptions): void;
+
+    export function parseJson(jsonString: string): any;
+    export function parseJson<T = any>(jsonString: string): T;
+
+    export function range(min: MaybeSubscribable<number>, max: MaybeSubscribable<number>): number[];
+
+    export function registerEventHandler(element: Element, eventType: string, handler: EventListener): void;
+
+    export function setTextContent(element: Node, textContent: MaybeSubscribable<string>): void;
+
+    export function stringifyJson(data: MaybeSubscribable<any>): string;
+    export function stringifyJson(data: MaybeSubscribable<any>, replacer: Function): string;
+    export function stringifyJson(data: MaybeSubscribable<any>, replacer: Function, space: string | number): string;
+
+    export function toggleDomNodeCssClass(node: Element, className: string, shouldHaveClass?: boolean): void;
+
+    export function triggerEvent(element: Element, eventType: string): void;
+
+    export function unwrapObservable<T = any>(value: MaybeSubscribable<T>): T;
+}
+
+export function unwrap<T = any>(value: MaybeSubscribable<T>): T;
+
+//#endregion
+
+//#region utils.domData.js
+
+export module utils {
+    export module domData {
+        export function get<T = any>(node: Node, key: string): T;
+
+        export function set<T = any>(node: Node, key: string, value: T): void;
+
+        export function clear(node: Node): boolean;
+    }
+}
+
+//#endregion
+
+//#region utils.domNodeDisposal.js
+
+export module utils {
+    export module domNodeDisposal {
+        export function addDisposeCallback(node: Node, callback: () => void): void;
+        export function removeDisposeCallback(node: Node, callback: () => void): void;
+        export function cleanExternalData(node: Node): void;
+    }
+}
+
+export function cleanNode(node: Node): typeof node;
+export function removeNode(node: Node): void;
+
+//#endregion
+
+//#region utils.domManipulation.js
+
+export module utils {
+    export function parseHtmlFragment(html: string, documentContext?: Document): Node[];
+    export function setHtml(node: Node, html: MaybeSubscribable<string>): void;
+}
+
+//#endregion
+
+//#region version.js
+
+export const version: string;
+
+//#endregion

--- a/build/types/tsconfig.json
+++ b/build/types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "umd", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "strict": true, /* Enable all strict type-checking options. */
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "author": "The Knockout.js team",
   "main": "build/output/knockout-latest.js",
+  "types": "build/types/knockout.d.ts",
   "scripts": {
     "prepublish": "grunt",
     "test": "node spec/runner.node.js"

--- a/spec/types/global/_references.d.ts
+++ b/spec/types/global/_references.d.ts
@@ -1,0 +1,38 @@
+
+declare module "knockout" {
+
+    // Have to define your own extenders
+    export interface ObservableArrayFunctions<T> {
+        filterByProperty(propName: string, matchValue: boolean): ko.Computed<any>;
+    }
+
+    export interface Extenders {
+        logChange(target: ko.Subscribable, option: string): typeof target;
+        numeric(target: ko.Subscribable, precision: number): typeof target;
+        required(target: ko.Subscribable, overrideMessage: string): typeof target;
+    }
+
+    // Define your own functions
+    export interface SubscribableFunctions<T> {
+        publishOn(topic: string): this;
+        subscribeTo(topic: string): this;
+    }
+
+    export interface BindingHandlers {
+        isolatedOptions: ko.BindingHandler;
+    }
+
+    // Define your own bindingHandler
+    export interface BindingHandlers {
+        allBindingsAccessorTest: ko.BindingHandler;
+    }
+
+    // Define your template engine optinos
+    export interface TemplateOptions<T> {
+        showParams?: boolean;
+        templateOptions?: any;
+        templateRenderingVariablesInScope?: any;
+    }
+}
+
+export { };

--- a/spec/types/global/test-global.ts
+++ b/spec/types/global/test-global.ts
@@ -1,0 +1,1265 @@
+/// <reference path="../../../build/types/knockout" />
+/// <reference path="_references" />
+
+declare var $: any;
+
+function test_creatingVMs() {
+    const myViewModel = {
+        personName: ko.observable('Bob'),
+        personAge: ko.observable(123)
+    };
+
+    ko.applyBindings(myViewModel);
+    ko.applyBindings(myViewModel, document.getElementById('someElementId'));
+
+    myViewModel.personName();
+    myViewModel.personName('Mary');
+    myViewModel.personAge(50);
+
+    const subscription = myViewModel.personName.subscribe(newValue => {
+        alert("The person's new name is " + newValue);
+    });
+
+    subscription.dispose();
+}
+
+function test_computed() {
+    class AppViewModel {
+        public firstName = ko.observable("Bob");
+        public lastName = ko.observable("Smith");
+
+        public fullName = ko.pureComputed(() => this.firstName() + " " + this.lastName());
+    }
+
+    class MyViewModel {
+        public firstName = ko.observable("Planet");
+        public lastName = ko.observable("Earth");
+
+        public fullName = ko.pureComputed({
+            read: () => this.firstName() + " " + this.lastName(),
+            write: (value) => {
+                const lastSpacePos = value.lastIndexOf(" ");
+                if (lastSpacePos > 0) {
+                    this.firstName(value.substring(0, lastSpacePos));
+                    this.lastName(value.substring(lastSpacePos + 1));
+                }
+            }
+        });
+    }
+
+    class MyViewModel1 {
+        public price = ko.observable(25.99);
+
+        public formattedPrice = ko.pureComputed({
+            read: () => "$" + this.price().toFixed(2),
+            write: value => {
+                const num = parseFloat(value.replace(/[^\.\d]/g, ""));
+                this.price(isNaN(num) ? 0 : num);
+            }
+        });
+    }
+
+    class MyViewModel2 {
+        public acceptedNumericValue = ko.observable(123);
+        public lastInputWasValid = ko.observable(true);
+
+        public attemptedValue = ko.computed<number>({
+            read: this.acceptedNumericValue,
+            write: function (this: MyViewModel2, value) {
+                if (isNaN(value))
+                    this.lastInputWasValid(false);
+                else {
+                    this.lastInputWasValid(true);
+                    this.acceptedNumericValue(value);
+                }
+            },
+            owner: this
+        });
+    }
+
+    ko.applyBindings(new MyViewModel());
+}
+
+class GetterViewModel {
+    private _selectedRange = ko.observable();
+    public range = ko.observable();
+}
+
+function testGetter() {
+    const model = new GetterViewModel();
+
+    model.range.subscribe((range: number) => {
+        console.log(range);
+    });
+}
+
+function test_observableArrays() {
+    const myObservableArray = ko.observableArray<string>();
+    myObservableArray.push('Some value');
+
+    const anotherObservableArray = ko.observableArray([
+        { name: "Bungle", type: "Bear", age: 10 },
+        { name: "George", type: "Hippo", age: 20 },
+        { name: "Zippy", type: "Unknown", age: 25 }
+    ]);
+
+    const multiTypeObservableArray = ko.observableArray<string | number | undefined>();
+
+    myObservableArray().length;
+    myObservableArray()[0];
+
+    myObservableArray.indexOf('Blah');
+
+    myObservableArray.push('Some new value');
+    myObservableArray.pop();
+
+    myObservableArray.unshift('Some new value');
+    myObservableArray.shift();
+
+    myObservableArray.reverse();
+    myObservableArray.sort((left, right) => left == right ? 0 : (left < right ? -1 : 1));
+
+    myObservableArray.splice(1, 3);
+
+    myObservableArray.remove('Blah');
+    anotherObservableArray.remove(item => item.age < 18);
+
+    multiTypeObservableArray.removeAll(['Chad', 132, undefined]);
+    myObservableArray.removeAll();
+
+    myObservableArray.destroy('Blah');
+    anotherObservableArray.destroy(someItem => someItem.age < 18);
+    multiTypeObservableArray.destroyAll(['Chad', 132, undefined]);
+
+    myObservableArray.destroyAll();
+
+    ko.utils.arrayForEach(anotherObservableArray(), item => {
+        console.log(item.name);
+    });
+}
+
+// You have to extend knockout for your own handlers
+// declare namespace ko {
+//     export interface BindingHandlers {
+//         yourBindingName: ko.BindingHandler;
+//         slideVisible: ko.BindingHandler;
+//         allowBindings: ko.BindingHandler;
+//         withProperties: ko.BindingHandler;
+//         randomOrder: ko.BindingHandler;
+//     }
+// }
+
+function test_bindings() {
+    const currentProfit = ko.observable(150000);
+    ko.applyBindings({
+        people: [
+            { firstName: 'Bert', lastName: 'Bertington' },
+            { firstName: 'Charles', lastName: 'Charlesforth' },
+            { firstName: 'Denise', lastName: 'Dentiste' }
+        ]
+    });
+
+    const viewModel = { availableCountries: ko.observableArray(['France', 'Germany', 'Spain']) };
+    viewModel.availableCountries.push('China');
+
+    ko.bindingHandlers.yourBindingName = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            return { "controlsDescendantBindings": true };
+        }
+    };
+
+    ko.bindingHandlers.slideVisible = {
+        update: function (element, valueAccessor, allBindingsAccessor) {
+            const
+                value = valueAccessor(), allBindings = allBindingsAccessor(),
+                valueUnwrapped = ko.utils.unwrapObservable(value),
+                duration = allBindings.slideDuration || 400;
+
+            if (valueUnwrapped == true)
+                $(element).slideDown(duration);
+            else
+                $(element).slideUp(duration);
+        },
+        init: function (element, valueAccessor) {
+            const value = ko.utils.unwrapObservable(valueAccessor());
+            $(element).toggle(value);
+        }
+    };
+
+    ko.bindingHandlers.hasFocus = {
+        init: function (element, valueAccessor) {
+            $(element)
+                .focus(() => {
+                    const value = valueAccessor();
+                    value(true);
+                })
+                .blur(() => {
+                    const value = valueAccessor();
+                    value(false);
+                });
+        },
+        update: function (element, valueAccessor) {
+            var value = valueAccessor();
+            if (ko.utils.unwrapObservable(value))
+                element.focus();
+            else
+                element.blur();
+        }
+    };
+
+    ko.bindingHandlers.allowBindings = {
+        init: function (elem, valueAccessor) {
+            var shouldAllowBindings = ko.utils.unwrapObservable(valueAccessor());
+            return { controlsDescendantBindings: !shouldAllowBindings };
+        }
+    };
+
+    ko.bindingHandlers.withProperties = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            const
+                newProperties = valueAccessor(),
+                innerBindingContext = bindingContext.extend(newProperties);
+
+            ko.applyBindingsToDescendants(innerBindingContext, element);
+
+            return { controlsDescendantBindings: true };
+        }
+    };
+
+    ko.bindingHandlers.withProperties = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            var newProperties = valueAccessor(),
+                childBindingContext = bindingContext.createChildContext(viewModel);
+
+            ko.utils.extend(childBindingContext, newProperties);
+            ko.applyBindingsToDescendants(childBindingContext, element);
+
+            return { controlsDescendantBindings: true };
+        }
+    };
+
+    ko.bindingHandlers.randomOrder = {
+        init: function (elem, valueAccessor) {
+            var child = ko.virtualElements.firstChild(elem),
+                childElems = [];
+
+            while (child) {
+                childElems.push(child);
+                child = ko.virtualElements.nextSibling(child);
+            }
+
+            ko.virtualElements.emptyNode(elem);
+
+            while (childElems.length) {
+                var randomIndex = Math.floor(Math.random() * childElems.length),
+                    chosenChild = childElems.splice(randomIndex, 1);
+                ko.virtualElements.prepend(elem, chosenChild[0]);
+            }
+        }
+    };
+
+    let node: Node = new Node(), containerElem: Element = new Element(),
+        nodeToInsert: Node = new Node(), insertAfter: Node = new Node(), nodeToPrepend: Node = new Node(), arrayOfNodes: Node[] = [];
+
+    ko.virtualElements.emptyNode(containerElem);
+    ko.virtualElements.firstChild(containerElem);
+    ko.virtualElements.insertAfter(containerElem, nodeToInsert, insertAfter);
+    ko.virtualElements.nextSibling(node);
+    ko.virtualElements.prepend(containerElem, nodeToPrepend);
+    ko.virtualElements.setDomNodeChildren(containerElem, arrayOfNodes);
+}
+
+function test_more() {
+    const viewModel = {
+        firstName: ko.observable("Bert"),
+        lastName: ko.observable("Smith"),
+        pets: ko.observableArray(["Cat", "Dog", "Fish"]),
+        type: "Customer",
+        hasALotOfPets: <any>null
+    };
+
+    viewModel.hasALotOfPets = ko.computed(() => viewModel.pets().length > 2);
+
+    const plainJs = ko.toJS(viewModel);
+
+    ko.extenders.logChange = function (target, option) {
+        target.subscribe((newValue: string) => {
+            console.log(option + ": " + newValue);
+        });
+
+        return target;
+    };
+
+    ko.extenders.numeric = function (target, precision) {
+        var result = ko.computed<any>({
+            read: target,
+            write: (newValue) => {
+                var current = target(),
+                    roundingMultiplier = Math.pow(10, precision),
+                    newValueAsNum = isNaN(newValue) ? 0 : parseFloat(newValue),
+                    valueToWrite = Math.round(newValueAsNum * roundingMultiplier) / roundingMultiplier;
+
+                if (valueToWrite !== current) {
+                    target(valueToWrite);
+                } else {
+                    if (newValue !== current) {
+                        target.notifySubscribers(valueToWrite);
+                    }
+                }
+            }
+        });
+
+        result(target());
+
+        return result;
+    };
+
+    class AppViewModel {
+        myNumberOne: ko.Observable<number>;
+        myNumberTwo: ko.Observable<number>;
+
+        constructor(one: number, two: number) {
+            this.myNumberOne = ko.observable(one).extend({ numeric: 0 });
+            this.myNumberTwo = ko.observable(two).extend({ numeric: 2 });
+        }
+    }
+
+    ko.applyBindings(new AppViewModel(221.2234, 123.4525));
+
+    ko.extenders.required = function (target: any, overrideMessage) {
+
+        target.hasError = ko.observable();
+        target.validationMessage = ko.observable();
+
+        function validate(newValue: any) {
+            target.hasError(newValue ? false : true);
+            target.validationMessage(newValue ? "" : overrideMessage || "This field is required");
+        }
+
+        validate(target());
+
+        target.subscribe(validate);
+
+        return target;
+    };
+
+    class AppViewModel2 {
+        firstName: ko.Observable<string>;
+        lastName: ko.Observable<string>;
+
+        constructor(first: string, last: string) {
+            this.firstName = ko.observable(first).extend({ required: "Please enter a first name" });
+            this.lastName = ko.observable(last).extend({ required: "" });
+        }
+
+        test() {
+            const first: string = "test";
+            this.firstName = ko.observable(first).extend({ required: "Please enter a first name", logChange: "first name" });
+        }
+    }
+
+    ko.applyBindings(new AppViewModel2("Bob", "Smith"));
+
+    let name = "";
+    const upperCaseName = ko.computed(() => name.toUpperCase()).extend({ throttle: 500 });
+
+    class AppViewModel3 {
+        public instantaneousValue = ko.observable<string>();
+        public throttledValue = ko.computed(this.instantaneousValue)
+            .extend({ throttle: 400 });
+
+        public loggedValues = ko.observableArray<string>([]);
+
+        public throttledValueLogger = ko.computed(() => {
+            const val = this.instantaneousValue();
+            if (val !== '')
+                this.loggedValues.push(val);
+        });
+    }
+
+    class GridViewModel {
+        public pageSize = ko.observable(20);
+        public pageIndex = ko.observable(1);
+        public currentPageData = ko.observableArray();
+
+        constructor() {
+
+            ko.computed(() => {
+                const params = { page: this.pageIndex(), size: this.pageSize() };
+                $.getJSON('/Some/Json/Service', params, this.currentPageData);
+            });
+        }
+    }
+
+    function setPageSize(this: GridViewModel, newPageSize: number) {
+        this.pageSize(newPageSize);
+        this.pageIndex(1);
+    };
+
+    ko.computed(function (this: GridViewModel) {
+        var params = { page: this.pageIndex(), size: this.pageSize() };
+        $.getJSON('/Some/Json/Service', params, this.currentPageData);
+    }).extend({ throttle: 1 });
+
+    const removeDom = document.querySelector(".remove");
+    if (removeDom) {
+        removeDom.addEventListener("click", function (this: HTMLElement) {
+            viewModel.pets.remove(ko.dataFor(this));
+        });
+
+        removeDom.addEventListener("click", function (this: HTMLElement) {
+            viewModel.pets.remove(ko.dataFor(this));
+        });
+    }
+
+    ko.observableArray.fn.filterByProperty = function (propName, matchValue) {
+        return ko.pureComputed(() => {
+            const allItems = this(), matchingItems = [];
+            for (let current of allItems) {
+                if (ko.utils.unwrapObservable(current[propName]) === matchValue)
+                    matchingItems.push(current);
+            }
+            return matchingItems;
+        });
+    }
+
+    class Task {
+        public title: ko.Observable<string>;
+        public done: ko.Observable<boolean>;
+
+        constructor(title: string, done: boolean) {
+            this.title = ko.observable(title);
+            this.done = ko.observable(done);
+        }
+    }
+
+    class AppViewModel4 {
+        public tasks = ko.observableArray([
+            new Task('Find new desktop background', true),
+            new Task('Put shiny stickers on laptop', false),
+            new Task('Request more reggae music in the office', true)
+        ]);
+
+        public doneTasks = this.tasks.filterByProperty("done", true);
+
+        constructor() {
+            this.doneTasks = ko.computed(() => {
+                const all = this.tasks(), done = [];
+                for (let cur of all)
+                    if (cur.done())
+                        done.push(cur);
+                return done;
+            }, this);
+        }
+    }
+
+    ko.applyBindings(new AppViewModel4());;
+}
+
+function test_misc(this: any) {
+    // define dummy vars
+    let callback: any;
+    let target: any;
+    let topic: any;
+    let vm: any;
+    let value: any;
+
+    const postbox = new ko.subscribable();
+    postbox.subscribe(callback, target, topic);
+
+    postbox.subscribe(function (this: typeof vm, newValue: string) {
+        this.latestTopic(newValue);
+    }, vm, "mytopic");
+
+    postbox.notifySubscribers(value, "mytopic");
+
+    ko.subscribable.fn.publishOn = function (topic) {
+        this.subscribe(function (newValue) {
+            postbox.notifySubscribers(newValue, topic);
+        });
+
+        return this;
+    };
+
+    this.myObservable = ko.observable("myValue").publishOn("myTopic");
+
+    ko.subscribable.fn.subscribeTo = function (this: any, topic: string) {
+        postbox.subscribe(this, null, topic);
+        return this;
+    };
+
+    this.observableFromAnotherVM = ko.observable().subscribeTo("myTopic");
+
+    postbox.subscribe(function (this: ko.Subscribable, newValue: string) {
+        this(newValue);
+    }, this, topic);
+
+    ko.bindingHandlers.isolatedOptions = {
+        init: function (element, valueAccessor) {
+            var args = arguments;
+            ko.computed({
+                read: () => {
+                    ko.utils.unwrapObservable(valueAccessor());
+                    ko.bindingHandlers.options.update.apply(this, args);
+                },
+                owner: this,
+                disposeWhenNodeIsRemoved: element
+            });
+        }
+    };
+
+    ko.subscribable.fn.publishOn = function (topic) {
+        this.subscribe(function (newValue) {
+            postbox.notifySubscribers(newValue, topic);
+        });
+
+        return this;
+    };
+
+    this.myObservable = ko.observable("myValue").publishOn("myTopic");
+
+    var x = ko.observableArray([1, 2, 3]);
+
+    let element = new HTMLElement();
+    ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+        $(element).datepicker("destroy");
+    });
+
+    this.observableFactory = function (readonly: boolean = false): ko.Subscribable<number> {
+        if (readonly) {
+            return ko.computed(() => 3);
+        } else {
+            return ko.observable(3);
+        }
+    }
+
+}
+
+function test_allBindingsAccessor() {
+    ko.bindingHandlers.allBindingsAccessorTest = {
+        init: (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) => {
+            var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
+            var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
+        },
+        update: (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) => {
+            var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
+            var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
+        }
+    };
+}
+
+
+function test_Components() {
+
+    // test all possible ko.components.register() overloads
+    function test_Register() {
+        // reused parameters
+        const nodeArray = [new Node, new Node];
+        const singleNode = new Node;
+        const viewModelFn = function (params: any) { return <any>null; }
+        class ViewModelClass { }
+
+        // ------- viewmodel overloads:
+        // viewModel as inline function (commonly used in examples)
+        ko.components.register("name", { template: "string-template", viewModel: viewModelFn });
+
+        // viewModel as a Class
+        ko.components.register("name", { template: "string-template", viewModel: ViewModelClass });
+
+        // viewModel from shared instance
+        ko.components.register("name", { template: "string-template", viewModel: { instance: null } });
+
+        // viewModel from createViewModel factory method
+        ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
+
+        // viewModel from an AMD module 
+        ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
+
+        // ------- template overloads
+        // template from named element
+        ko.components.register("name", { template: { element: "elementID" }, viewModel: viewModelFn });
+
+        // template using single Node
+        ko.components.register("name", { template: { element: singleNode }, viewModel: viewModelFn });
+
+        // template using Node array
+        ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
+
+        // template using an AMD module 
+        ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
+
+        // Empty config for registering custom elements that are handled by name convention
+        ko.components.register('name', { /* No config needed */ });
+    }
+}
+
+
+function testUnwrapUnion(this: any) {
+    let possibleObs: ko.Observable<number> | number = this.getValue();
+    const num = ko.unwrap(possibleObs);
+}
+
+
+// *****************************
+// Template and Databinding Tests
+// *****************************
+
+class DummyTemplateSource {
+    constructor(private engine: DummyTemplateEngine, public id: string) { }
+
+    text(): string;
+    text(val: string): void;
+    text(val?: string) {
+        if (arguments.length > 0) {
+            this.engine.inMemoryTemplates[this.id] = val;
+        }
+        else {
+            return this.engine.inMemoryTemplates[this.id];
+        }
+    }
+
+    data(): any;
+    data(val: any): void;
+    data(val?: any) {
+        if (arguments.length > 0) {
+            this.engine.inMemoryTemplateData[this.id] = val;
+        }
+        else {
+            return this.engine.inMemoryTemplateData[this.id];
+        }
+    }
+}
+
+class DummyTemplateEngine extends ko.templateEngine {
+    public inMemoryTemplates: { [key: string]: any } = {};
+    public inMemoryTemplateData: { [key: string]: any } = {};
+
+    constructor(templates?: { [key: string]: any }) {
+        super();
+        this.inMemoryTemplateData = templates || {};
+    }
+
+    public makeTemplateSource(template: string | Node, templateDocument?: Document): ko.TemplateSource {
+        if (typeof template === "string") {
+            return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
+        }
+        else if ((template.nodeType == 1) || (template.nodeType == 8)) {
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+        }
+        else {
+            throw new Error("Unrecognized template source");
+        }
+    }
+
+    public renderTemplateSource(templateSource: ko.TemplateSource, bindingContext: ko.BindingContext<any>, options?: ko.TemplateOptions<any>, templateDocument?: Document): Node[] {
+        const data = bindingContext['$data'];
+        options = options || {};
+        let templateText = templateSource.text() as string | Function;
+        if (typeof templateText == "function")
+            templateText = templateText(data, options) as string;
+
+        templateText = options.showParams ? templateText + ", data=" + data + ", options=" + options : templateText;
+        var templateOptions = options.templateOptions; // Have templateOptions in scope to support [js:templateOptions.foo] syntax
+        var result;
+        //with (bindingContext)
+        {
+            //with (data || {})
+            {
+                //with (options.templateRenderingVariablesInScope || {})
+                {
+                    // Dummy [renderTemplate:...] syntax
+                    result = templateText.replace(/\[renderTemplate\:(.*?)\]/g, function (match, templateName) {
+                        return ko.renderTemplate(templateName, data, options || {});
+                    });
+
+
+                    var evalHandler = function (match: string, script: any) {
+                        try {
+                            var evalResult = eval(script);
+                            return (evalResult === null) || (evalResult === undefined) ? "" : evalResult.toString();
+                        } catch (ex) {
+                            throw new Error("Error evaluating script: [js: " + script + "]\n\nException: " + ex.toString());
+                        }
+                    }
+
+                    // Dummy [[js:...]] syntax (in case you need to use square brackets inside the expression)
+                    result = result.replace(/\[\[js\:([\s\S]*?)\]\]/g, evalHandler);
+
+                    // Dummy [js:...] syntax
+                    result = result.replace(/\[js\:([\s\S]*?)\]/g, evalHandler);
+                }
+            }
+        }
+
+        // Use same HTML parsing code as real template engine so as to trigger same combination of IE weirdnesses
+        // Also ensure resulting nodelist is an array to mimic what the default templating engine does, so we see the effects of not being able to remove dead memo comment nodes.
+        return ko.utils.arrayPushAll([], ko.utils.parseHtmlFragment(result));
+    }
+
+    public rewriteTemplate(template: string | Node, rewriterCallback: (val: string) => any) {
+        // Only rewrite if the template isn't a function (can't rewrite those)
+        var templateSource = new ko.templateSources.anonymousTemplate(template as any); //this.makeTemplateSource(template);
+        if (typeof templateSource.text() != "function")
+            return ko.templateEngine.prototype.rewriteTemplate.call(this, template, rewriterCallback);
+    }
+
+    public createJavaScriptEvaluatorBlock(script: string): string {
+        return "[js:" + script + "]";
+    };
+
+}
+
+let testNode: any;
+
+ko.setTemplateEngine(new ko.nativeTemplateEngine());
+
+ko.setTemplateEngine(new DummyTemplateEngine({ x: [document.createElement("div"), document.createElement("span")] }));
+ko.renderTemplate("x", null);
+
+var threw = false;
+ko.setTemplateEngine(undefined);
+try { ko.renderTemplate("someTemplate", {}) }
+catch (ex) { threw = true }
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "ABC" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ emptyTemplate: "" }));
+ko.renderTemplate("emptyTemplate", null, null, testNode);
+
+var passedElement, passedDataItem;
+var myCallback = function (elementsArray: Node[], dataItem: any) {
+    passedElement = elementsArray[0];
+    passedDataItem = dataItem;
+}
+
+var myModel = {};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "ABC" }));
+ko.renderTemplate("someTemplate", myModel, { afterRender: myCallback }, testNode);
+
+var dependency = ko.observable("A");
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: () => "Value = " + dependency() }));
+
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+dependency("B");
+
+var observable = ko.observable("A"), count = 0;
+var myCallback = function (elementsArray: Node[], dataItem: any) {
+    observable();   // access observable in callback
+};
+var myTemplate = function () {
+    return "Value = " + (++count);
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: myTemplate }));
+ko.renderTemplate("someTemplate", {}, { afterRender: myCallback }, testNode);
+
+observable("B");
+
+var observable = ko.observable("A");
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: function (data: string) {
+        return "Value = " + data;
+    }
+}));
+ko.renderTemplate("someTemplate", observable, null, testNode);
+
+observable("B");
+
+var dependency = ko.observable("A");
+var template = { someTemplate: () => "Value = " + dependency() };
+ko.setTemplateEngine(new DummyTemplateEngine(template));
+
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+testNode.parentNode.removeChild(testNode);
+dependency("B");
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "template output" }));
+testNode.innerHTML = "<div data-bind='template:\"someTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: 123 } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+
+var myData = ko.observable({ childProp: 123 });
+ko.applyBindings({ someProp: myData }, testNode);
+
+// Now mutate and notify
+myData().childProp = 456;
+myData.valueHasMutated();
+
+var innerObservable = ko.observable("some value");
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp()]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: innerObservable } }, testNode);
+
+ko.removeNode(testNode.childNodes[0]);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    firstTemplate: "First template output",
+    secondTemplate: "Second template output"
+}));
+
+var chosenTemplate = ko.observable("firstTemplate");
+testNode.innerHTML = "<div data-bind='template: chosenTemplate'></div>";
+ko.applyBindings({ chosenTemplate: chosenTemplate }, testNode);
+
+chosenTemplate("secondTemplate");
+
+interface MyTemplate {
+    myTemplate: string;
+}
+
+var templatePicker = function (dataItem: MyTemplate, bindingContext: ko.BindingContext) {
+    // Having the entire binding context available means you can read sibling or parent level properties
+    return dataItem.myTemplate;
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: templateSelectorFunction, data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: 123, myTemplate: "someTemplate" }, templateSelectorFunction: templatePicker, anotherProperty: 456 }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "outer template output, [renderTemplate:innerTemplate]", // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: "inner template output <span data-bind='text: 123'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template:\"outerTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+var observable = ko.observable("ABC");
+var timesRenderedOuter = 0, timesRenderedInner = 0;
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: function () { timesRenderedOuter++; return "outer template output, [renderTemplate:innerTemplate]" }, // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: function () { timesRenderedInner++; return observable() }
+}));
+testNode.innerHTML = "<div data-bind='template:\"outerTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+observable("DEF");
+
+var innerObservable = ko.observable("some value");
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "outer template output, <span id='innerTemplateOutput'>[renderTemplate:innerTemplate]</span>",
+    innerTemplate: "result = [js: childProp()]"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: innerObservable } }, testNode);
+
+const node = document.getElementById('innerTemplateOutput');
+node && ko.removeNode(node);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<INPUT Data-Bind='value:\"Hi\"' />" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input data-bind='value:\n\"Hi\"' />" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input data-bind='value:message' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { message: "hello" } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<div data-bind='text: $element.tagName'></div>" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<div data-bind='text: $context.$data === $data'></div>" }));
+ko.renderTemplate("someTemplate", {}, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: "<input data-bind='value:message' />[js: message = 'goodbye'; undefined; ]"
+}));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { message: "hello" } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: "<button data-bind='click: someFunctionOnModel'>click me</button>"
+}));
+var viewModel = {
+    didCallMyFunction: false,
+    someFunctionOnModel: function () { this.didCallMyFunction = true }
+};
+ko.renderTemplate("someTemplate", viewModel, null, testNode);
+var buttonNode = testNode.childNodes[0];
+buttonNode.click();
+
+// Will verify that bindings are applied only once for both inline (rewritten) bindings,
+// and external (non-rewritten) ones
+var originalBindingProvider = ko.bindingProvider.instance;
+ko.bindingProvider.instance = {
+    nodeHasBindings: (node: Element) => (node.tagName == 'EM') || originalBindingProvider.nodeHasBindings(node),
+    getBindings: (node, bindingContext) => {
+        if ((<Element>node).tagName == 'EM')
+            return { text: ++model.numBindings } as Object;
+
+        return originalBindingProvider.getBindings(node, bindingContext);
+    },
+    getBindingAccessors: (node, bindingContext) => {
+        if ((<Element>node).tagName == 'EM')
+            return { text: () => ++model.numBindings };
+
+        return originalBindingProvider.getBindingAccessors(node, bindingContext);
+    }
+};
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "Outer <div data-bind='template: { name: \"innerTemplate\", bypassDomNodeWrap: true }'></div>",
+    innerTemplate: "Inner via inline binding: <span data-bind='text: ++numBindings'></span>"
+        + "Inner via external binding: <em></em>"
+}));
+var model = { numBindings: 0 };
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", bypassDomNodeWrap: true }'></div>";
+ko.applyBindings(model, testNode);
+
+ko.bindingProvider.instance = originalBindingProvider;
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>The item is [js: personName]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+var originalBobNode = testNode.childNodes[0].childNodes[0];
+var originalFrankNode = testNode.childNodes[0].childNodes[1];
+
+myArray.push({ personName: "Steve" });
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is <span data-bind='text: personName'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var initCalls = 0;
+(<any>ko.bindingHandlers).countInits = { init: function () { initCalls++ } };
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<span data-bind='countInits: true'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: [1, 2, 3] }, testNode);
+
+// Represents https://github.com/SteveSanderson/knockout/pull/440
+// Previously, the rewriting (which introduces a comment node before the bound node) was interfering
+// with the array-to-DOM-node mapping state tracking
+ko.setTemplateEngine(new DummyTemplateEngine({ mytemplate: "<div data-bind='text: $data'></div>" }));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'mytemplate', foreach: items }\"></div>";
+
+// Bind against initial array containing one entry. UI just shows "original"
+var myArray2 = ko.observableArray(["original"]);
+ko.applyBindings({ items: myArray2 }, testNode);
+
+// Now replace the entire array contents with one different entry.
+// UI just shows "new" (previously with bug, showed "original" AND "new")
+myArray2(["new"]);
+
+// See https://github.com/SteveSanderson/knockout/pull/440 and https://github.com/SteveSanderson/knockout/pull/144
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "<div data-bind='text: $data'></div>[renderTemplate:innerTemplate]x", // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: "inner <span data-bind='text: 123'></span>"
+}));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'outerTemplate', foreach: items }\"></div>";
+
+// Bind against initial array containing one entry.
+var myArray3 = ko.observableArray(["original"]);
+ko.applyBindings({ items: myArray3 }, testNode);
+
+// Now replace the entire array contents with one different entry.
+myArray3(["new"]);
+
+// Represents https://github.com/SteveSanderson/knockout/issues/739
+// Previously, the rewriting (which introduces a comment node before the bound node) was interfering
+// with the array-to-DOM-node mapping state tracking
+ko.setTemplateEngine(new DummyTemplateEngine({ mytemplate: "<div data-bind='attr: {}'>[js:name()]</div>" }));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'mytemplate', foreach: items }\"></div>";
+
+// Bind against array, referencing an observable property
+var myItem = { name: ko.observable("a") };
+ko.applyBindings({ items: [myItem] }, testNode);
+
+// Modify the observable property and check that UI is updated
+// Previously with the bug, it wasn't updated because the removal of the memo comment caused the array-to-DOM-node computed to be disposed
+myItem.name("b");
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item # is <span data-bind='text: $index'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item <span data-bind='text: personName'></span>is <span data-bind='text: $index'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var frank = myArray.pop(); // remove frank
+myArray.unshift(frank); // put frank in the front
+var myArray4 = ko.observableArray([undefined, null]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is <span data-bind='text: String($data)'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray4 }, testNode);
+
+var myObservable = ko.observable("Steve");
+var myArray5 = ko.observableArray([{ personName: "Bob" }, { personName: myObservable }, { personName: "Another" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>The item is [js: ko.utils.unwrapObservable(personName)]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray5 }, testNode);
+var originalBobNode = testNode.childNodes[0].childNodes[0];
+
+myObservable("Steve2");
+
+// Ensure we can still remove the corresponding nodes (even though they've changed), and that doing so causes the subscription to be disposed
+myArray5.splice(1, 1);
+myObservable("Something else"); // Re-evaluating the observable causes the orphaned subscriptions to be disposed
+var myArray6 = ko.observableArray(["A", "B"]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "hello" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray6 }, testNode);
+
+// Now set the observable to null and check it's treated like an empty array
+// (because how else should null be interpreted?)
+myArray6(null);
+
+// Note: There are more detailed specs (e.g., covering nesting) associated with the "foreach" binding which
+// uses this templating functionality internally.
+var myArray7 = ko.observableArray(["A", "B"]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "[js:myAliasedItem]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection, as: \"myAliasedItem\" }'></div>";
+
+ko.applyBindings({ myCollection: myArray7 }, testNode);
+
+var innerObservable = ko.observable("some value");
+var myArray8 = ko.observableArray([{ obsVal: innerObservable }, { obsVal: innerObservable }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is [js: ko.utils.unwrapObservable(obsVal)]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray8 }, testNode);
+
+ko.removeNode(testNode.childNodes[0]);
+
+var innerObservable = ko.observable("some value");
+var myArray9 = ko.observableArray([{ obsVal: innerObservable }, { obsVal: innerObservable }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is [js: ko.utils.unwrapObservable(obsVal)]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray9 }, testNode);
+
+myArray9.splice(1, 1);
+myArray9([]);
+
+var myArray10 = ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp: 3 }, { someProp: 4, _destroy: ko.observable(false) }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray10 }, testNode);
+
+var myArray11 = ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp: 3 }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection, includeDestroyed: true }'></div>";
+
+ko.applyBindings({ myCollection: myArray11 }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp }'></div>";
+
+interface ChildProp { childProp: string; }
+var viewModel2 = { myProp: ko.observable<ChildProp | null>({ childProp: 'abc' }) };
+ko.applyBindings(viewModel2, testNode);
+
+// Causing the condition to become false causes the output to be removed
+viewModel2.myProp(null);
+
+// Causing the condition to become true causes the output to reappear
+viewModel2.myProp({ childProp: 'def' });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Hello" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", ifnot: shouldHide }'></div>";
+
+var viewModel3 = { shouldHide: ko.observable(true) };
+ko.applyBindings(viewModel3, testNode);
+
+// Causing the condition to become false causes the output to be displayed
+viewModel3.shouldHide(false);
+
+// Causing the condition to become true causes the output to disappear
+viewModel3.shouldHide(true);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp, foreach: [$data, $data, $data] }'></div>";
+
+var viewModel4 = { myProp: ko.observable<ChildProp | null>({ childProp: 'abc' }) };
+ko.applyBindings(viewModel4, testNode);
+
+// Causing the condition to become false causes the output to be removed
+viewModel4.myProp(null);
+
+// Causing the condition to become true causes the output to reappear
+viewModel4.myProp({ childProp: 'def' });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input type='checkbox' data-bind='checked:isChecked' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { isChecked: true } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input type='radio' name='somename' value='abc' data-bind='checked:someValue' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { someValue: 'abc' } }, testNode);
+
+var myArray12 = ko.observableArray([
+    { preferredTemplate: 1, someProperty: 'firstItemValue' },
+    { preferredTemplate: 2, someProperty: 'secondItemValue' }
+]);
+ko.setTemplateEngine(new DummyTemplateEngine({
+    firstTemplate: "<div>Template1Output, [js:someProperty]</div>",
+    secondTemplate: "<div>Template2Output, [js:someProperty]</div>"
+}));
+testNode.innerHTML = "<div data-bind='template: {name: getTemplateModelProperty, foreach: myCollection}'></div>";
+
+var getTemplate = function (dataItem: any, bindingContext: ko.BindingContext) {
+    return dataItem.preferredTemplate == 1 ? 'firstTemplate' : 'secondTemplate';
+};
+ko.applyBindings({ myCollection: myArray12, getTemplateModelProperty: getTemplate, anotherProperty: 123 }, testNode);
+
+var myModel2 = {
+    someAdditionalData: { myAdditionalProp: "someAdditionalValue" },
+    people: ko.observableArray([
+        { name: "Alpha" },
+        { name: "Beta" }
+    ])
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<div>Person [js:name] has additional property [js:templateOptions.myAdditionalProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: {name: \"myTemplate\", foreach: people, templateOptions: someAdditionalData }'></div>";
+
+ko.applyBindings(myModel2, testNode);
+
+var myObservable = ko.observable("some value"),
+    myModel3 = {
+        subModel: ko.observable({ myObservable: myObservable })
+    };
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<span>The value is [js:myObservable()]</span>" }));
+testNode.innerHTML = "<div data-bind='template: {name: \"myTemplate\", data: subModel}'></div>";
+ko.applyBindings(myModel3, testNode);
+
+// Right now the template references myObservable, so there should be exactly one subscription on it
+var renderedNode1 = testNode.childNodes[0].childNodes[0];
+
+// By changing the object for subModel, we force the data-bind value to be re-evaluated and the template to be re-rendered,
+// setting up a new template subscription, so there have now existed two subscriptions on myObservable...
+myModel3.subModel({ myObservable: myObservable });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ theTemplate: "Default output" })); // Not going to use this one
+var alternativeTemplateEngine = new DummyTemplateEngine({ theTemplate: "Alternative output" });
+
+testNode.innerHTML = "<div data-bind='template: { name: \"theTemplate\", templateEngine: chosenEngine }'></div>";
+ko.applyBindings({ chosenEngine: alternativeTemplateEngine }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "ValueLiteral: [js:item.prop], ValueBound: <span data-bind='text: item.prop'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", data: someItem, as: \"item\" }'></div>";
+ko.applyBindings({ someItem: { prop: 'Hello' } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "ValueLiteral: [js:$parent.parentProp], ValueBound: <span data-bind='text: $parent.parentProp'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", data: someItem }'></div>";
+ko.applyBindings({ someItem: {}, parentProp: 'Hello' }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "<div data-bind='template: { name:\"middleTemplate\", data: middleItem }'></div>",
+    middleTemplate: "<div data-bind='template: { name: \"innerTemplate\", data: innerItem }'></div>",
+    innerTemplate: "(Data:[js:$data.val], Parent:[[js:$parents[0].val]], Grandparent:[[js:$parents[1].val]], Root:[js:$root.val], Depth:[js:$parents.length])"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", data: outerItem }'></div>";
+
+ko.applyBindings({
+    val: "ROOT",
+    outerItem: {
+        val: "OUTER",
+        middleItem: {
+            val: "MIDDLE",
+            innerItem: { val: "INNER" }
+        }
+    }
+}, testNode);
+
+// The reason is that your template engine's native control flow and variable evaluation logic is going to run first, independently
+// of any KO-native control flow, so variables would get evaluated in the wrong context. Example:
+//
+// <div data-bind="foreach: someArray">
+//     ${ somePropertyOfEachArrayItem }   <-- This gets evaluated *before* the foreach binds, so it can't reference array entries
+// </div>
+//
+// It should be perfectly OK to fix this just by preventing anonymous templates within rewritten templates, because
+// (1) The developer can always use their template engine's native control flow syntax instead of the KO-native ones - that will work
+// (2) The developer can use KO's native templating instead, if they are keen on KO-native control flow or anonymous templates
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "<div data-bind='template: { data: someData }'>Childprop: [js: childProp]</div>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
+
+var didThrow = false;
+try {
+    ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
+} catch (ex) {
+    didThrow = true;
+}
+
+// Same reason as above
+ko.utils.arrayForEach(['if', 'ifnot', 'with', 'foreach'], function (bindingName) {
+    ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<div data-bind='" + bindingName + ": \"SomeValue\"'>Hello</div>" }));
+    testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
+
+    var didThrow = false;
+    ko.utils.domData.clear(testNode);
+    try { ko.applyBindings({ someData: { childProp: 'abc' } }, testNode) }
+    catch (ex) {
+        didThrow = true;
+    }
+    if (!didThrow)
+        throw new Error("Did not prevent use of " + bindingName);
+});
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "Outer <!-- ko template: \n" +
+        "{ name: \"innerTemplate\" } \n" +
+        "--><!-- /ko -->",
+    innerTemplate: "Inner via inline binding: <span data-bind='text: \"someText\"'></span>"
+}));
+var model2 = {};
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\" }'></div>";
+ko.applyBindings(model2, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine());
+testNode.innerHTML = "Start <!-- ko template: { data: someData } -->Childprop: [js: childProp]<!-- /ko --> End";
+ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
+
+// This represents issue https://github.com/SteveSanderson/knockout/issues/188
+// (IE < 9 strips out leading comment nodes when you use .innerHTML)
+ko.setTemplateEngine(new DummyTemplateEngine({}));
+testNode.innerHTML = "start <div data-bind='foreach: [1,2]'><span><!-- leading comment -->hello</span></div>";
+ko.applyBindings(null, testNode);
+
+delete (<any>ko.bindingHandlers).nonexistentHandler;
+var initCalls = 0;
+(<any>ko.bindingHandlers).countInits = { init: function () { initCalls++ } };
+testNode.innerHTML = "<div data-bind='template: {}'><!-- ko nonexistentHandler: true --><span data-bind='countInits: true'></span><!-- /ko --></div>";
+ko.applyBindings(null, testNode);
+
+// Represents https://github.com/SteveSanderson/knockout/issues/660
+// A <span> can't go directly into a <tr>, so modern browsers will silently strip it. We need to verify this doesn't
+// throw errors during unmemoization (when unmemoizing, it will try to apply the text to the following text node
+// instead of the node you intended to bind to).
+// Note that IE < 9 won't strip the <tr>; instead it has much stranger behaviors regarding unexpected DOM structures.
+// It just happens not to give an error in this particular case, though it would throw errors in many other cases
+// of malformed template DOM.
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "<tr><span data-bind=\"text: 'Some text'\"></span> </tr>" // The whitespace after the closing span is what triggers the strange HTML parsing
+}));
+testNode.innerHTML = "<div data-bind='template: \"myTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+// Since the actual template markup was invalid, we don't really care what the
+// resulting DOM looks like. We are only verifying there were no exceptions.

--- a/spec/types/global/tsconfig.json
+++ b/spec/types/global/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "none", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "noEmit": true, /* Do not emit outputs. */
+    "strict": true, /* Enable all strict type-checking options. */
+    "moduleResolution": "classic",
+    "baseUrl": ".",
+    "paths": {
+      "knockout": [
+        "../../../build/types/knockout"
+      ]
+    }
+  }
+}

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -1,0 +1,1302 @@
+import * as ko from "knockout";
+declare var $: any;
+
+function test_creatingVMs() {
+    const myViewModel = {
+        personName: ko.observable('Bob'),
+        personAge: ko.observable(123)
+    };
+
+    ko.applyBindings(myViewModel);
+    ko.applyBindings(myViewModel, document.getElementById('someElementId'));
+
+    myViewModel.personName();
+    myViewModel.personName('Mary');
+    myViewModel.personAge(50);
+
+    const subscription = myViewModel.personName.subscribe(newValue => {
+        alert("The person's new name is " + newValue);
+    });
+
+    subscription.dispose();
+}
+
+function test_computed() {
+    class AppViewModel {
+        public firstName = ko.observable("Bob");
+        public lastName = ko.observable("Smith");
+
+        public fullName = ko.pureComputed(() => this.firstName() + " " + this.lastName());
+    }
+
+    class MyViewModel {
+        public firstName = ko.observable("Planet");
+        public lastName = ko.observable("Earth");
+
+        public fullName = ko.pureComputed({
+            read: () => this.firstName() + " " + this.lastName(),
+            write: (value) => {
+                const lastSpacePos = value.lastIndexOf(" ");
+                if (lastSpacePos > 0) {
+                    this.firstName(value.substring(0, lastSpacePos));
+                    this.lastName(value.substring(lastSpacePos + 1));
+                }
+            }
+        });
+    }
+
+    class MyViewModel1 {
+        public price = ko.observable(25.99);
+
+        public formattedPrice = ko.pureComputed({
+            read: () => "$" + this.price().toFixed(2),
+            write: value => {
+                const num = parseFloat(value.replace(/[^\.\d]/g, ""));
+                this.price(isNaN(num) ? 0 : num);
+            }
+        });
+    }
+
+    class MyViewModel2 {
+        public acceptedNumericValue = ko.observable(123);
+        public lastInputWasValid = ko.observable(true);
+
+        public attemptedValue = ko.computed<number>({
+            read: this.acceptedNumericValue,
+            write: function (this: MyViewModel2, value) {
+                if (isNaN(value))
+                    this.lastInputWasValid(false);
+                else {
+                    this.lastInputWasValid(true);
+                    this.acceptedNumericValue(value);
+                }
+            },
+            owner: this
+        });
+    }
+
+    ko.applyBindings(new MyViewModel());
+}
+
+class GetterViewModel {
+    private _selectedRange = ko.observable();
+    public range = ko.observable();
+}
+
+function testGetter() {
+    const model = new GetterViewModel();
+
+    model.range.subscribe((range: number) => {
+        console.log(range);
+    });
+}
+
+function test_observableArrays() {
+    const myObservableArray = ko.observableArray<string>();
+    myObservableArray.push('Some value');
+
+    const anotherObservableArray = ko.observableArray([
+        { name: "Bungle", type: "Bear", age: 10 },
+        { name: "George", type: "Hippo", age: 20 },
+        { name: "Zippy", type: "Unknown", age: 25 }
+    ]);
+
+    const multiTypeObservableArray = ko.observableArray<string | number | undefined>();
+
+    myObservableArray().length;
+    myObservableArray()[0];
+
+    myObservableArray.indexOf('Blah');
+
+    myObservableArray.push('Some new value');
+    myObservableArray.pop();
+
+    myObservableArray.unshift('Some new value');
+    myObservableArray.shift();
+
+    myObservableArray.reverse();
+    myObservableArray.sort((left, right) => left == right ? 0 : (left < right ? -1 : 1));
+
+    myObservableArray.splice(1, 3);
+
+    myObservableArray.remove('Blah');
+    anotherObservableArray.remove(item => item.age < 18);
+
+    multiTypeObservableArray.removeAll(['Chad', 132, undefined]);
+    myObservableArray.removeAll();
+
+    myObservableArray.destroy('Blah');
+    anotherObservableArray.destroy(someItem => someItem.age < 18);
+    multiTypeObservableArray.destroyAll(['Chad', 132, undefined]);
+
+    myObservableArray.destroyAll();
+
+    ko.utils.arrayForEach(anotherObservableArray(), item => {
+        console.log(item.name);
+    });
+}
+
+// You have to extend knockout for your own handlers
+declare module "knockout" {
+    export interface BindingHandlers {
+        yourBindingName: ko.BindingHandler;
+        slideVisible: ko.BindingHandler;
+        allowBindings: ko.BindingHandler;
+        withProperties: ko.BindingHandler;
+        randomOrder: ko.BindingHandler;
+    }
+}
+
+function test_bindings() {
+    const currentProfit = ko.observable(150000);
+    ko.applyBindings({
+        people: [
+            { firstName: 'Bert', lastName: 'Bertington' },
+            { firstName: 'Charles', lastName: 'Charlesforth' },
+            { firstName: 'Denise', lastName: 'Dentiste' }
+        ]
+    });
+
+    const viewModel = { availableCountries: ko.observableArray(['France', 'Germany', 'Spain']) };
+    viewModel.availableCountries.push('China');
+
+    ko.bindingHandlers.yourBindingName = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            return { "controlsDescendantBindings": true };
+        }
+    };
+
+    ko.bindingHandlers.slideVisible = {
+        update: function (element, valueAccessor, allBindingsAccessor) {
+            const
+                value = valueAccessor(), allBindings = allBindingsAccessor(),
+                valueUnwrapped = ko.utils.unwrapObservable(value),
+                duration = allBindings.slideDuration || 400;
+
+            if (valueUnwrapped == true)
+                $(element).slideDown(duration);
+            else
+                $(element).slideUp(duration);
+        },
+        init: function (element, valueAccessor) {
+            const value = ko.utils.unwrapObservable(valueAccessor());
+            $(element).toggle(value);
+        }
+    };
+
+    ko.bindingHandlers.hasFocus = {
+        init: function (element, valueAccessor) {
+            $(element)
+                .focus(() => {
+                    const value = valueAccessor();
+                    value(true);
+                })
+                .blur(() => {
+                    const value = valueAccessor();
+                    value(false);
+                });
+        },
+        update: function (element, valueAccessor) {
+            var value = valueAccessor();
+            if (ko.utils.unwrapObservable(value))
+                element.focus();
+            else
+                element.blur();
+        }
+    };
+
+    ko.bindingHandlers.allowBindings = {
+        init: function (elem, valueAccessor) {
+            var shouldAllowBindings = ko.utils.unwrapObservable(valueAccessor());
+            return { controlsDescendantBindings: !shouldAllowBindings };
+        }
+    };
+
+    ko.bindingHandlers.withProperties = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            const
+                newProperties = valueAccessor(),
+                innerBindingContext = bindingContext.extend(newProperties);
+
+            ko.applyBindingsToDescendants(innerBindingContext, element);
+
+            return { controlsDescendantBindings: true };
+        }
+    };
+
+    ko.bindingHandlers.withProperties = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            var newProperties = valueAccessor(),
+                childBindingContext = bindingContext.createChildContext(viewModel);
+
+            ko.utils.extend(childBindingContext, newProperties);
+            ko.applyBindingsToDescendants(childBindingContext, element);
+
+            return { controlsDescendantBindings: true };
+        }
+    };
+
+    ko.bindingHandlers.randomOrder = {
+        init: function (elem, valueAccessor) {
+            var child = ko.virtualElements.firstChild(elem),
+                childElems = [];
+
+            while (child) {
+                childElems.push(child);
+                child = ko.virtualElements.nextSibling(child);
+            }
+
+            ko.virtualElements.emptyNode(elem);
+
+            while (childElems.length) {
+                var randomIndex = Math.floor(Math.random() * childElems.length),
+                    chosenChild = childElems.splice(randomIndex, 1);
+                ko.virtualElements.prepend(elem, chosenChild[0]);
+            }
+        }
+    };
+
+    let node: Node = new Node(), containerElem: Element = new Element(),
+        nodeToInsert: Node = new Node(), insertAfter: Node = new Node(), nodeToPrepend: Node = new Node(), arrayOfNodes: Node[] = [];
+
+    ko.virtualElements.emptyNode(containerElem);
+    ko.virtualElements.firstChild(containerElem);
+    ko.virtualElements.insertAfter(containerElem, nodeToInsert, insertAfter);
+    ko.virtualElements.nextSibling(node);
+    ko.virtualElements.prepend(containerElem, nodeToPrepend);
+    ko.virtualElements.setDomNodeChildren(containerElem, arrayOfNodes);
+}
+
+// Have to define your own extenders
+declare module "knockout" {
+    export interface ObservableArrayFunctions<T> {
+        filterByProperty(propName: string, matchValue: boolean): ko.Computed<any>;
+    }
+
+    export interface Extenders {
+        logChange(target: ko.Subscribable, option: string): typeof target;
+        numeric(target: ko.Subscribable, precision: number): typeof target;
+        required(target: ko.Subscribable, overrideMessage: string): typeof target;
+    }
+}
+
+function test_more() {
+    const viewModel = {
+        firstName: ko.observable("Bert"),
+        lastName: ko.observable("Smith"),
+        pets: ko.observableArray(["Cat", "Dog", "Fish"]),
+        type: "Customer",
+        hasALotOfPets: <any>null
+    };
+
+    viewModel.hasALotOfPets = ko.computed(() => viewModel.pets().length > 2);
+
+    const plainJs = ko.toJS(viewModel);
+
+    ko.extenders.logChange = function (target, option) {
+        target.subscribe((newValue: string) => {
+            console.log(option + ": " + newValue);
+        });
+
+        return target;
+    };
+
+    ko.extenders.numeric = function (target, precision) {
+        var result = ko.computed<any>({
+            read: target,
+            write: (newValue) => {
+                var current = target(),
+                    roundingMultiplier = Math.pow(10, precision),
+                    newValueAsNum = isNaN(newValue) ? 0 : parseFloat(newValue),
+                    valueToWrite = Math.round(newValueAsNum * roundingMultiplier) / roundingMultiplier;
+
+                if (valueToWrite !== current) {
+                    target(valueToWrite);
+                } else {
+                    if (newValue !== current) {
+                        target.notifySubscribers(valueToWrite);
+                    }
+                }
+            }
+        });
+
+        result(target());
+
+        return result;
+    };
+
+    class AppViewModel {
+        myNumberOne: ko.Observable<number>;
+        myNumberTwo: ko.Observable<number>;
+
+        constructor(one: number, two: number) {
+            this.myNumberOne = ko.observable(one).extend({ numeric: 0 });
+            this.myNumberTwo = ko.observable(two).extend({ numeric: 2 });
+        }
+    }
+
+    ko.applyBindings(new AppViewModel(221.2234, 123.4525));
+
+    ko.extenders.required = function (target: any, overrideMessage) {
+
+        target.hasError = ko.observable();
+        target.validationMessage = ko.observable();
+
+        function validate(newValue: any) {
+            target.hasError(newValue ? false : true);
+            target.validationMessage(newValue ? "" : overrideMessage || "This field is required");
+        }
+
+        validate(target());
+
+        target.subscribe(validate);
+
+        return target;
+    };
+
+    class AppViewModel2 {
+        firstName: ko.Observable<string>;
+        lastName: ko.Observable<string>;
+
+        constructor(first: string, last: string) {
+            this.firstName = ko.observable(first).extend({ required: "Please enter a first name" });
+            this.lastName = ko.observable(last).extend({ required: "" });
+        }
+
+        test() {
+            const first: string = "test";
+            this.firstName = ko.observable(first).extend({ required: "Please enter a first name", logChange: "first name" });
+        }
+    }
+
+    ko.applyBindings(new AppViewModel2("Bob", "Smith"));
+
+    let name = "";
+    const upperCaseName = ko.computed(() => name.toUpperCase()).extend({ throttle: 500 });
+
+    class AppViewModel3 {
+        public instantaneousValue = ko.observable<string>();
+        public throttledValue = ko.computed(this.instantaneousValue)
+            .extend({ throttle: 400 });
+
+        public loggedValues = ko.observableArray<string>([]);
+
+        public throttledValueLogger = ko.computed(() => {
+            const val = this.instantaneousValue();
+            if (val !== '')
+                this.loggedValues.push(val);
+        });
+    }
+
+    class GridViewModel {
+        public pageSize = ko.observable(20);
+        public pageIndex = ko.observable(1);
+        public currentPageData = ko.observableArray();
+
+        constructor() {
+
+            ko.computed(() => {
+                const params = { page: this.pageIndex(), size: this.pageSize() };
+                $.getJSON('/Some/Json/Service', params, this.currentPageData);
+            });
+        }
+    }
+
+    function setPageSize(this: GridViewModel, newPageSize: number) {
+        this.pageSize(newPageSize);
+        this.pageIndex(1);
+    };
+
+    ko.computed(function (this: GridViewModel) {
+        var params = { page: this.pageIndex(), size: this.pageSize() };
+        $.getJSON('/Some/Json/Service', params, this.currentPageData);
+    }).extend({ throttle: 1 });
+
+    const removeDom = document.querySelector(".remove");
+    if (removeDom) {
+        removeDom.addEventListener("click", function (this: HTMLElement) {
+            viewModel.pets.remove(ko.dataFor(this));
+        });
+
+        removeDom.addEventListener("click", function (this: HTMLElement) {
+            viewModel.pets.remove(ko.dataFor(this));
+        });
+    }
+
+    ko.observableArray.fn.filterByProperty = function (propName, matchValue) {
+        return ko.pureComputed(() => {
+            const allItems = this(), matchingItems = [];
+            for (let current of allItems) {
+                if (ko.utils.unwrapObservable(current[propName]) === matchValue)
+                    matchingItems.push(current);
+            }
+            return matchingItems;
+        });
+    }
+
+    class Task {
+        public title: ko.Observable<string>;
+        public done: ko.Observable<boolean>;
+
+        constructor(title: string, done: boolean) {
+            this.title = ko.observable(title);
+            this.done = ko.observable(done);
+        }
+    }
+
+    class AppViewModel4 {
+        public tasks = ko.observableArray([
+            new Task('Find new desktop background', true),
+            new Task('Put shiny stickers on laptop', false),
+            new Task('Request more reggae music in the office', true)
+        ]);
+
+        public doneTasks = this.tasks.filterByProperty("done", true);
+
+        constructor() {
+            this.doneTasks = ko.computed(() => {
+                const all = this.tasks(), done = [];
+                for (let cur of all)
+                    if (cur.done())
+                        done.push(cur);
+                return done;
+            }, this);
+        }
+    }
+
+    ko.applyBindings(new AppViewModel4());;
+}
+
+// Define your own functions
+declare module "knockout" {
+    export interface SubscribableFunctions<T> {
+        publishOn(topic: string): this;
+        subscribeTo(topic: string): this;
+    }
+
+    export interface BindingHandlers {
+        isolatedOptions: BindingHandler;
+    }
+}
+
+function test_misc(this: any) {
+    // define dummy vars
+    let callback: any;
+    let target: any;
+    let topic: any;
+    let vm: any;
+    let value: any;
+
+    const postbox = new ko.subscribable();
+    postbox.subscribe(callback, target, topic);
+
+    postbox.subscribe(function (this: typeof vm, newValue: string) {
+        this.latestTopic(newValue);
+    }, vm, "mytopic");
+
+    postbox.notifySubscribers(value, "mytopic");
+
+    ko.subscribable.fn.publishOn = function (topic) {
+        this.subscribe(function (newValue) {
+            postbox.notifySubscribers(newValue, topic);
+        });
+
+        return this;
+    };
+
+    this.myObservable = ko.observable("myValue").publishOn("myTopic");
+
+    ko.subscribable.fn.subscribeTo = function (this: any, topic: string) {
+        postbox.subscribe(this, null, topic);
+        return this;
+    };
+
+    this.observableFromAnotherVM = ko.observable().subscribeTo("myTopic");
+
+    postbox.subscribe(function (this: ko.Subscribable, newValue: string) {
+        this(newValue);
+    }, this, topic);
+
+    ko.bindingHandlers.isolatedOptions = {
+        init: function (element, valueAccessor) {
+            var args = arguments;
+            ko.computed({
+                read: () => {
+                    ko.utils.unwrapObservable(valueAccessor());
+                    ko.bindingHandlers.options.update.apply(this, args);
+                },
+                owner: this,
+                disposeWhenNodeIsRemoved: element
+            });
+        }
+    };
+
+    ko.subscribable.fn.publishOn = function (topic) {
+        this.subscribe(function (newValue) {
+            postbox.notifySubscribers(newValue, topic);
+        });
+
+        return this;
+    };
+
+    this.myObservable = ko.observable("myValue").publishOn("myTopic");
+
+    var x = ko.observableArray([1, 2, 3]);
+
+    let element = new HTMLElement();
+    ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+        $(element).datepicker("destroy");
+    });
+
+    this.observableFactory = function (readonly: boolean = false): ko.Subscribable<number> {
+        if (readonly) {
+            return ko.computed(() => 3);
+        } else {
+            return ko.observable(3);
+        }
+    }
+
+}
+
+// Define your own bindingHandler
+declare module "knockout" {
+    export interface BindingHandlers {
+        allBindingsAccessorTest: BindingHandler;
+    }
+}
+
+function test_allBindingsAccessor() {
+    ko.bindingHandlers.allBindingsAccessorTest = {
+        init: (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) => {
+            var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
+            var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
+        },
+        update: (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) => {
+            var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
+            var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
+        }
+    };
+}
+
+
+function test_Components() {
+
+    // test all possible ko.components.register() overloads
+    function test_Register() {
+        // reused parameters
+        const nodeArray = [new Node, new Node];
+        const singleNode = new Node;
+        const viewModelFn = function (params: any) { return <any>null; }
+        class ViewModelClass { }
+
+        // ------- viewmodel overloads:
+        // viewModel as inline function (commonly used in examples)
+        ko.components.register("name", { template: "string-template", viewModel: viewModelFn });
+
+        // viewModel as a Class
+        ko.components.register("name", { template: "string-template", viewModel: ViewModelClass });
+
+        // viewModel from shared instance
+        ko.components.register("name", { template: "string-template", viewModel: { instance: null } });
+
+        // viewModel from createViewModel factory method
+        ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
+
+        // viewModel from an AMD module 
+        ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
+
+        // ------- template overloads
+        // template from named element
+        ko.components.register("name", { template: { element: "elementID" }, viewModel: viewModelFn });
+
+        // template using single Node
+        ko.components.register("name", { template: { element: singleNode }, viewModel: viewModelFn });
+
+        // template using Node array
+        ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
+
+        // template using an AMD module 
+        ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
+
+        // Empty config for registering custom elements that are handled by name convention
+        ko.components.register('name', { /* No config needed */ });
+    }
+}
+
+
+function testUnwrapUnion(this: any) {
+    let possibleObs: ko.Observable<number> | number = this.getValue();
+    const num = ko.unwrap(possibleObs);
+}
+
+
+// *****************************
+// Template and Databinding Tests
+// *****************************
+declare module "knockout" {
+    export interface TemplateOptions<T> {
+        showParams?: boolean;
+        templateOptions?: any;
+        templateRenderingVariablesInScope?: any;
+    }
+}
+
+class DummyTemplateSource {
+    constructor(private engine: DummyTemplateEngine, public id: string) { }
+
+    text(): string;
+    text(val: string): void;
+    text(val?: string) {
+        if (arguments.length > 0) {
+            this.engine.inMemoryTemplates[this.id] = val;
+        }
+        else {
+            return this.engine.inMemoryTemplates[this.id];
+        }
+    }
+
+    data(): any;
+    data(val: any): void;
+    data(val?: any) {
+        if (arguments.length > 0) {
+            this.engine.inMemoryTemplateData[this.id] = val;
+        }
+        else {
+            return this.engine.inMemoryTemplateData[this.id];
+        }
+    }
+}
+
+class DummyTemplateEngine extends ko.templateEngine {
+    public inMemoryTemplates: { [key: string]: any } = {};
+    public inMemoryTemplateData: { [key: string]: any } = {};
+
+    constructor(templates?: { [key: string]: any }) {
+        super();
+        this.inMemoryTemplateData = templates || {};
+    }
+
+    public makeTemplateSource(template: string | Node, templateDocument?: Document): ko.TemplateSource {
+        if (typeof template === "string") {
+            return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
+        }
+        else if ((template.nodeType == 1) || (template.nodeType == 8)) {
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+        }
+        else {
+            throw new Error("Unrecognized template source");
+        }
+    }
+
+    public renderTemplateSource(templateSource: ko.TemplateSource, bindingContext: ko.BindingContext<any>, options?: ko.TemplateOptions<any>, templateDocument?: Document): Node[] {
+        const data = bindingContext['$data'];
+        options = options || {};
+        let templateText = templateSource.text() as string | Function;
+        if (typeof templateText == "function")
+            templateText = templateText(data, options) as string;
+
+        templateText = options.showParams ? templateText + ", data=" + data + ", options=" + options : templateText;
+        var templateOptions = options.templateOptions; // Have templateOptions in scope to support [js:templateOptions.foo] syntax
+        var result;
+        //with (bindingContext)
+        {
+            //with (data || {})
+            {
+                //with (options.templateRenderingVariablesInScope || {})
+                {
+                    // Dummy [renderTemplate:...] syntax
+                    result = templateText.replace(/\[renderTemplate\:(.*?)\]/g, function (match, templateName) {
+                        return ko.renderTemplate(templateName, data, options || {});
+                    });
+
+
+                    var evalHandler = function (match: string, script: any) {
+                        try {
+                            var evalResult = eval(script);
+                            return (evalResult === null) || (evalResult === undefined) ? "" : evalResult.toString();
+                        } catch (ex) {
+                            throw new Error("Error evaluating script: [js: " + script + "]\n\nException: " + ex.toString());
+                        }
+                    }
+
+                    // Dummy [[js:...]] syntax (in case you need to use square brackets inside the expression)
+                    result = result.replace(/\[\[js\:([\s\S]*?)\]\]/g, evalHandler);
+
+                    // Dummy [js:...] syntax
+                    result = result.replace(/\[js\:([\s\S]*?)\]/g, evalHandler);
+                }
+            }
+        }
+
+        // Use same HTML parsing code as real template engine so as to trigger same combination of IE weirdnesses
+        // Also ensure resulting nodelist is an array to mimic what the default templating engine does, so we see the effects of not being able to remove dead memo comment nodes.
+        return ko.utils.arrayPushAll([], ko.utils.parseHtmlFragment(result));
+    }
+
+    public rewriteTemplate(template: string | Node, rewriterCallback: (val: string) => any) {
+        // Only rewrite if the template isn't a function (can't rewrite those)
+        var templateSource = new ko.templateSources.anonymousTemplate(template as any); //this.makeTemplateSource(template);
+        if (typeof templateSource.text() != "function")
+            return ko.templateEngine.prototype.rewriteTemplate.call(this, template, rewriterCallback);
+    }
+
+    public createJavaScriptEvaluatorBlock(script: string): string {
+        return "[js:" + script + "]";
+    };
+
+}
+
+let testNode: any;
+
+ko.setTemplateEngine(new ko.nativeTemplateEngine());
+
+ko.setTemplateEngine(new DummyTemplateEngine({ x: [document.createElement("div"), document.createElement("span")] }));
+ko.renderTemplate("x", null);
+
+var threw = false;
+ko.setTemplateEngine(undefined);
+try { ko.renderTemplate("someTemplate", {}) }
+catch (ex) { threw = true }
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "ABC" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ emptyTemplate: "" }));
+ko.renderTemplate("emptyTemplate", null, null, testNode);
+
+var passedElement, passedDataItem;
+var myCallback = function (elementsArray: Node[], dataItem: any) {
+    passedElement = elementsArray[0];
+    passedDataItem = dataItem;
+}
+
+var myModel = {};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "ABC" }));
+ko.renderTemplate("someTemplate", myModel, { afterRender: myCallback }, testNode);
+
+var dependency = ko.observable("A");
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: () => "Value = " + dependency() }));
+
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+dependency("B");
+
+var observable = ko.observable("A"), count = 0;
+var myCallback = function (elementsArray: Node[], dataItem: any) {
+    observable();   // access observable in callback
+};
+var myTemplate = function () {
+    return "Value = " + (++count);
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: myTemplate }));
+ko.renderTemplate("someTemplate", {}, { afterRender: myCallback }, testNode);
+
+observable("B");
+
+var observable = ko.observable("A");
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: function (data: string) {
+        return "Value = " + data;
+    }
+}));
+ko.renderTemplate("someTemplate", observable, null, testNode);
+
+observable("B");
+
+var dependency = ko.observable("A");
+var template = { someTemplate: () => "Value = " + dependency() };
+ko.setTemplateEngine(new DummyTemplateEngine(template));
+
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+testNode.parentNode.removeChild(testNode);
+dependency("B");
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "template output" }));
+testNode.innerHTML = "<div data-bind='template:\"someTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: 123 } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+
+var myData = ko.observable({ childProp: 123 });
+ko.applyBindings({ someProp: myData }, testNode);
+
+// Now mutate and notify
+myData().childProp = 456;
+myData.valueHasMutated();
+
+var innerObservable = ko.observable("some value");
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp()]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"someTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: innerObservable } }, testNode);
+
+ko.removeNode(testNode.childNodes[0]);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    firstTemplate: "First template output",
+    secondTemplate: "Second template output"
+}));
+
+var chosenTemplate = ko.observable("firstTemplate");
+testNode.innerHTML = "<div data-bind='template: chosenTemplate'></div>";
+ko.applyBindings({ chosenTemplate: chosenTemplate }, testNode);
+
+chosenTemplate("secondTemplate");
+
+interface MyTemplate {
+    myTemplate: string;
+}
+
+var templatePicker = function (dataItem: MyTemplate, bindingContext: ko.BindingContext) {
+    // Having the entire binding context available means you can read sibling or parent level properties
+    return dataItem.myTemplate;
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "result = [js: childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: templateSelectorFunction, data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: 123, myTemplate: "someTemplate" }, templateSelectorFunction: templatePicker, anotherProperty: 456 }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "outer template output, [renderTemplate:innerTemplate]", // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: "inner template output <span data-bind='text: 123'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template:\"outerTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+var observable = ko.observable("ABC");
+var timesRenderedOuter = 0, timesRenderedInner = 0;
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: function () { timesRenderedOuter++; return "outer template output, [renderTemplate:innerTemplate]" }, // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: function () { timesRenderedInner++; return observable() }
+}));
+testNode.innerHTML = "<div data-bind='template:\"outerTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+
+observable("DEF");
+
+var innerObservable = ko.observable("some value");
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "outer template output, <span id='innerTemplateOutput'>[renderTemplate:innerTemplate]</span>",
+    innerTemplate: "result = [js: childProp()]"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", data: someProp }'></div>";
+ko.applyBindings({ someProp: { childProp: innerObservable } }, testNode);
+
+const node = document.getElementById('innerTemplateOutput');
+node && ko.removeNode(node);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<INPUT Data-Bind='value:\"Hi\"' />" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input data-bind='value:\n\"Hi\"' />" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input data-bind='value:message' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { message: "hello" } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<div data-bind='text: $element.tagName'></div>" }));
+ko.renderTemplate("someTemplate", null, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<div data-bind='text: $context.$data === $data'></div>" }));
+ko.renderTemplate("someTemplate", {}, null, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: "<input data-bind='value:message' />[js: message = 'goodbye'; undefined; ]"
+}));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { message: "hello" } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    someTemplate: "<button data-bind='click: someFunctionOnModel'>click me</button>"
+}));
+var viewModel = {
+    didCallMyFunction: false,
+    someFunctionOnModel: function () { this.didCallMyFunction = true }
+};
+ko.renderTemplate("someTemplate", viewModel, null, testNode);
+var buttonNode = testNode.childNodes[0];
+buttonNode.click();
+
+// Will verify that bindings are applied only once for both inline (rewritten) bindings,
+// and external (non-rewritten) ones
+var originalBindingProvider = ko.bindingProvider.instance;
+ko.bindingProvider.instance = {
+    nodeHasBindings: (node: Element) => (node.tagName == 'EM') || originalBindingProvider.nodeHasBindings(node),
+    getBindings: (node, bindingContext) => {
+        if ((<Element>node).tagName == 'EM')
+            return { text: ++model.numBindings } as Object;
+
+        return originalBindingProvider.getBindings(node, bindingContext);
+    },
+    getBindingAccessors: (node, bindingContext) => {
+        if ((<Element>node).tagName == 'EM')
+            return { text: () => ++model.numBindings };
+
+        return originalBindingProvider.getBindingAccessors(node, bindingContext);
+    }
+};
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "Outer <div data-bind='template: { name: \"innerTemplate\", bypassDomNodeWrap: true }'></div>",
+    innerTemplate: "Inner via inline binding: <span data-bind='text: ++numBindings'></span>"
+        + "Inner via external binding: <em></em>"
+}));
+var model = { numBindings: 0 };
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", bypassDomNodeWrap: true }'></div>";
+ko.applyBindings(model, testNode);
+
+ko.bindingProvider.instance = originalBindingProvider;
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>The item is [js: personName]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+var originalBobNode = testNode.childNodes[0].childNodes[0];
+var originalFrankNode = testNode.childNodes[0].childNodes[1];
+
+myArray.push({ personName: "Steve" });
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is <span data-bind='text: personName'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var initCalls = 0;
+(<any>ko.bindingHandlers).countInits = { init: function () { initCalls++ } };
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<span data-bind='countInits: true'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: [1, 2, 3] }, testNode);
+
+// Represents https://github.com/SteveSanderson/knockout/pull/440
+// Previously, the rewriting (which introduces a comment node before the bound node) was interfering
+// with the array-to-DOM-node mapping state tracking
+ko.setTemplateEngine(new DummyTemplateEngine({ mytemplate: "<div data-bind='text: $data'></div>" }));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'mytemplate', foreach: items }\"></div>";
+
+// Bind against initial array containing one entry. UI just shows "original"
+var myArray2 = ko.observableArray(["original"]);
+ko.applyBindings({ items: myArray2 }, testNode);
+
+// Now replace the entire array contents with one different entry.
+// UI just shows "new" (previously with bug, showed "original" AND "new")
+myArray2(["new"]);
+
+// See https://github.com/SteveSanderson/knockout/pull/440 and https://github.com/SteveSanderson/knockout/pull/144
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "<div data-bind='text: $data'></div>[renderTemplate:innerTemplate]x", // [renderTemplate:...] is special syntax supported by dummy template engine
+    innerTemplate: "inner <span data-bind='text: 123'></span>"
+}));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'outerTemplate', foreach: items }\"></div>";
+
+// Bind against initial array containing one entry.
+var myArray3 = ko.observableArray(["original"]);
+ko.applyBindings({ items: myArray3 }, testNode);
+
+// Now replace the entire array contents with one different entry.
+myArray3(["new"]);
+
+// Represents https://github.com/SteveSanderson/knockout/issues/739
+// Previously, the rewriting (which introduces a comment node before the bound node) was interfering
+// with the array-to-DOM-node mapping state tracking
+ko.setTemplateEngine(new DummyTemplateEngine({ mytemplate: "<div data-bind='attr: {}'>[js:name()]</div>" }));
+testNode.innerHTML = "<div data-bind=\"template: { name: 'mytemplate', foreach: items }\"></div>";
+
+// Bind against array, referencing an observable property
+var myItem = { name: ko.observable("a") };
+ko.applyBindings({ items: [myItem] }, testNode);
+
+// Modify the observable property and check that UI is updated
+// Previously with the bug, it wasn't updated because the removal of the memo comment caused the array-to-DOM-node computed to be disposed
+myItem.name("b");
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item # is <span data-bind='text: $index'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var myArray = ko.observableArray([{ personName: "Bob" }, { personName: "Frank" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item <span data-bind='text: personName'></span>is <span data-bind='text: $index'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray }, testNode);
+
+var frank = myArray.pop(); // remove frank
+myArray.unshift(frank); // put frank in the front
+var myArray4 = ko.observableArray([undefined, null]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is <span data-bind='text: String($data)'></span>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray4 }, testNode);
+
+var myObservable = ko.observable("Steve");
+var myArray5 = ko.observableArray([{ personName: "Bob" }, { personName: myObservable }, { personName: "Another" }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>The item is [js: ko.utils.unwrapObservable(personName)]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray5 }, testNode);
+var originalBobNode = testNode.childNodes[0].childNodes[0];
+
+myObservable("Steve2");
+
+// Ensure we can still remove the corresponding nodes (even though they've changed), and that doing so causes the subscription to be disposed
+myArray5.splice(1, 1);
+myObservable("Something else"); // Re-evaluating the observable causes the orphaned subscriptions to be disposed
+var myArray6 = ko.observableArray(["A", "B"]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "hello" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray6 }, testNode);
+
+// Now set the observable to null and check it's treated like an empty array
+// (because how else should null be interpreted?)
+myArray6(null);
+
+// Note: There are more detailed specs (e.g., covering nesting) associated with the "foreach" binding which
+// uses this templating functionality internally.
+var myArray7 = ko.observableArray(["A", "B"]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "[js:myAliasedItem]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection, as: \"myAliasedItem\" }'></div>";
+
+ko.applyBindings({ myCollection: myArray7 }, testNode);
+
+var innerObservable = ko.observable("some value");
+var myArray8 = ko.observableArray([{ obsVal: innerObservable }, { obsVal: innerObservable }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is [js: ko.utils.unwrapObservable(obsVal)]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray8 }, testNode);
+
+ko.removeNode(testNode.childNodes[0]);
+
+var innerObservable = ko.observable("some value");
+var myArray9 = ko.observableArray([{ obsVal: innerObservable }, { obsVal: innerObservable }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "The item is [js: ko.utils.unwrapObservable(obsVal)]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray9 }, testNode);
+
+myArray9.splice(1, 1);
+myArray9([]);
+
+var myArray10 = ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp: 3 }, { someProp: 4, _destroy: ko.observable(false) }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection }'></div>";
+
+ko.applyBindings({ myCollection: myArray10 }, testNode);
+
+var myArray11 = ko.observableArray([{ someProp: 1 }, { someProp: 2, _destroy: 'evals to true' }, { someProp: 3 }]);
+ko.setTemplateEngine(new DummyTemplateEngine({ itemTemplate: "<div>someProp=[js: someProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"itemTemplate\", foreach: myCollection, includeDestroyed: true }'></div>";
+
+ko.applyBindings({ myCollection: myArray11 }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp }'></div>";
+
+interface ChildProp { childProp: string; }
+var viewModel2 = { myProp: ko.observable<ChildProp | null>({ childProp: 'abc' }) };
+ko.applyBindings(viewModel2, testNode);
+
+// Causing the condition to become false causes the output to be removed
+viewModel2.myProp(null);
+
+// Causing the condition to become true causes the output to reappear
+viewModel2.myProp({ childProp: 'def' });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Hello" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", ifnot: shouldHide }'></div>";
+
+var viewModel3 = { shouldHide: ko.observable(true) };
+ko.applyBindings(viewModel3, testNode);
+
+// Causing the condition to become false causes the output to be displayed
+viewModel3.shouldHide(false);
+
+// Causing the condition to become true causes the output to disappear
+viewModel3.shouldHide(true);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp, foreach: [$data, $data, $data] }'></div>";
+
+var viewModel4 = { myProp: ko.observable<ChildProp | null>({ childProp: 'abc' }) };
+ko.applyBindings(viewModel4, testNode);
+
+// Causing the condition to become false causes the output to be removed
+viewModel4.myProp(null);
+
+// Causing the condition to become true causes the output to reappear
+viewModel4.myProp({ childProp: 'def' });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input type='checkbox' data-bind='checked:isChecked' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { isChecked: true } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({ someTemplate: "<input type='radio' name='somename' value='abc' data-bind='checked:someValue' />" }));
+ko.renderTemplate("someTemplate", null, { templateRenderingVariablesInScope: { someValue: 'abc' } }, testNode);
+
+var myArray12 = ko.observableArray([
+    { preferredTemplate: 1, someProperty: 'firstItemValue' },
+    { preferredTemplate: 2, someProperty: 'secondItemValue' }
+]);
+ko.setTemplateEngine(new DummyTemplateEngine({
+    firstTemplate: "<div>Template1Output, [js:someProperty]</div>",
+    secondTemplate: "<div>Template2Output, [js:someProperty]</div>"
+}));
+testNode.innerHTML = "<div data-bind='template: {name: getTemplateModelProperty, foreach: myCollection}'></div>";
+
+var getTemplate = function (dataItem: any, bindingContext: ko.BindingContext) {
+    return dataItem.preferredTemplate == 1 ? 'firstTemplate' : 'secondTemplate';
+};
+ko.applyBindings({ myCollection: myArray12, getTemplateModelProperty: getTemplate, anotherProperty: 123 }, testNode);
+
+var myModel2 = {
+    someAdditionalData: { myAdditionalProp: "someAdditionalValue" },
+    people: ko.observableArray([
+        { name: "Alpha" },
+        { name: "Beta" }
+    ])
+};
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<div>Person [js:name] has additional property [js:templateOptions.myAdditionalProp]</div>" }));
+testNode.innerHTML = "<div data-bind='template: {name: \"myTemplate\", foreach: people, templateOptions: someAdditionalData }'></div>";
+
+ko.applyBindings(myModel2, testNode);
+
+var myObservable = ko.observable("some value"),
+    myModel3 = {
+        subModel: ko.observable({ myObservable: myObservable })
+    };
+
+ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<span>The value is [js:myObservable()]</span>" }));
+testNode.innerHTML = "<div data-bind='template: {name: \"myTemplate\", data: subModel}'></div>";
+ko.applyBindings(myModel3, testNode);
+
+// Right now the template references myObservable, so there should be exactly one subscription on it
+var renderedNode1 = testNode.childNodes[0].childNodes[0];
+
+// By changing the object for subModel, we force the data-bind value to be re-evaluated and the template to be re-rendered,
+// setting up a new template subscription, so there have now existed two subscriptions on myObservable...
+myModel3.subModel({ myObservable: myObservable });
+
+ko.setTemplateEngine(new DummyTemplateEngine({ theTemplate: "Default output" })); // Not going to use this one
+var alternativeTemplateEngine = new DummyTemplateEngine({ theTemplate: "Alternative output" });
+
+testNode.innerHTML = "<div data-bind='template: { name: \"theTemplate\", templateEngine: chosenEngine }'></div>";
+ko.applyBindings({ chosenEngine: alternativeTemplateEngine }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "ValueLiteral: [js:item.prop], ValueBound: <span data-bind='text: item.prop'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", data: someItem, as: \"item\" }'></div>";
+ko.applyBindings({ someItem: { prop: 'Hello' } }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "ValueLiteral: [js:$parent.parentProp], ValueBound: <span data-bind='text: $parent.parentProp'></span>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", data: someItem }'></div>";
+ko.applyBindings({ someItem: {}, parentProp: 'Hello' }, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "<div data-bind='template: { name:\"middleTemplate\", data: middleItem }'></div>",
+    middleTemplate: "<div data-bind='template: { name: \"innerTemplate\", data: innerItem }'></div>",
+    innerTemplate: "(Data:[js:$data.val], Parent:[[js:$parents[0].val]], Grandparent:[[js:$parents[1].val]], Root:[js:$root.val], Depth:[js:$parents.length])"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\", data: outerItem }'></div>";
+
+ko.applyBindings({
+    val: "ROOT",
+    outerItem: {
+        val: "OUTER",
+        middleItem: {
+            val: "MIDDLE",
+            innerItem: { val: "INNER" }
+        }
+    }
+}, testNode);
+
+// The reason is that your template engine's native control flow and variable evaluation logic is going to run first, independently
+// of any KO-native control flow, so variables would get evaluated in the wrong context. Example:
+//
+// <div data-bind="foreach: someArray">
+//     ${ somePropertyOfEachArrayItem }   <-- This gets evaluated *before* the foreach binds, so it can't reference array entries
+// </div>
+//
+// It should be perfectly OK to fix this just by preventing anonymous templates within rewritten templates, because
+// (1) The developer can always use their template engine's native control flow syntax instead of the KO-native ones - that will work
+// (2) The developer can use KO's native templating instead, if they are keen on KO-native control flow or anonymous templates
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "<div data-bind='template: { data: someData }'>Childprop: [js: childProp]</div>"
+}));
+testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
+
+var didThrow = false;
+try {
+    ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
+} catch (ex) {
+    didThrow = true;
+}
+
+// Same reason as above
+ko.utils.arrayForEach(['if', 'ifnot', 'with', 'foreach'], function (bindingName) {
+    ko.setTemplateEngine(new DummyTemplateEngine({ myTemplate: "<div data-bind='" + bindingName + ": \"SomeValue\"'>Hello</div>" }));
+    testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\" }'></div>";
+
+    var didThrow = false;
+    ko.utils.domData.clear(testNode);
+    try { ko.applyBindings({ someData: { childProp: 'abc' } }, testNode) }
+    catch (ex) {
+        didThrow = true;
+    }
+    if (!didThrow)
+        throw new Error("Did not prevent use of " + bindingName);
+});
+
+ko.setTemplateEngine(new DummyTemplateEngine({
+    outerTemplate: "Outer <!-- ko template: \n" +
+        "{ name: \"innerTemplate\" } \n" +
+        "--><!-- /ko -->",
+    innerTemplate: "Inner via inline binding: <span data-bind='text: \"someText\"'></span>"
+}));
+var model2 = {};
+testNode.innerHTML = "<div data-bind='template: { name: \"outerTemplate\" }'></div>";
+ko.applyBindings(model2, testNode);
+
+ko.setTemplateEngine(new DummyTemplateEngine());
+testNode.innerHTML = "Start <!-- ko template: { data: someData } -->Childprop: [js: childProp]<!-- /ko --> End";
+ko.applyBindings({ someData: { childProp: 'abc' } }, testNode);
+
+// This represents issue https://github.com/SteveSanderson/knockout/issues/188
+// (IE < 9 strips out leading comment nodes when you use .innerHTML)
+ko.setTemplateEngine(new DummyTemplateEngine({}));
+testNode.innerHTML = "start <div data-bind='foreach: [1,2]'><span><!-- leading comment -->hello</span></div>";
+ko.applyBindings(null, testNode);
+
+delete (<any>ko.bindingHandlers).nonexistentHandler;
+var initCalls = 0;
+(<any>ko.bindingHandlers).countInits = { init: function () { initCalls++ } };
+testNode.innerHTML = "<div data-bind='template: {}'><!-- ko nonexistentHandler: true --><span data-bind='countInits: true'></span><!-- /ko --></div>";
+ko.applyBindings(null, testNode);
+
+// Represents https://github.com/SteveSanderson/knockout/issues/660
+// A <span> can't go directly into a <tr>, so modern browsers will silently strip it. We need to verify this doesn't
+// throw errors during unmemoization (when unmemoizing, it will try to apply the text to the following text node
+// instead of the node you intended to bind to).
+// Note that IE < 9 won't strip the <tr>; instead it has much stranger behaviors regarding unexpected DOM structures.
+// It just happens not to give an error in this particular case, though it would throw errors in many other cases
+// of malformed template DOM.
+ko.setTemplateEngine(new DummyTemplateEngine({
+    myTemplate: "<tr><span data-bind=\"text: 'Some text'\"></span> </tr>" // The whitespace after the closing span is what triggers the strange HTML parsing
+}));
+testNode.innerHTML = "<div data-bind='template: \"myTemplate\"'></div>";
+ko.applyBindings(null, testNode);
+// Since the actual template markup was invalid, we don't really care what the
+// resulting DOM looks like. We are only verifying there were no exceptions.

--- a/spec/types/module/tsconfig.json
+++ b/spec/types/module/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "umd", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "noEmit": true, /* Do not emit outputs. */
+    "strict": true, /* Enable all strict type-checking options. */
+    "moduleResolution": "classic",
+    "baseUrl": ".",
+    "paths": {
+      "knockout": [
+        "../../../build/types/knockout"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This Pull Request is created to include `TypeScript` types into `knockout` repository. This is related to #2353. 

This allows the `TypeScript` compiler to automatically find the `knockout` types when using option `moduleResolution: "node"`.

This includes:
 * Types definitions taken from [typed-contrib](https://github.com/typed-contrib/knockout) and revised for `TypeScript` 2+
 * Types tests taken from [typed-contrib](https://github.com/typed-contrib/knockout)
* `Grunt` task to test types automatically
* `package.json` configuration to help `tsc` finding the types.
