### PR TITLE
Changed condition for displaying a content in the with binding

### DIFF
--- a/src/binding/defaultBindings/ifIfnotWith.js
+++ b/src/binding/defaultBindings/ifIfnotWith.js
@@ -23,7 +23,7 @@ function makeWithIfBinding(bindingKey, isWith, isNot) {
 
             ko.computed(function() {
                 var value = wrapCondition ? ifCondition() : ko.utils.unwrapObservable(valueAccessor()),
-                    shouldDisplay = !!value,
+                    shouldDisplay = isWith ? value != null : !!value,
                     isFirstRender = !savedNodes;
 
                 // Save a copy of the inner nodes on the initial update, but only if we have dependencies.


### PR DESCRIPTION
According to the docs:
* The `with` binding will dynamically add or remove descendant elements depending on whether the associated value is **null/undefined** or not
* The `if` binding causes a section of markup to appear in your document, only if a specified expression evaluates to **true** (or a **true-ish** value such as a non-null object or nonempty string).