### PR TITLE
Typings: First argument to equalityComparer for computeds may be undefined

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -136,7 +136,9 @@ export type ComputedWriteFunction<T = any, TTarget = void> = (this: TTarget, val
 export type MaybeComputed<T = any> = T | Computed<T>;
 
 export interface ComputedFunctions<T = any> extends Subscribable<T> {
-    equalityComparer(a: T, b: T): boolean;
+    // It's possible for a to be undefined, since the equalityComparer is run on the initial
+    // computation with undefined as the first argument. This is user-relevant for deferred computeds.
+    equalityComparer(a: T | undefined, b: T): boolean;
     peek(): T;
     dispose(): void;
     isActive(): boolean;


### PR DESCRIPTION
For ko.computeds, the signature of equalityComparer is currently `equalityComparer(a: T, b: T)`, but a more accurate signature is `equalityComparer(a: T | undefined, b: T)`, since the equality comparer is run with the initial computation of a computed, with `undefined` as the first argument.  For example:

```
const o = ko.observable(4);
const c = ko.pureComputed(() => o());
c.equalityComparer = (a, b) => {
     console.log(`Comparing ${a} to ${b}`);
     return true;
};
c(); // Wake up the computed
// Prints "Comparing undefined to 4"
```

---

I'm actually not sure this behavior is desired; ideally, I think that the `equalityComparer` probably shouldn't run on the initial computation for a computed... but that's a much harder change and I'm not sure what the implications of that change would be.