### PR TITLE
enhancement(types): Add generic to extender and extenderoptions

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -28,8 +28,8 @@ export interface SubscribableFunctions<T = any> extends Function {
     subscribe<TTarget = void>(callback: SubscriptionCallback<T, TTarget>, callbackTarget?: TTarget, event?: "change"): Subscription;
     subscribe<X = any, TTarget = void>(callback: SubscriptionCallback<X, TTarget>, callbackTarget: TTarget, event: string): Subscription;
 
-    extend(requestedExtenders: ObservableExtenderOptions): this;
-    extend<S extends Subscribable<any>>(requestedExtenders: ObservableExtenderOptions): S;
+    extend(requestedExtenders: ObservableExtenderOptions<T>): this;
+    extend<S extends Subscribable<T>>(requestedExtenders: ObservableExtenderOptions<T>): S;
 
     getSubscriptionsCount(event?: string): number;
 }
@@ -219,7 +219,7 @@ export interface RateLimitOptions {
     [option: string]: any;
 }
 
-export interface ExtendersOptions {
+export interface ExtendersOptions<T> {
     trackArrayChanges: true | utils.CompareArraysOptions;
     throttle: number;
     rateLimit: number | RateLimitOptions;
@@ -233,13 +233,13 @@ export interface Extender<T extends Subscribable = any, O = any> {
 
 type AsExtenders<T> = { [P in keyof T]: Extender<Subscribable, T[P]> }
 
-export interface Extenders extends AsExtenders<ExtendersOptions> {
+export interface Extenders<T> extends AsExtenders<ExtendersOptions<T>> {
     [name: string]: Extender;
 }
 
-export interface ObservableExtenderOptions extends Partial<ExtendersOptions> { }
+export interface ObservableExtenderOptions<T> extends Partial<ExtendersOptions<T>> { }
 
-export const extenders: Extenders;
+export const extenders: Extenders<any>;
 
 //#endregion
 

--- a/spec/types/global/_references.d.ts
+++ b/spec/types/global/_references.d.ts
@@ -6,7 +6,7 @@ declare module "knockout" {
         filterByProperty(propName: string, matchValue: boolean): ko.Computed<any>;
     }
 
-    export interface ExtendersOptions {
+    export interface ExtendersOptions<T> {
         numeric: number;
         required: string;
         logChange: string;

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -300,7 +300,7 @@ declare module "knockout" {
         filterByProperty(propName: string, matchValue: boolean): ko.Computed<any>;
     }
 
-    export interface ExtendersOptions {
+    export interface ExtendersOptions<T> {
         numeric: number;
         required: string;
         logChange: string;


### PR DESCRIPTION
Adds generic to `Extenders` and `ExtendersOptions` to pass through boxed observable type. Useful for extenders that accept functions that pass through the observable value.

Consider the following use case:

```typescript
import * as ko from 'knockout'

declare module 'knockout' {
  interface ExtendersOptions<T> {
    validate(v: T): boolean
  }
}

function strValidator(v: string) {
  return true
}

const strObs = ko.observable<string>().extend({
  // types match, all good
  validate: strValidator
})

const numObs = ko.observable<number>().extend({
  // type mismatch, caught by typescript
  validate: strValidator
})

const boolObs = ko.observable<boolean>().extend({
  // type of v is inferred as boolean
  validate: (v) => true
})
```