### PR TITLE
enhancement(types): infer return type from `toJS`

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -245,7 +245,17 @@ export const extenders: Extenders;
 
 //#region subscribables/mappingHelpers.js
 
-export function toJS(rootObject: any): any;
+type Unwrapped<T> = T extends ko.Observable<infer R>
+    ? R
+    : T extends ko.ObservableArray<infer R>
+    ? R[]
+    : T extends ko.Computed<infer R>
+    ? R
+    : T extends Record<any, any>
+    ? { [P in keyof T]: Unwrapped<T[P]> }
+    : T
+
+export function toJS<T>(rootObject: T): Unwrapped<T>;
 export function toJSON(rootObject: any, replacer?: Function, space?: number): string;
 
 //#endregion

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -245,14 +245,12 @@ export const extenders: Extenders;
 
 //#region subscribables/mappingHelpers.js
 
-type Unwrapped<T> = T extends ko.Observable<infer R>
-    ? R
-    : T extends ko.ObservableArray<infer R>
-    ? R[]
-    : T extends ko.Computed<infer R>
+type Unwrapped<T> = T extends ko.Subscribable<infer R>
     ? R
     : T extends Record<any, any>
-    ? { [P in keyof T]: Unwrapped<T[P]> }
+    ? {
+        [P in keyof T]: Unwrapped<T[P]>
+    }
     : T
 
 export function toJS<T>(rootObject: T): Unwrapped<T>;

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -246,7 +246,7 @@ export const extenders: Extenders;
 //#region subscribables/mappingHelpers.js
 
 export function toJS(rootObject: any): any;
-export function toJSON(rootObject: any, replacer?: Function, space?: number): any;
+export function toJSON(rootObject: any, replacer?: Function, space?: number): string;
 
 //#endregion
 


### PR DESCRIPTION
Tested w/:

```typescript
    type Unwrapped<T> = T extends ko.Subscribable<infer R>
      ? R
      : T extends Record<any, any>
      ? {
          [P in keyof T]: Unwrapped<T[P]>
        }
      : T

    // don't throw errors
    const unwrappedObs: Unwrapped<ko.Observable<string>> = ''
    const unwrappedObsArr: Unwrapped<ko.ObservableArray<string>> = ['']
    const unwrappedComputed: Unwrapped<ko.Computed<string>> = ''
    const unwrappedPureComputed: Unwrapped<ko.PureComputed<string>> = ''
    const unwrappedNonObs: Unwrapped<string> = ''
    const unwrappedObj: Unwrapped<{
      foo: string
      bar: {
        baz: ko.Observable<number>
      }
    }> = {
      foo: 'foo',
      bar: {
        baz: 1
      }
    }

    // throw errors
    const unwrappedObsBad: Unwrapped<ko.Observable<string>> = 1
    const unwrappedObsArrBad: Unwrapped<ko.ObservableArray<string>> = [1]
    const unwrappedComputedBad: Unwrapped<ko.Computed<string>> = 1
    const unwrappedPureComputedBad: Unwrapped<ko.PureComputed<string>> = 1
    const unwrappedNonObsBad: Unwrapped<string> = 1
    const unwrappedObjBad: Unwrapped<{
      foo: string
      bar: {
        baz: ko.Observable<number>
      }
    }> = {
      foo: 'foo',
      bar: {
        baz: ''
      }
    }
```