### PR TITLE
Revert 3.5.0-rc changes to `foreach`

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -184,7 +184,7 @@ export interface ComputedContext {
     getDependenciesCount(): number;
     getDependencies(): Subscribable[];
     isInitial(): boolean;
-    registerDependency(subscribable: Subscribable): void; 
+    registerDependency(subscribable: Subscribable): void;
 }
 
 export const computedContext: ComputedContext;
@@ -285,6 +285,14 @@ export interface BindingContext<T = any> {
 
     createChildContext<X>(dataItem: T | Observable<T>, dataItemAlias?: string, extendCallback?: BindingContextExtendCallback<X>): BindingContext<X>;
     createChildContext<X>(accessor: () => T | Observable<T>, dataItemAlias?: string, extendCallback?: BindingContextExtendCallback<X>): BindingContext<X>;
+    createChildContext<X>(dataItem: T | Observable<T>, options: BindingChildContextOptions<X>): BindingContext<X>;
+    createChildContext<X>(accessor: () => T | Observable<T>, options: BindingChildContextOptions<X>): BindingContext<X>;
+}
+
+export interface BindingChildContextOptions<T = any> {
+    as?: string;
+    extend?: BindingContextExtendCallback<T>;
+    noChildContext?: boolean;
 }
 
 export function applyBindings<T = any>(bindingContext: T | BindingContext<T>): void;

--- a/spec/defaultBindings/foreachBehaviors.js
+++ b/spec/defaultBindings/foreachBehaviors.js
@@ -734,14 +734,14 @@ describe('Binding: Foreach', function() {
         });
     }
 
-    describe('With "createChildContextWithAs = false" and "as"', function () {
+    describe('With "noChildContext = true" and "as"', function () {
         beforeEach(function() {
             this.restoreAfter(ko.options, 'createChildContextWithAs');
             ko.options.createChildContextWithAs = false;
         });
 
         it('Should not create a child context', function () {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: true }'><span data-bind='text: item'></span></div>";
             var someItems = ['alpha', 'beta'];
             ko.applyBindings({ someItems: someItems }, testNode);
 
@@ -753,7 +753,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should provide access to observable items', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><input data-bind='value: item'/></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: true }'><input data-bind='value: item'/></div>";
             var x = ko.observable('first'), y = ko.observable('second'), someItems = ko.observableArray([ x, y ]);
             ko.applyBindings({ someItems: someItems }, testNode);
             expect(testNode.childNodes[0]).toHaveValues(['first', 'second']);
@@ -776,7 +776,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should not re-render the nodes when an observable item changes', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: true }'><span data-bind='text: item'></span></div>";
             var x = ko.observable('first'), someItems = [ x ];
             ko.applyBindings({ someItems: someItems }, testNode);
             expect(testNode.childNodes[0]).toContainText('first');
@@ -788,7 +788,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should call an afterRender callback function with the array item', function () {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", afterRender: callback }'>[<span data-bind='text: item'></span>]</div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: true, afterRender: callback }'>[<span data-bind='text: item'></span>]</div>";
             var someItems = ko.observableArray(['Alpha', 'Beta']),
                 callbackReceivedArrayValues = [];
             ko.applyBindings({
@@ -803,8 +803,8 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should provide itemIndex observable in the context accessible across multiple nested levels', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'>"
-                               +    "<span data-bind='foreach: { data: item.sub, as: \"subvalue\" }'>"
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: true }'>"
+                               +    "<span data-bind='foreach: { data: item.sub, as: \"subvalue\", noChildContext: true }'>"
                                +        "<span data-bind='text: itemIndex()+item.name+\":\"+subvalueIndex()+subvalue'></span>,"
                                +    "</span>"
                                + "</div>";
@@ -814,14 +814,9 @@ describe('Binding: Foreach', function() {
         });
     });
 
-    describe('With "createChildContextWithAs = true" and "as"', function () {
-        beforeEach(function() {
-            this.restoreAfter(ko.options, 'createChildContextWithAs');
-            ko.options.createChildContextWithAs = true;
-        });
-
+    describe('With "noChildContext = false" and "as"', function () {
         it('Should create a child context', function () {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: false }'><span data-bind='text: item'></span></div>";
             var someItems = ['alpha', 'beta'];
             ko.applyBindings({ someItems: someItems }, testNode);
 
@@ -833,7 +828,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should unwrap observable items', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><input data-bind='value: item'/><input data-bind='value: $rawData'/></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: false }'><input data-bind='value: item'/><input data-bind='value: $rawData'/></div>";
             var x = ko.observable('first'), y = ko.observable('second'), someItems = ko.observableArray([ x, y ]);
             ko.applyBindings({ someItems: someItems }, testNode);
             expect(testNode.childNodes[0]).toHaveValues(['first', 'first', 'second', 'second']);
@@ -858,7 +853,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should not re-render the nodes when an observable item changes', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: false }'><span data-bind='text: item'></span></div>";
             var x = ko.observable('first'), someItems = [ x ];
             ko.applyBindings({ someItems: someItems }, testNode);
             expect(testNode.childNodes[0]).toContainText('first');
@@ -870,7 +865,7 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should call an afterRender callback function with the array item', function () {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", afterRender: callback }'>[<span data-bind='text: item'></span>]</div>";
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: false, afterRender: callback }'>[<span data-bind='text: item'></span>]</div>";
             var someItems = ko.observableArray(['Alpha', 'Beta']),
                 callbackReceivedArrayValues = [];
             ko.applyBindings({
@@ -885,8 +880,8 @@ describe('Binding: Foreach', function() {
         });
 
         it('Should provide itemIndex observable in the context accessible across multiple nested levels', function() {
-            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\" }'>"
-                               +    "<span data-bind='foreach: { data: item.sub, as: \"subvalue\" }'>"
+            testNode.innerHTML = "<div data-bind='foreach: { data: someItems, as: \"item\", noChildContext: false }'>"
+                               +    "<span data-bind='foreach: { data: item.sub, as: \"subvalue\", noChildContext: false }'>"
                                +        "<span data-bind='text: itemIndex()+item.name+\":\"+subvalueIndex()+subvalue'></span>,"
                                +    "</span>"
                                + "</div>";

--- a/spec/defaultBindings/withBehaviors.js
+++ b/spec/defaultBindings/withBehaviors.js
@@ -134,10 +134,7 @@ describe('Binding: With', function() {
         expect(ko.contextFor(firstSpan).$parents[1].name).toEqual("top");
     });
 
-    it('Should be able to access all parent bindings when using "as" when "createChildContextWithAs" is set', function() {
-        this.restoreAfter(ko.options, 'createChildContextWithAs');
-        ko.options.createChildContextWithAs = true;
-
+    it('Should be able to access all parent bindings when using "as"', function() {
         testNode.innerHTML = "<div data-bind='with: topItem'>" +
                                 "<div data-bind='with: middleItem, as: \"middle\"'>" +
                                     "<div data-bind='with: bottomItem'>" +
@@ -431,14 +428,9 @@ describe('Binding: With', function() {
         expect(testNode).toContainText('');
     });
 
-    describe('With "createChildContextWithAs = false" and "as"', function () {
-        beforeEach(function() {
-            this.restoreAfter(ko.options, 'createChildContextWithAs');
-            ko.options.createChildContextWithAs = false;
-        });
-
+    describe('With "noChildContext = true" and "as"', function () {
         it('Should not create a child context', function () {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item.childProp'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: true'><span data-bind='text: item.childProp'></span></div>";
             var someItem = { childProp: 'Hello' };
             ko.applyBindings({ someItem: someItem }, testNode);
 
@@ -447,7 +439,7 @@ describe('Binding: With', function() {
         });
 
         it('Should provide access to observable value', function() {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><input data-bind='value: item'/></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: true'><input data-bind='value: item'/></div>";
             var someItem = ko.observable('Hello');
             ko.applyBindings({ someItem: someItem }, testNode);
             expect(testNode.childNodes[0].childNodes[0].value).toEqual('Hello');
@@ -465,7 +457,7 @@ describe('Binding: With', function() {
         });
 
         it('Should not re-render the nodes when an observable value changes', function() {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: true'><span data-bind='text: item'></span></div>";
             var someItem = ko.observable('first');
             ko.applyBindings({ someItem: someItem }, testNode);
             expect(testNode.childNodes[0]).toContainText('first');
@@ -478,7 +470,7 @@ describe('Binding: With', function() {
 
         it('Should remove nodes when an observable value become falsy', function() {
             var someItem = ko.observable(undefined);
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item().occasionallyExistentChildProp'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: true'><span data-bind='text: item().occasionallyExistentChildProp'></span></div>";
             ko.applyBindings({ someItem: someItem }, testNode);
 
             // First it's not there
@@ -495,14 +487,9 @@ describe('Binding: With', function() {
         });
     });
 
-    describe('With "createChildContextWithAs = true" and "as"', function () {
-        beforeEach(function() {
-            this.restoreAfter(ko.options, 'createChildContextWithAs');
-            ko.options.createChildContextWithAs = true;
-        });
-
+    describe('With "noChildContext = false" and "as"', function () {
         it('Should create a child context', function () {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item.childProp'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: false'><span data-bind='text: item.childProp'></span></div>";
             var someItem = { childProp: 'Hello' };
             ko.applyBindings({ someItem: someItem }, testNode);
 
@@ -511,7 +498,7 @@ describe('Binding: With', function() {
         });
 
         it('Should unwrap observable value', function() {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><input data-bind='value: item'/><input data-bind='value: $rawData'/></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: false'><input data-bind='value: item'/><input data-bind='value: $rawData'/></div>";
             var someItem = ko.observable('Hello');
             ko.applyBindings({ someItem: someItem }, testNode);
             expect(testNode.childNodes[0]).toHaveValues(['Hello', 'Hello']);
@@ -532,7 +519,7 @@ describe('Binding: With', function() {
         });
 
         it('Should re-render the nodes when an observable value changes', function() {
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: false'><span data-bind='text: item'></span></div>";
             var someItem = ko.observable('first');
             ko.applyBindings({ someItem: someItem }, testNode);
             expect(testNode.childNodes[0]).toContainText('first');
@@ -545,7 +532,7 @@ describe('Binding: With', function() {
 
         it('Should remove nodes when an observable value become falsy', function() {
             var someItem = ko.observable(undefined);
-            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\"'><span data-bind='text: item.occasionallyExistentChildProp'></span></div>";
+            testNode.innerHTML = "<div data-bind='with: someItem, as: \"item\", noChildContext: false'><span data-bind='text: item.occasionallyExistentChildProp'></span></div>";
             ko.applyBindings({ someItem: someItem }, testNode);
 
             // First it's not there

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -117,13 +117,19 @@
     // view model also depends on the parent view model, you must provide a function that returns the correct
     // view model on each update.
     ko.bindingContext.prototype['createChildContext'] = function (dataItemOrAccessor, dataItemAlias, extendCallback, options) {
-        if (dataItemAlias && !ko.options['createChildContextWithAs']) {
+        if (!options && dataItemAlias && typeof dataItemAlias == "object") {
+            options = dataItemAlias;
+            dataItemAlias = options['as'];
+            extendCallback = options['extend'];
+        }
+
+        if (dataItemAlias && options && options['noChildContext']) {
             var isFunc = typeof(dataItemOrAccessor) == "function" && !ko.isObservable(dataItemOrAccessor);
             return new ko.bindingContext(inheritParentVm, this, null, function (self) {
                 if (extendCallback)
                     extendCallback(self);
                 self[dataItemAlias] = isFunc ? dataItemOrAccessor() : dataItemOrAccessor;
-            });
+            }, options);
         }
 
         return new ko.bindingContext(dataItemOrAccessor, this, dataItemAlias, function (self, parentContext) {
@@ -146,10 +152,6 @@
         return new ko.bindingContext(inheritParentVm, this, null, function(self, parentContext) {
             ko.utils.extend(self, typeof(properties) == "function" ? properties(self) : properties);
         });
-    };
-
-    ko.bindingContext.prototype.createStaticChildContext = function (dataItemOrAccessor, dataItemAlias) {
-        return this['createChildContext'](dataItemOrAccessor, dataItemAlias, null, { "exportDependencies": true });
     };
 
     var boundElementDomDataKey = ko.utils.domData.nextKey();

--- a/src/binding/defaultBindings/foreach.js
+++ b/src/binding/defaultBindings/foreach.js
@@ -17,6 +17,7 @@ ko.bindingHandlers['foreach'] = {
             return {
                 'foreach': unwrappedValue['data'],
                 'as': unwrappedValue['as'],
+                'noChildContext': unwrappedValue['noChildContext'],
                 'includeDestroyed': unwrappedValue['includeDestroyed'],
                 'afterAdd': unwrappedValue['afterAdd'],
                 'beforeRemove': unwrappedValue['beforeRemove'],

--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -4,13 +4,12 @@
 function makeWithIfBinding(bindingKey, isWith, isNot) {
     ko.bindingHandlers[bindingKey] = {
         'init': function(element, valueAccessor, allBindings, viewModel, bindingContext) {
-            var savedNodes, asOption, wrapCondition, ifCondition, completeOnRender, needAsyncContext;
+            var savedNodes, wrapCondition = true, withOptions, ifCondition, completeOnRender, needAsyncContext;
 
             if (isWith) {
-                asOption = allBindings.get('as');
-                wrapCondition = asOption && !ko.options['createChildContextWithAs'];
-            } else {
-                wrapCondition = true;
+                var as = allBindings.get('as'), noChildContext = allBindings.get('noChildContext');
+                wrapCondition = as && noChildContext;
+                withOptions = { 'as': as, 'noChildContext': noChildContext };
             }
 
             if (wrapCondition) {
@@ -43,7 +42,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot) {
 
                     var childContext;
                     if (isWith) {
-                        childContext = bindingContext['createChildContext'](typeof value == "function" ? value : valueAccessor, asOption);
+                        childContext = bindingContext['createChildContext'](typeof value == "function" ? value : valueAccessor, withOptions);
                     } else if (ifCondition.isActive()) {
                         childContext = bindingContext['extend'](function() { ifCondition(); return null; });
                     } else {

--- a/src/components/componentBinding.js
+++ b/src/components/componentBinding.js
@@ -63,9 +63,11 @@
                     };
 
                     var componentViewModel = createViewModel(componentDefinition, componentParams, componentInfo),
-                        childBindingContext = asyncContext['createChildContext'](componentViewModel, /* dataItemAlias */ undefined, function(ctx) {
-                            ctx['$component'] = componentViewModel;
-                            ctx['$componentTemplateNodes'] = originalChildNodes;
+                        childBindingContext = asyncContext['createChildContext'](componentViewModel, {
+                            'extend': function(ctx) {
+                                ctx['$component'] = componentViewModel;
+                                ctx['$componentTemplateNodes'] = originalChildNodes;
+                            }
                         });
 
                     if (componentViewModel && componentViewModel['koDescendantsComplete']) {

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,6 @@
 ko.options = {
     'deferUpdates': false,
     'useOnlyNativeEvents': false,
-    'createChildContextWithAs': false,
     'foreachHidesDestroyed': false
 };
 


### PR DESCRIPTION
 Remove global `createChildContextWithAs` option and add local `noChildContext` option to `with`, `foreach`, and `template`. Fixes #2386