### PR TITLE
fix ko.contextFor after applyBindingAccessorsToNode, etc.

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -291,6 +291,23 @@ describe('Binding attribute syntax', function() {
         expect(ko.contextFor(testNode.childNodes[0].childNodes[1].childNodes[0])).toBeUndefined();
     });
 
+    it('Should return the context object for nodes specifically bound, but override with general binding', function() {
+        // See https://github.com/knockout/knockout/issues/231#issuecomment-388210267
+        testNode.innerHTML = '<div data-bind="text: name"></div>';
+
+        var vm1 = { name: "specific" };
+        ko.applyBindingsToNode(testNode.childNodes[0], { text: vm1.name }, vm1);
+        expect(testNode).toContainText(vm1.name);
+        expect(ko.dataFor(testNode.childNodes[0])).toBe(vm1);
+        expect(ko.contextFor(testNode.childNodes[0]).$data).toBe(vm1);
+
+        var vm2 = { name: "general" };
+        ko.applyBindings(vm2, testNode);
+        expect(testNode).toContainText(vm2.name);
+        expect(ko.dataFor(testNode.childNodes[0])).toBe(vm2);
+        expect(ko.contextFor(testNode.childNodes[0]).$data).toBe(vm2);
+    });
+
     it('Should not be allowed to use containerless binding syntax for bindings other than whitelisted ones', function() {
         testNode.innerHTML = "Hello <!-- ko visible: false -->Some text<!-- /ko --> Goodbye";
         expect(function () {

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -373,13 +373,17 @@
     }
 
     function applyBindingsToNodeInternal(node, sourceBindings, bindingContext) {
+        var bindingInfo = ko.utils.domData.getOrSet(node, boundElementDomDataKey, {});
+
         // Prevent multiple applyBindings calls for the same node, except when a binding value is specified
+        var alreadyBound = bindingInfo.alreadyBound;
         if (!sourceBindings) {
-            var bindingInfo = ko.utils.domData.getOrSet(node, boundElementDomDataKey, {});
-            if (bindingInfo.context) {
+            if (alreadyBound) {
                 throw Error("You cannot apply bindings multiple times to the same element.");
             }
-
+            bindingInfo.alreadyBound = true;
+        }
+        if (!alreadyBound) {
             bindingInfo.context = bindingContext;
         }
 

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -309,12 +309,10 @@
                 nextInQueue = ko.virtualElements.firstChild(elementOrVirtualElement);
             }
 
-            var bindingApplied = false;
             while (currentChild = nextInQueue) {
                 // Keep a record of the next child *before* applying bindings, in case the binding removes the current child from its position
                 nextInQueue = ko.virtualElements.nextSibling(currentChild);
                 applyBindingsToNodeAndDescendantsInternal(bindingContext, currentChild);
-                bindingApplied = true;
             }
         }
         ko.bindingEvent.notify(elementOrVirtualElement, ko.bindingEvent.childrenComplete);


### PR DESCRIPTION
Make sure you can access a node's context and data when a node has bindings only from `ko.applyBindingsToNode` or `ko.applyBindingAccessorsToNode`. Related: #2148.

From https://github.com/knockout/knockout/issues/231#issuecomment-388210267:

> One bad issue I'm dealing with right now is contextFor() and dataFor() not working on a dynamically added element (that then had bindings applied via applyBindingAccessorsToNode). Both return undefined. If I call either on the parentElement, they return the data or context as expected.