### PR TITLE
Types: Improve the signature of ignoreDependencies

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -194,7 +194,11 @@ export interface ComputedContext {
 
 export const computedContext: ComputedContext;
 
-export function ignoreDependencies(callback: Function, callbackTarget?: any, callbackArgs?: any[]): void;
+export function ignoreDependencies<Return, Target, Args extends any[]>(
+    callback: (this: Target, ...args: Args) => Return,
+    callbackTarget?: Target,
+    callbackArgs?: Args
+): Return;
 
 //#endregion
 

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -194,6 +194,12 @@ export interface ComputedContext {
 
 export const computedContext: ComputedContext;
 
+/**
+ * Executes a function and returns the result, while disabling depdendency tracking
+ * @param callback - the function to execute without dependency tracking
+ * @param callbackTarget - the `this` binding for `callback`
+ * @param callbackArgs - the args to provide to `callback`
+ */
 export function ignoreDependencies<Return, Target, Args extends any[]>(
     callback: (this: Target, ...args: Args) => Return,
     callbackTarget?: Target,

--- a/spec/types/global/test-global.ts
+++ b/spec/types/global/test-global.ts
@@ -574,12 +574,12 @@ function test_customObservable() {
         // Set up the attribute observable cache
         model._koObservables || (model._koObservables = {});
 
-        // If we already have a cached observable then just return it		
+        // If we already have a cached observable then just return it
         if (attribute in model._koObservables) {
             return model._koObservables[attribute];
         }
 
-        // Create our observable getter/setter function	
+        // Create our observable getter/setter function
         var observableAttribute = <ko.Observable>(function (this: any): any {
             if (arguments.length > 0) {
                 observableAttribute.valueWillMutate();
@@ -667,7 +667,7 @@ function test_Components() {
         // viewModel from createViewModel factory method
         ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
 
-        // viewModel from an AMD module 
+        // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
 
         // ------- template overloads
@@ -680,7 +680,7 @@ function test_Components() {
         // template using Node array
         ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
 
-        // template using an AMD module 
+        // template using an AMD module
         ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
 
         // Empty config for registering custom elements that are handled by name convention
@@ -739,7 +739,7 @@ class DummyTemplateEngine extends ko.templateEngine {
             return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
         }
         else if ((template.nodeType == 1) || (template.nodeType == 8)) {
-            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous
         }
         else {
             throw new Error("Unrecognized template source");
@@ -1354,3 +1354,15 @@ testNode.innerHTML = "<div data-bind='template: \"myTemplate\"'></div>";
 ko.applyBindings(null, testNode);
 // Since the actual template markup was invalid, we don't really care what the
 // resulting DOM looks like. We are only verifying there were no exceptions.
+
+function testIgnoreDependencies() {
+    const five = ko.ignoreDependencies(() => 5);
+
+    const target = {foo: "foo"};
+
+    const foobar = ko.ignoreDependencies(function (bar) {
+        return this.foo + bar;
+    }, target, ["bar"])
+
+    foobar.toUpperCase();
+}

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -597,12 +597,12 @@ function test_customObservable() {
         // Set up the attribute observable cache
         model._koObservables || (model._koObservables = {});
 
-        // If we already have a cached observable then just return it		
+        // If we already have a cached observable then just return it
         if (attribute in model._koObservables) {
             return model._koObservables[attribute];
         }
 
-        // Create our observable getter/setter function	
+        // Create our observable getter/setter function
         var observableAttribute = <ko.Observable>(function (this: any): any {
             if (arguments.length > 0) {
                 observableAttribute.valueWillMutate();
@@ -690,7 +690,7 @@ function test_Components() {
         // viewModel from createViewModel factory method
         ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: ko.components.ComponentInfo) { return null; } } });
 
-        // viewModel from an AMD module 
+        // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
 
         // ------- template overloads
@@ -703,7 +703,7 @@ function test_Components() {
         // template using Node array
         ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
 
-        // template using an AMD module 
+        // template using an AMD module
         ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
 
         // Empty config for registering custom elements that are handled by name convention
@@ -769,7 +769,7 @@ class DummyTemplateEngine extends ko.templateEngine {
             return new DummyTemplateSource(this, template); // Named template comes from the in-memory collection
         }
         else if ((template.nodeType == 1) || (template.nodeType == 8)) {
-            return new ko.templateSources.anonymousTemplate(template); // Anonymous 
+            return new ko.templateSources.anonymousTemplate(template); // Anonymous
         }
         else {
             throw new Error("Unrecognized template source");
@@ -1384,3 +1384,16 @@ testNode.innerHTML = "<div data-bind='template: \"myTemplate\"'></div>";
 ko.applyBindings(null, testNode);
 // Since the actual template markup was invalid, we don't really care what the
 // resulting DOM looks like. We are only verifying there were no exceptions.
+
+
+function testIgnoreDependencies() {
+    const five = ko.ignoreDependencies(() => 5);
+
+    const target = {foo: "foo"};
+
+    const foobar = ko.ignoreDependencies(function (bar) {
+        return this.foo + bar;
+    }, target, ["bar"])
+
+    foobar.toUpperCase();
+}


### PR DESCRIPTION
The main change is fixing the return value so that it returns whatever the inner function returns, but this also adds types so that the second and third args (`callbackTarget and callbackArgs`) are used appropriately:

```ts
const foobar = ko.ignoreDependencies(function (bar) { // bar is inferred as string
        // this.foo is inferred as string
        return this.foo + bar;
}, {foo: "foo"}, ["bar"])
```

---

Note: this Args syntax requires Typescript 3.0+ (released in July of 2018).  I'm not sure if you had a specific TS target in mind.  If you want to maintain 2.0 support, I'd still add support for `callbackTarget` and the return type, but `callbackArgs` would go back to being `any[]`.