### PR TITLE
Fixes simpleHttpParse logic for table-like names

### DIFF
--- a/spec/parseHtmlFragment.js
+++ b/spec/parseHtmlFragment.js
@@ -18,6 +18,8 @@ describe('Parse HTML fragment', function() {
         { html: '<div></div>', parsed: ['<div></div>'] },
         { html: '<custom-component></custom-component>', parsed: ['<custom-component></custom-component>'] },
         { html: '<tr></tr>', parsed: ['<tr></tr>'] },
+        { html: '<!-- ko if:true --><tr></tr><!-- /ko -->', parsed: ['<!-- ko if:true -->','<tr></tr>','<!-- /ko -->'] },
+        { html: '<!-- this is a table row --><tr></tr>', parsed: ['<!-- this is a table row -->','<tr></tr>'] },
         { html: '<tr></tr><tr></tr>', parsed: ['<tr></tr>', '<tr></tr>'] },
         { html: '<td></td>', parsed: ['<td></td>'] },
         { html: '<th></th>', parsed: ['<th></th>'] },

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -19,7 +19,7 @@
         mayRequireCreateElementHack = ko.utils.ieVersion <= 8;
 
     function getWrap(tags) {
-        var m = tags.match(/^<([a-z]+)[ >]/);
+        var m = tags.match(/^(?:<!--.*?-->\s*?)*?<([a-z]+)[\s>]/);
         return (m && lookup[m[1]]) || none;
     }
 


### PR DESCRIPTION
The logic fails to parse table-like tags properly, if there are comments or ko blocks at the beginning of template