### PR TITLE
Types: handle the empty observable case safely

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -60,9 +60,10 @@ export interface Observable<T = any> extends ObservableFunctions<T> {
     (): T;
     (value: T): any;
 }
-
-export function observable<T = any>(): Observable<T>;
-export function observable<T = any>(initialValue: T): Observable<T>;
+export function observable<T>(value: T): Observable<T>;
+export function observable<T = any>(value: null): Observable<T | null>
+/** No initial value provided, so implicitly includes `undefined` as a possible value */
+export function observable<T = any>(): Observable<T | undefined>
 export module observable {
     export const fn: ObservableFunctions;
 }

--- a/spec/types/global/test-global.ts
+++ b/spec/types/global/test-global.ts
@@ -391,6 +391,7 @@ function test_more() {
     const upperCaseName = ko.computed(() => name.toUpperCase()).extend({ throttle: 500 });
 
     class AppViewModel3 {
+        // Observable<string | undefined> since there's no initial value
         public instantaneousValue = ko.observable<string>();
         public throttledValue = ko.computed(this.instantaneousValue)
             .extend({ throttle: 400 });
@@ -399,7 +400,7 @@ function test_more() {
 
         public throttledValueLogger = ko.computed(() => {
             const val = this.instantaneousValue();
-            if (val !== '')
+            if (val && val !== '')
                 this.loggedValues.push(val);
         });
     }
@@ -574,12 +575,12 @@ function test_customObservable() {
         // Set up the attribute observable cache
         model._koObservables || (model._koObservables = {});
 
-        // If we already have a cached observable then just return it		
+        // If we already have a cached observable then just return it
         if (attribute in model._koObservables) {
             return model._koObservables[attribute];
         }
 
-        // Create our observable getter/setter function	
+        // Create our observable getter/setter function
         var observableAttribute = <ko.Observable>(function (this: any): any {
             if (arguments.length > 0) {
                 observableAttribute.valueWillMutate();
@@ -667,7 +668,7 @@ function test_Components() {
         // viewModel from createViewModel factory method
         ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
 
-        // viewModel from an AMD module 
+        // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
 
         // ------- template overloads
@@ -680,7 +681,7 @@ function test_Components() {
         // template using Node array
         ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
 
-        // template using an AMD module 
+        // template using an AMD module
         ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
 
         // Empty config for registering custom elements that are handled by name convention
@@ -739,7 +740,7 @@ class DummyTemplateEngine extends ko.templateEngine {
             return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
         }
         else if ((template.nodeType == 1) || (template.nodeType == 8)) {
-            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous
         }
         else {
             throw new Error("Unrecognized template source");

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -402,6 +402,7 @@ function test_more() {
     const upperCaseName = ko.computed(() => name.toUpperCase()).extend({ throttle: 500 });
 
     class AppViewModel3 {
+        // Observable<string | undefined> since there's no initial value
         public instantaneousValue = ko.observable<string>();
         public throttledValue = ko.computed(this.instantaneousValue)
             .extend({ throttle: 400 });
@@ -410,7 +411,7 @@ function test_more() {
 
         public throttledValueLogger = ko.computed(() => {
             const val = this.instantaneousValue();
-            if (val !== '')
+            if (val && val !== '')
                 this.loggedValues.push(val);
         });
     }
@@ -597,12 +598,12 @@ function test_customObservable() {
         // Set up the attribute observable cache
         model._koObservables || (model._koObservables = {});
 
-        // If we already have a cached observable then just return it		
+        // If we already have a cached observable then just return it
         if (attribute in model._koObservables) {
             return model._koObservables[attribute];
         }
 
-        // Create our observable getter/setter function	
+        // Create our observable getter/setter function
         var observableAttribute = <ko.Observable>(function (this: any): any {
             if (arguments.length > 0) {
                 observableAttribute.valueWillMutate();
@@ -690,7 +691,7 @@ function test_Components() {
         // viewModel from createViewModel factory method
         ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
 
-        // viewModel from an AMD module 
+        // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
 
         // ------- template overloads
@@ -703,7 +704,7 @@ function test_Components() {
         // template using Node array
         ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
 
-        // template using an AMD module 
+        // template using an AMD module
         ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
 
         // Empty config for registering custom elements that are handled by name convention
@@ -769,7 +770,7 @@ class DummyTemplateEngine extends ko.templateEngine {
             return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
         }
         else if ((template.nodeType == 1) || (template.nodeType == 8)) {
-            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous
         }
         else {
             throw new Error("Unrecognized template source");


### PR DESCRIPTION
The current typings for observable allow for type unsafe behavior when an observable is initialized.  For example:

```ts
const obs = ko.observable<string>();  // Observable<string>
console.log(obs().toUpperCase()); // Compiles, but runtime error
```

Providing a type param to a method shouldn't be a "dangerous" operation: ideally it shouldn't be possible to create runtime errors like this without type assertions (which are "dangerous").

---

There are two ways this could be fixed:

1.  Disallow `ko.observable<string>();` 
2.  Change the return type of `ko.observable<string>()` to be safe.

This PR opts for the second approach, with the same change that I made to the public typings ~9 months ago.  (Main PR here: DefinitelyTyped/DefinitelyTyped#26627 with a small tweak here: DefinitelyTyped/DefinitelyTyped#26854)  

With these changes `ko.observable<string>()` returns `Observable<string | undefined>` which is a more 'honest' type.

The alternative is to disallow `ko.observable<string>()` and require the user to type this function as `ko.observable<string | undefined>()`.  I've noticed that some people find the 'implicit' `| undefined` surprising, but it's pretty convenient.  

This PR's version has the advantage of matching the existing, behavior for the existing public typings - which will help existing TS users migrate to 3.5.

---

In either case, if the user wants to suppress the undefined case - e.g. they know that the observable will be immediately written to, or if they simply prefer to live dangerously - they will need a cast:

```ts
// Option 1
const obs = ko.observable<string>() as Observable<string>; 
// Option 2
// const obs = ko.observable<string | undefined>() as Observable<string>
```

This is good, as the `as` operator is meant to be an indicator of a possible runtime error, due to the user overriding Typescript's default types.