### PR TITLE
Forcing use of setProperty for CSS variables

### DIFF
--- a/spec/defaultBindings/styleBehaviors.js
+++ b/spec/defaultBindings/styleBehaviors.js
@@ -52,6 +52,20 @@ describe('Binding: CSS style', function() {
         expect(testNode.childNodes[0].style.width).toBe("");
     });
 
+    xit('Should be able to assign values to custom CSS properties', function() {
+        var customWidth = ko.observable();
+        testNode.innerHTML = "<div style=\"width: var(--custom-width)\" data-bind=\"style: {'--custom-width': customWidth}\"></div>";
+
+        ko.applyBindings({customWidth: customWidth}, testNode);
+        expect(testNode.childNodes[0].style.getPropertyValue("--custom-width")).toBe("");
+
+        customWidth("100px");
+        expect(testNode.childNodes[0].style.getPropertyValue("--custom-width")).toBe("100px");
+
+        customWidth(false);
+        expect(testNode.childNodes[0].style.getPropertyValue("--custom-width")).toBe("");
+    });
+
     it('Should properly respond to changes in the observable, adding px when appropriate', function() {
         var width = ko.observable();
         testNode.innerHTML = "<div data-bind='style: { width: width }'></div>";

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -12,15 +12,30 @@ ko.bindingHandlers['style'] = {
             if (jQueryInstance) {
                 jQueryInstance(element)['css'](styleName, styleValue);
             } else {
-                styleName = styleName.replace(/-(\w)/g, function (all, letter) {
-                    return letter.toUpperCase();
-                });
+                var previousStyle;
+                var postStyle;
+                var requiresGetPropertyValue = (styleName.substring(0, 2) === "--");
 
-                var previousStyle = element.style[styleName];
-                element.style[styleName] = styleValue;
+                if(requiresGetPropertyValue){
+                    previousStyle = element.style.getPropertyValue(styleName);
+                    element.style.setProperty(styleName, styleValue);
+                    postStyle = element.style.getPropertyValue(styleName);
 
-                if (styleValue !== previousStyle && element.style[styleName] == previousStyle && !isNaN(styleValue)) {
-                    element.style[styleName] = styleValue + "px";
+                    if (styleValue !== previousStyle && postStyle == previousStyle && !isNaN(styleValue)) {
+                        element.style.setProperty(styleName, styleValue + "px");
+                    }
+                } else {
+                    styleName = styleName.replace(/-(\w)/g, function (all, letter) {
+                        return letter.toUpperCase();
+                    });
+
+                    previousStyle = element.style[styleName];
+                    element.style[styleName] = styleValue;
+                    postStyle = element.style[styleName];
+
+                    if (styleValue !== previousStyle && postStyle == previousStyle && !isNaN(styleValue)) {
+                        element.style[styleName] = styleValue + "px";
+                    }
                 }
             }
         });

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -12,30 +12,21 @@ ko.bindingHandlers['style'] = {
             if (jQueryInstance) {
                 jQueryInstance(element)['css'](styleName, styleValue);
             } else {
-                var previousStyle;
-                var postStyle;
-                var requiresGetPropertyValue = (styleName.substring(0, 2) === "--");
-
-                if(requiresGetPropertyValue){
-                    previousStyle = element.style.getPropertyValue(styleName);
+                // Is styleName a custom CSS property?
+                if(styleName.substring(0, 2) === "--"){
                     element.style.setProperty(styleName, styleValue);
-                    postStyle = element.style.getPropertyValue(styleName);
+                    return;
+                }
 
-                    if (styleValue !== previousStyle && postStyle == previousStyle && !isNaN(styleValue)) {
-                        element.style.setProperty(styleName, styleValue + "px");
-                    }
-                } else {
-                    styleName = styleName.replace(/-(\w)/g, function (all, letter) {
-                        return letter.toUpperCase();
-                    });
+                styleName = styleName.replace(/-(\w)/g, function (all, letter) {
+                    return letter.toUpperCase();
+                });
 
-                    previousStyle = element.style[styleName];
-                    element.style[styleName] = styleValue;
-                    postStyle = element.style[styleName];
+                var previousStyle = element.style[styleName];
+                element.style[styleName] = styleValue;
 
-                    if (styleValue !== previousStyle && postStyle == previousStyle && !isNaN(styleValue)) {
-                        element.style[styleName] = styleValue + "px";
-                    }
+                if (styleValue !== previousStyle && element.style[styleName] == previousStyle && !isNaN(styleValue)) {
+                    element.style[styleName] = styleValue + "px";
                 }
             }
         });

--- a/src/binding/defaultBindings/style.js
+++ b/src/binding/defaultBindings/style.js
@@ -11,13 +11,10 @@ ko.bindingHandlers['style'] = {
 
             if (jQueryInstance) {
                 jQueryInstance(element)['css'](styleName, styleValue);
-            } else {
+            } else if (/^--/.test(styleName)) {
                 // Is styleName a custom CSS property?
-                if(styleName.substring(0, 2) === "--"){
-                    element.style.setProperty(styleName, styleValue);
-                    return;
-                }
-
+                element.style.setProperty(styleName, styleValue);
+            } else {
                 styleName = styleName.replace(/-(\w)/g, function (all, letter) {
                     return letter.toUpperCase();
                 });


### PR DESCRIPTION
I made a really narrow commit to address #2400.  It seems as though Custom CSS properties can only be set through [`CSSStyleDeclaration#setProperty`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty).

I'm not sure why you use the Array syntax for all properties instead of having everything go through `setProperty`, but I wanted to err on the side of caution and only use it when we are using CSS variables.  If you'd prefer this commit to be broader or if you would like some sort of coding style change, let me know.