### PR TITLE
Fix descendantComplete for if, ifnot, with

### DIFF
--- a/spec/defaultBindings/ifnotBehaviors.js
+++ b/spec/defaultBindings/ifnotBehaviors.js
@@ -65,19 +65,164 @@ describe('Binding: Ifnot', function() {
 
     it('Should call a childrenComplete callback function', function () {
         testNode.innerHTML = "<div data-bind='ifnot: condition, childrenComplete: callback'><span data-bind='text: someText'></span></div>";
-        var someItem = ko.observable({ childprop: 'child' }),
-            callbacks = 0;
+        var callbacks = 0;
         var viewModel = { condition: ko.observable(false), someText: "hello", callback: function () { callbacks++; } };
         ko.applyBindings(viewModel, testNode);
         expect(callbacks).toEqual(1);
-        expect(testNode.childNodes[0]).toContainText('hello');
+        expect(testNode).toContainText('hello');
 
         viewModel.condition(true);
         expect(callbacks).toEqual(1);
-        expect(testNode.childNodes[0].childNodes.length).toEqual(0);
+        expect(testNode).toContainText('');
 
         viewModel.condition(false);
         expect(callbacks).toEqual(2);
-        expect(testNode.childNodes[0]).toContainText('hello');
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should call a descendantsComplete callback function', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: condition, descendantsComplete: callback'><span data-bind='text: someText'></span></div>";
+        var callbacks = 0;
+        var viewModel = { condition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        viewModel.condition(false);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should call a descendantsComplete callback function each time the binding switches between false and true', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: condition, descendantsComplete: callback'><span data-bind='text: someText'></span></div>";
+        var callbacks = 0;
+        var viewModel = { condition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        viewModel.condition(false);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('hello');
+
+        viewModel.condition(true);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('');
+
+        viewModel.condition(false);
+        expect(callbacks).toEqual(2);
+        expect(testNode).toContainText('hello');
+
+        // Should not call if value remains falsy (no re-render)
+        viewModel.condition('');
+        expect(callbacks).toEqual(2);
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should call a descendantsComplete callback function after nested \"ifno\" binding with completeOn: \"render\" is complete', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: outerCondition, descendantsComplete: callback'><div data-bind='ifnot: innerCondition, completeOn: \"render\"'><span data-bind='text: someText'></span></div></div>";
+        var callbacks = 0;
+        var viewModel = { outerCondition: ko.observable(true), innerCondition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        // Complete the outer condition first and then the inner one
+        viewModel.outerCondition(false);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        viewModel.innerCondition(false);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should call a descendantsComplete callback function after nested \"ifnot\" binding with completeOn: \"render\" is complete using a containerless template', function () {
+        testNode.innerHTML = "xx<!-- ko ifnot: outerCondition, descendantsComplete: callback --><!-- ko ifnot: innerCondition, completeOn: \"render\" --><span data-bind='text: someText'></span><!--/ko--><!--/ko-->";
+        var callbacks = 0;
+        var viewModel = { outerCondition: ko.observable(true), innerCondition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('xx');
+
+        // Complete the outer condition first and then the inner one
+        viewModel.outerCondition(false);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('xx');
+
+        viewModel.innerCondition(false);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('xxhello');
+    });
+
+    it('Should call a descendantsComplete callback function when nested \"ifnot\" binding with completeOn: \"render\" is complete', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: outerCondition, descendantsComplete: callback'><div data-bind='ifnot: innerCondition, completeOn: \"render\"'><span data-bind='text: someText'></span></div></div>";
+        var callbacks = 0;
+        var viewModel = { outerCondition: ko.observable(true), innerCondition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        // Complete the inner condition first and then the outer one (reverse order from previous test)
+        viewModel.innerCondition(false);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        viewModel.outerCondition(false);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should not delay descendantsComplete callback if nested \"ifnot\" binding also has descendantsComplete', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: outerCondition, descendantsComplete: outerCallback'><div data-bind='ifnot: innerCondition, descendantsComplete: innerCallback'><span data-bind='text: someText'></span></div></div>";
+        var outerCallbacks = 0, innerCallbacks = 0;
+        var viewModel = {
+            outerCondition: ko.observable(true),
+            innerCondition: ko.observable(true),
+            someText: "hello",
+            outerCallback: function () { outerCallbacks++; },
+            innerCallback: function () { innerCallbacks++; }
+        };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(outerCallbacks).toEqual(0);
+        expect(innerCallbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        // Callback is called when content is rendered
+        viewModel.outerCondition(false);
+        expect(outerCallbacks).toEqual(1);
+        expect(innerCallbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        // Rendering inner content doesn't affect outer callback
+        viewModel.innerCondition(false);
+        expect(outerCallbacks).toEqual(1);
+        expect(innerCallbacks).toEqual(1);
+        expect(testNode).toContainText('hello');
+    });
+
+    it('Should call a descendantsComplete callback function if nested \"ifnot\" binding with completeOn: \"render\" is disposed before completion', function () {
+        testNode.innerHTML = "<div data-bind='ifnot: outerCondition, descendantsComplete: callback'><div data-bind='ifnot: innerCondition, completeOn: \"render\"'><span data-bind='text: someText'></span></div></div>";
+        var callbacks = 0;
+        var viewModel = { outerCondition: ko.observable(true), innerCondition: ko.observable(true), someText: "hello", callback: function () { callbacks++; } };
+
+        ko.applyBindings(viewModel, testNode);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        // Complete the outer condition and then dispose the inner one
+        viewModel.outerCondition(false);
+        expect(callbacks).toEqual(0);
+        expect(testNode).toContainText('');
+
+        ko.cleanNode(testNode.childNodes[0].childNodes[0]);
+        expect(callbacks).toEqual(1);
+        expect(testNode).toContainText('');
     });
 });

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -158,7 +158,7 @@
         var bindingInfo = ko.utils.domData.get(node, boundElementDomDataKey),
             asyncContext = bindingInfo && bindingInfo.asyncContext;
         if (asyncContext) {
-            bindingInfo.asyncContext = undefined;
+            bindingInfo.asyncContext = null;
             asyncContext.notifyAncestor();
         }
     }
@@ -191,7 +191,7 @@
     AsyncCompleteContext.prototype.completeChildren = function () {
         this.childrenComplete = true;
         if (this.bindingInfo.asyncContext && !this.asyncDescendants.length) {
-            this.bindingInfo.asyncContext = undefined;
+            this.bindingInfo.asyncContext = null;
             ko.utils.domNodeDisposal.removeDisposeCallback(this.node, asyncContextDispose);
             ko.bindingEvent.notify(this.node, ko.bindingEvent.descendantsComplete);
             this.notifyAncestor();
@@ -219,7 +219,9 @@
                 if (event == ko.bindingEvent.childrenComplete) {
                     if (bindingInfo.asyncContext) {
                         bindingInfo.asyncContext.completeChildren();
-                    } else if (bindingInfo.eventSubscribable && bindingInfo.eventSubscribable.hasSubscriptionsForEvent(ko.bindingEvent.descendantsComplete)) {
+                    } else if (bindingInfo.asyncContext === undefined && bindingInfo.eventSubscribable && bindingInfo.eventSubscribable.hasSubscriptionsForEvent(ko.bindingEvent.descendantsComplete)) {
+                        // It's currently an error to register a descendantsComplete handler for a node that was never registered as completing asynchronously.
+                        // That's because without the asyncContext, we don't have a way to know that all descendants have completed.
                         throw new Error("descendantsComplete event not supported for bindings on this node");
                     }
                 }


### PR DESCRIPTION
See knockout/tko#65 and #2342

Add `completeOn: "render"` binding option for `if`, `ifnot`, and `with` that makes them treat their un-rendered state as incomplete, instead of using the existence of a `descendantsComplete` callback for this. Also make sure the event works for multiple renders.