### PR TITLE
Use of Reserved Word Breaking IE <= 8 Compatibility

### DIFF
--- a/src/components/defaultLoader.js
+++ b/src/components/defaultLoader.js
@@ -196,8 +196,8 @@
             // The config is the value of an AMD module
             if (amdRequire || window['require']) {
                 (amdRequire || window['require'])([config['require']], function (module) {
-                    if (module && typeof module === 'object' && module.__esModule && module.default) {
-                        module = module.default;
+                    if (module && typeof module === 'object' && module.__esModule && module['default']) {
+                        module = module['default'];
                     }
                     callback(module);
                 });


### PR DESCRIPTION
In the Knockout 3.5.1 release, there was a change to the components/defaultLoader.js that is breaking compatibility issues with IE <= 8 due to the use of reserved word default.

if (module && typeof module === 'object' && module.__esModule && module.default) { module = module.default; }

My suggested fix is to change from dot notation to bracket notation.
if (module && typeof module === 'object' && module.__esModule && module['default']) { module = module['default']; }

I have tested this with IE 8 and it seems to fix the issue.