### PR TITLE
Types: Add types for ReadonlyObservable, ReaonlyObservableArray, ReadonlyComputed

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -166,19 +166,26 @@ export type ComputedReadFunction<T = any, TTarget = void> = Subscribable<T> | Ob
 export type ComputedWriteFunction<T = any, TTarget = void> = (this: TTarget, val: T) => void;
 export type MaybeComputed<T = any> = T | Computed<T>;
 
-export interface ComputedFunctions<T = any> extends Subscribable<T> {
+export interface ReadonlyComputedFunctions<T = any> extends Subscribable<T> {
+    dispose(): void;
+}
+export interface ComputedFunctions<T = any> extends ReadonlyComputedFunctions<T> {
     // It's possible for a to be undefined, since the equalityComparer is run on the initial
     // computation with undefined as the first argument. This is user-relevant for deferred computeds.
     equalityComparer(a: T | undefined, b: T): boolean;
     peek(): T;
-    dispose(): void;
     isActive(): boolean;
     getDependenciesCount(): number;
     getDependencies(): Subscribable[];
 }
 
-export interface Computed<T = any> extends ComputedFunctions<T> {
+/**
+ * The part of an computed contract that do not mutate the underlying value - see ReadableObservable type for rationale
+ */
+export interface ReadonlyComputed<T = any> extends ReadonlyComputedFunctions<T> {
     (): T;
+}
+export interface Computed<T = any> extends ComputedFunctions<T>, ReadonlyComputed<T> {
     (value: T): this;
 }
 

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -97,7 +97,10 @@ export function isWritableObservable<T = any>(instance: any): instance is Observ
 
 export type MaybeObservableArray<T = any> = T[] | ObservableArray<T>;
 
-export interface ObservableArrayFunctions<T = any> extends ObservableFunctions<T[]> {
+/**
+ * The part of an observable array contract that do not mutate the underlying value - see ReadableObservable type for rationale
+ */
+export interface ReadonlyObservableArrayFunctions<T = any> extends ReadonlyObservableFunctions<T[]> {
     // General Array functions
     indexOf(searchElement: T, fromIndex?: number): number;
 
@@ -107,6 +110,14 @@ export interface ObservableArrayFunctions<T = any> extends ObservableFunctions<T
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
 
+    // Ko specific
+    reversed(): T[];
+
+    sorted(compareFunction?: (left: T, right: T) => number): T[];
+}
+
+export interface ObservableArrayFunctions<T = any> extends ReadonlyObservableArrayFunctions<T>, ObservableFunctions<T[]> {
+    // General Array functions
     pop(): T;
     push(...items: T[]): number;
 
@@ -118,10 +129,6 @@ export interface ObservableArrayFunctions<T = any> extends ObservableFunctions<T
     sort(compareFunction?: (left: T, right: T) => number): this;
 
     // Ko specific
-    reversed(): T[];
-
-    sorted(compareFunction?: (left: T, right: T) => number): T[];
-
     replace(oldItem: T, newItem: T): void;
 
     remove(item: T): T[];
@@ -137,7 +144,9 @@ export interface ObservableArrayFunctions<T = any> extends ObservableFunctions<T
     destroyAll(items: T[]): void;
 }
 
-export interface ObservableArray<T = any> extends Observable<T[]>, ObservableArrayFunctions<T> {
+export interface ReadonlyObservableArray<T = any> extends ReadonlyObservable<T[]>, ReadonlyObservableArrayFunctions<T> {}
+
+export interface ObservableArray<T = any> extends Observable<T[]>, ReadonlyObservableArray<T>, ObservableArrayFunctions<T> {
     (value: T[] | null | undefined): this;
 }
 

--- a/spec/types/module/test-readonly.ts
+++ b/spec/types/module/test-readonly.ts
@@ -1,4 +1,4 @@
-import { ReadonlyObservable, Observable} from "knockout";
+import { ReadonlyObservable, Observable, ReadonlyComputed} from "knockout";
 import * as ko from "knockout";
 
 function testReadonlyObservable() {
@@ -32,4 +32,16 @@ function testReadonlyObservableArray() {
     // Can cast back to a writeable
     const writeAgain = read as ko.ObservableArray<string>
     writeAgain(["foo"]);
+}
+
+function testReadonlyComputed() {
+    const write = ko.computed({
+        read: () => {},
+        write: () => {},
+    });
+
+    // Can cast a computed as readonly
+    const read: ReadonlyComputed<any> = write;
+    read();
+    // read("foo"); // $ExpectError // no way to test this currently
 }

--- a/spec/types/module/test-readonly.ts
+++ b/spec/types/module/test-readonly.ts
@@ -1,0 +1,16 @@
+import { ReadonlyObservable, Observable} from "knockout";
+import * as ko from "knockout";
+
+function testReadonlyObservable() {
+    const write = ko.observable("foo");
+    write("bar");
+    const read = write as ReadonlyObservable<string>;
+
+    read(); // $ExpectType string
+    read.subscribe(() => {});  // Can still subscribe
+    // But can't write to it
+    // read("foo") // $ExpectError // Don't currently have a good mechanism for testing this outside of DT repo
+
+    const writeAgain = read as Observable<string>
+    writeAgain("bar");
+};

--- a/spec/types/module/test-readonly.ts
+++ b/spec/types/module/test-readonly.ts
@@ -14,3 +14,22 @@ function testReadonlyObservable() {
     const writeAgain = read as Observable<string>
     writeAgain("bar");
 };
+
+function testReadonlyObservableArray() {
+    // Normal observable array behavior
+    const write = ko.observableArray(["foo"]);
+    write(["bar"]);
+    write.push("foo");
+
+    // Readonly observable array
+    const read = write as ko.ReadonlyObservableArray<string>;
+    read(); //$ExpectType ReadonlyArray<string>
+    read.slice(0, 1); //$ExpectType string[]
+
+    // read(["foo"]); // $ExpectError // no way to test this, currently
+    const _hasPushMethod: typeof read extends { push: any } ? true : false = false;
+
+    // Can cast back to a writeable
+    const writeAgain = read as ko.ObservableArray<string>
+    writeAgain(["foo"]);
+}


### PR DESCRIPTION
This adds types for representing immutable versions of observables, observable arrays, and computeds.  The changes in this PR match changes that were introduced into the public typings in DefinitelyTyped/DefinitelyTyped#30499.  

Although the underlying objects may actually be mutable, it's frequently useful to treat them as if they weren't: functions can accept readonly versions to indicate that they won't modify the contents, or things can be made publicly immutable, while still being privately mutable.  

```ts
class Counter {
    value: ReadonlyObservable<number>;
    incr: () => void;

    constructor() {
        const value = this.value = ko.observable(0);
        this.incr = () => value(value.peek() + 1);
    }
}
```

The consumer can read the value, subscribe to it, or call `incr` to increment it, but they can't set arbitrary values without circumventing the types.

---

Additionally, while `Computed<T>` is no longer assignable to `Observable<T>` like it was in the public typings (missing the '.willMutate' methods and the '.valueHasMutated` and `.valueWillMutate` methods), a computed is assignable to `ReadonlyObservable<T>`, which is convenient for functions like:

```ts
function logChanges(observable: ReadonlyObservable<any>);
```

instead of:

```ts
function logChanges(observable: KnockoutObservable<any> | KnockoutComputed<any>);
```
   

---

In theory, certain overrides of `ko.computed` should return readonly computeds, not writable computeds:

```ts
const five = ko.computed(() => 5)
five(6); // Runtime error but not type error
```

This PR *does not* address that issue.  It never was addressed in the public typings - it caused a prohibitive number of type errors in our project, but it might be a smoother transition here.  (A lot of the 'prohibitive errors' are type errors we're going to need to fix to go from 3.4 to 3.5 anyway)