### PR TITLE
Make jQuery detection more robust

### DIFF
--- a/build/fragments/extern-pre.js
+++ b/build/fragments/extern-pre.js
@@ -4,5 +4,5 @@
     var window = this || (0, eval)('this'),
         document = window['document'],
         navigator = window['navigator'],
-        jQueryInstance = window["jQuery"],
+        jQueryInstance = window["jQuery"] || jQuery,
         JSON = window["JSON"];

--- a/build/fragments/extern-pre.js
+++ b/build/fragments/extern-pre.js
@@ -4,5 +4,9 @@
     var window = this || (0, eval)('this'),
         document = window['document'],
         navigator = window['navigator'],
-        jQueryInstance = window["jQuery"] || jQuery,
+        jQueryInstance = window["jQuery"],
         JSON = window["JSON"];
+
+    if (!jQueryInstance && typeof jQuery !== "undefined") {
+        jQueryInstance = jQuery;
+    }


### PR DESCRIPTION
A widely applied approach with `webpack` is to use the `provide` plugin for such libraries like `jQuery`. When using that plugin, 99% of developers will ask the plugin to expose `jQuery` in a `jQuery` variable for every imported module in an inner scope (but out from the module itself).

With this enhancement we could support this case out of the box without needing an even more special webpack configuration.