### PR TITLE
Event binding improvements

### DIFF
--- a/spec/defaultBindings/eventBehaviors.js
+++ b/spec/defaultBindings/eventBehaviors.js
@@ -1,6 +1,24 @@
 describe('Binding: Event', function() {
     beforeEach(jasmine.prepareTestNode);
 
+    it('Should throw an error if bound value is not a function', function () {
+        var koOnError = ko.onError;
+        var lastError;
+        ko.onError = function(e) {
+            lastError = e;
+        }
+
+        testNode.innerHTML = "<a href='#' data-bind='event: { click: a }'>hey</button>";
+        ko.applyBindings({ a: 1 }, testNode);
+
+        try {
+            ko.utils.triggerEvent(testNode.childNodes[0], "click");
+            expect(lastError.message).toContain("The value for");
+        } finally {
+            ko.onError = koOnError;
+        }
+    });
+
     it('Should invoke the supplied function when the event occurs, using model as \'this\' param and first arg, and event as second arg', function () {
         var model = {
             firstWasCalled: false,
@@ -62,6 +80,21 @@ describe('Binding: Event', function() {
         ko.utils.triggerEvent(testNode.childNodes[0].childNodes[0], "click");
         expect(model.innerWasCalled).toEqual(true);
         expect(model.outerWasCalled).toEqual(false);
+    });
+
+    it('Should be able to prevent bubbling of bubblable events using an explicit false return value from handler', function() {
+      var model = {
+        innerWasCalled: false, innerDoCall: function () {
+            this.innerWasCalled = true;
+            return false;
+        },
+        outerWasCalled: false, outerDoCall: function () { this.outerWasCalled = true; }
+      };
+      testNode.innerHTML = "<div data-bind='event:{click:outerDoCall}'><button data-bind='event:{click:innerDoCall}'>hey</button></div>";
+      ko.applyBindings(model, testNode);
+      ko.utils.triggerEvent(testNode.childNodes[0].childNodes[0], "click");
+      expect(model.innerWasCalled).toEqual(true);
+      expect(model.outerWasCalled).toEqual(false);
     });
 
     it('Should be able to supply handler params using "bind" helper', function() {

--- a/spec/defaultBindings/submitBehaviors.js
+++ b/spec/defaultBindings/submitBehaviors.js
@@ -11,4 +11,17 @@ describe('Binding: Submit', function() {
         expect(model.wasCalled).toEqual(true);
         expect(firstParamStored).toEqual(formNode);
     });
+
+    it('Should be able to prevent bubbling of submit event using the submitBubble:false option', function() {
+        var model = {
+            innerWasCalled: false, innerDoCall: function () { this.innerWasCalled = true; },
+            outerWasCalled: false, outerDoCall: function () { this.outerWasCalled = true; }
+        };
+        testNode.innerHTML = "<div data-bind='event:{submit:outerDoCall}'><form data-bind='submit:innerDoCall,submitBubble:false' /></div>";
+        var formNode = testNode.childNodes[0].childNodes[0];
+        ko.applyBindings(model, testNode);
+        ko.utils.triggerEvent(formNode, "submit");
+        expect(model.innerWasCalled).toEqual(true);
+        expect(model.outerWasCalled).toEqual(false);
+    });
 });

--- a/src/binding/defaultBindings/event.js
+++ b/src/binding/defaultBindings/event.js
@@ -21,6 +21,10 @@ ko.bindingHandlers['event'] = {
                 ko.utils.registerEventHandler(element, eventName, function (event) {
                     var handlerReturnValue;
                     var handlerFunction = valueAccessor()[eventName];
+                    if (handlerFunction !== null && handlerFunction !== undefined && typeof handlerFunction !== "function") {
+                        throw new Error("The value for a '" + eventName + "' event binding must be a function");
+                    }
+
                     if (!handlerFunction)
                         return;
 
@@ -39,7 +43,7 @@ ko.bindingHandlers['event'] = {
                         }
                     }
 
-                    var bubble = allBindings.get(eventName + 'Bubble') !== false;
+                    var bubble = allBindings.get(eventName + 'Bubble') !== false && handlerReturnValue !== false;
                     if (!bubble) {
                         event.cancelBubble = true;
                         if (event.stopPropagation)

--- a/src/binding/defaultBindings/submit.js
+++ b/src/binding/defaultBindings/submit.js
@@ -1,19 +1,11 @@
 ko.bindingHandlers['submit'] = {
     'init': function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-        if (typeof valueAccessor() != "function")
-            throw new Error("The value for a submit binding must be a function");
-        ko.utils.registerEventHandler(element, "submit", function (event) {
-            var handlerReturnValue;
-            var value = valueAccessor();
-            try { handlerReturnValue = value.call(bindingContext['$data'], element); }
-            finally {
-                if (handlerReturnValue !== true) { // Normally we want to prevent default action. Developer can override this be explicitly returning true.
-                    if (event.preventDefault)
-                        event.preventDefault();
-                    else
-                        event.returnValue = false;
+        ko.bindingHandlers.event.init(element, function() {
+            return {
+                "submit": function(event) {
+                    return valueAccessor().call(this, element);
                 }
             }
-        });
+        }, allBindings, viewModel, bindingContext);
     }
 };


### PR DESCRIPTION
This PR contains several minor improvements related to the `event` and `submit` bindings.

- Refactored the `submit` binding to reuse the `event` binding. This way some concepts can be easily shared, like preventing default behavior or stopping bubbling.
- Added a check in the bound event handler to throw an exception in case of the bound value is not a function. This adds some level of additional usability and makes debugging strange issues easier.
- Added support for stopping event propagation from the handler by returning an explicit `false` value. This behavior is similar to how `jQuery` handles return values from event handlers and it adds support for run-time event propagation handling (in contrast to the existing "design-time" `*Bubble` feature).

The latter point introduces somewhat a breaking change, but I don't think that many code is affected as returning `false` explicitly to prevent default behavior *and* stop propagation is an old convention in my opinion.

Please let me know if we should refine anything here.