### PR TITLE
Apply bindings to shadow DOMs via passing shadowRoot or host element

### DIFF
--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -560,7 +560,7 @@
     };
 
     ko.applyBindingsToDescendants = function(viewModelOrBindingContext, rootNode) {
-        if (rootNode.nodeType === 1 || rootNode.nodeType === 8)
+        if (rootNode.nodeType === 1 || rootNode.nodeType === 8 || rootNode.nodeType === 11)
             applyBindingsToDescendantsInternal(getBindingContext(viewModelOrBindingContext), rootNode);
     };
 
@@ -575,17 +575,20 @@
             if (!rootNode) {
                 throw Error("ko.applyBindings: could not find document.body; has the document been loaded?");
             }
-        } else if (!rootNode || (rootNode.nodeType !== 1 && rootNode.nodeType !== 8)) {
+        } else if (!rootNode || (rootNode.nodeType !== 1 && rootNode.nodeType !== 8 && rootNode.nodeType !== 11)) {
             throw Error("ko.applyBindings: first parameter should be your view model; second parameter should be a DOM node");
         }
 
-        applyBindingsToNodeAndDescendantsInternal(getBindingContext(viewModelOrBindingContext, extendContextCallback), rootNode);
+        // If the node has a Shadow DOM, then it's a Web Component.  The correct context is the shadowRoot.
+        rootNode.shadowRoot
+        ? applyBindingsToNodeAndDescendantsInternal(getBindingContext(viewModelOrBindingContext, extendContextCallback), rootNode.shadowRoot)
+        : applyBindingsToNodeAndDescendantsInternal(getBindingContext(viewModelOrBindingContext, extendContextCallback), rootNode)
     };
 
     // Retrieving binding context from arbitrary nodes
     ko.contextFor = function(node) {
-        // We can only do something meaningful for elements and comment nodes (in particular, not text nodes, as IE can't store domdata for them)
-        if (node && (node.nodeType === 1 || node.nodeType === 8)) {
+        // We can only do something meaningful for elements, comment nodes, and document fragments (in particular, not text nodes, as IE can't store domdata for them)
+        if (node && (node.nodeType === 1 || node.nodeType === 8 || node.nodeType === 11)) {
             return ko.storedBindingContextForNode(node);
         }
         return undefined;


### PR DESCRIPTION
I hope the tests are OK.

I added a simple check such that it would work if applyBindings is passed the host element rather than its shadowRoot, as I expect this would be quite a common mistake.

Might be worth steering people towards ko.postbox if this feature is documented, as some will inevitably want to know how to communicate between the VMs.

Let me know if there is anything that needs changing.  Thanks.

EDIT:  For the sake of posterity, I guess I'll explain what this is about.

Knockout had custom elements and components before they were ~~cool~~ standardized, but now many libraries and frameworks use them and they are standardized.

These changes allow Knockout to play better with vanilla custom elements by
* Making it possible to applyBindings to a document fragment and therefore the shadowRoot of a Shadow DOM; and,
* Making it possible to applyBindings directly to the host element, e.g. `<my-custom-el>`, and having them properly applied to the Shadow DOM.

This can be used either to create, register, and load encapsulated and reusable components in the new(ish) ECMA way or to get Knockout to behave better with libraries/frameworks that do create components in this way.

It doesn't provide for passing params like with Knockout components.  If that's desired, just use regular Knockout components because you're clearly building a Knockout app rather than an app that happens to have a Knockout component.

That said, if you really want to break the encapsulation and communicate between the VMs, use knockout.postbox or a potentially forthcoming SSoT plugin.