### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT) - http://www.opensource.org/licenses/mit-license.php
 
-Copyright (c) Steven Sanderson, the Knockout.js team, and other contributors
+Copyright (c) 2010 Steven Sanderson, the Knockout.js team, and other contributors
 http://knockoutjs.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
MIT license needs both of year and copyright holder.
Please complete MIT license. We want to use this without legal risk.