### PR TITLE
TypeScript: Modified default component loader to load transpiled classes.

### DIFF
--- a/src/components/defaultLoader.js
+++ b/src/components/defaultLoader.js
@@ -195,7 +195,12 @@
         if (typeof config['require'] === 'string') {
             // The config is the value of an AMD module
             if (amdRequire || window['require']) {
-                (amdRequire || window['require'])([config['require']], callback);
+                (amdRequire || window['require'])([config['require']], function (module) {
+                    if (module && typeof module === 'object' && module.__esModule && module.default) {
+                        module = module.default;
+                    }
+                    callback(module);
+                });
             } else {
                 errorCallback('Uses require, but no AMD loader is present');
             }


### PR DESCRIPTION
This change proposes to have the defaultLoader handle `default export`'s of TypeScript classes.

**Motivation:**
When using Knockout in combination with TypeScript or (presumably) Babel/etc, it is very hard (if not impossible) to get the transpiler to output the correct format for lazy loading Components via the defaultLoader and AMD/RequireJS.

**Elaboration:**
Using this syntax to lazy load Components:
```javascript
ko.components.register('my-component', {
    viewModel: { require: 'some/module/name' },
    template: { require: 'text!some-template.html' }
});
```

Knockout expects the AMD module to return either a constructor or a shared object instance or a factory function. When using TypeScript together with this loader we can make the assumption that we're using RequireJS (or other AMD loader) and that we have TSC transpiling to AMD-modules.

In this setup TSC will not transpile to an AMD module that returns a constructor, shared object instance or factory function. (At least definately not if we coded the ViewModel as a class).

A way around this would be to let the transpiler handle the loading of the module like so:
```typescript
import * as ko from 'knockout';
import { MyViewModel } from './components/myviewmodel';

ko.components.register('my-component', {
    viewModel: MyViewModel,
    template: { require: 'text!some-template.html' }
});
```
But then we lose the deferred loading.

And ofcourse, we can build a custom loader, but that seems overkill, since this basically is the default use case.

**Proposal:**
My proposed change is unobtrusive and handles this common case. It is, as far as I can tell, unopinionated, because using AMD is at this time assumed and even checked for by Knockout. It just handles the default output of TSC's transpiling of classes.

With this change you can have a ViewModel like this ('some/module/name.ts', note the **default** export):
```typescript
import * as ko from 'knockout';
import { Observable, Computed } from 'knockout';

export default class MyViewModel {
    foo: Observable<string>;
    bar: Observable<string>;
    dummy: Observable<number>;
    ...
}
```
and still use the default syntax for deferred/lazy loading:
```javascript
ko.components.register('my-component', {
    viewModel: { require: 'some/module/name' },
    template: { require: 'text!some-template.html' }
});
```