### PR TITLE
Removing the observable unwrapping in ko.toJS function

### DIFF
--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -10,7 +10,7 @@
         return mapJsObjectGraph(rootObject, function(valueToMap) {
             // Loop because an observable's value might in turn be another observable wrapper
             for (var i = 0; ko.isObservable(valueToMap) && (i < maxNestedObservableDepth); i++)
-                valueToMap = valueToMap();
+                valueToMap = valueToMap.peek();
             return valueToMap;
         });
     };


### PR DESCRIPTION
The utility function ko.toJSON unwraps each observable in order to get their value. If an observable is unwrapped elsewhere in other computeds, they will be re-evaluated after calling ko.toJSON. 
 
This behavior is causing us issues and in order to prevent this, mapJsObjectGraph should peek the value of the observable which removes that dependency.

Moreover, we thought of overriding the current mapJsObjectGraph callback but it is not possible while everything is private except ko.toJS and ko.toJSON