### PR TITLE
fix(typings): utils.toJS return type when observable array, regexp, or date

### DIFF
--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -329,8 +329,19 @@ export const extenders: Extenders<any>;
 
 //#region subscribables/mappingHelpers.js
 
-type Unwrapped<T> = T extends ko.Subscribable<infer R> ? R :
-    T extends Record<any, any> ? { [P in keyof T]: Unwrapped<T[P]> } : T;
+type Unwrapped<T> = T extends ko.ObservableArray<infer R>
+    ? Unwrapped<R>[]
+    : T extends ko.Subscribable<infer R>
+    ? (
+        R extends Record<any, any>
+            ? { [P in keyof R]: Unwrapped<R[P]>}
+            : R
+    )
+    : T extends Date | RegExp | Function
+    ? T
+    : T extends Record<any, any>
+    ? { [P in keyof T]: Unwrapped<T[P]> } 
+    : T
 
 export function toJS<T>(rootObject: T): Unwrapped<T>;
 export function toJSON(rootObject: any, replacer?: Function, space?: number): string;

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -329,7 +329,9 @@ export const extenders: Extenders<any>;
 
 //#region subscribables/mappingHelpers.js
 
-export type Unwrapped<T> = T extends ko.Subscribable<infer R>
+export type Unwrapped<T> = T extends ko.ObservableArray<infer R>
+    ? Unwrapped<R>[]
+    : T extends ko.Subscribable<infer R>
     ? (
         R extends ko.Subscribable
         ? unknown 

--- a/build/types/knockout.d.ts
+++ b/build/types/knockout.d.ts
@@ -329,13 +329,13 @@ export const extenders: Extenders<any>;
 
 //#region subscribables/mappingHelpers.js
 
-type Unwrapped<T> = T extends ko.ObservableArray<infer R>
-    ? Unwrapped<R>[]
-    : T extends ko.Subscribable<infer R>
+export type Unwrapped<T> = T extends ko.Subscribable<infer R>
     ? (
-        R extends Record<any, any>
+        R extends ko.Subscribable
+        ? unknown 
+        : R extends Record<any, any>
             ? { [P in keyof R]: Unwrapped<R[P]>}
-            : R
+            :  R
     )
     : T extends Date | RegExp | Function
     ? T

--- a/spec/types/global/test-global.ts
+++ b/spec/types/global/test-global.ts
@@ -701,6 +701,44 @@ function testUnwrapUnion(this: any) {
 }
 
 
+function testToJS() {
+    const obj: {
+        foo: string
+        bar: string
+    } = ko.toJS({ foo: ko.observable(''), bar: '' })
+
+    const arr: {
+        foo: string
+        bar: string
+    }[] = ko.toJS([{ foo: ko.observable(''), bar: '' }])
+
+    const observableArr: {
+        foo: string
+        bar: string
+    }[] = ko.toJS(ko.observableArray([ ko.observable({ foo: ko.observable(''), bar: '' }) ]))
+
+    const nestedObj: {
+        foo: {
+            bar: string
+        }
+    } = ko.toJS(
+        ko.observable({
+            foo: ko.observable({ bar: '' })
+        })
+    )
+
+    const builtins: {
+        date: Date
+        regexp: RegExp
+        func: (v: string) => string
+    } = ko.toJS({
+        date: new Date(),
+        regexp: /foo/,
+        func: (v: string) => ''
+    })
+}
+
+
 // *****************************
 // Template and Databinding Tests
 // *****************************

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -741,15 +741,28 @@ function testToJS() {
     const observableArr: {
         foo: string
         bar: string
-    }[] = ko.toJS(ko.observableArray([ ko.observable({ foo: ko.observable(''), bar: '' }) ]))
+    }[] = ko.toJS(ko.observableArray([
+        ko.observable({ foo: ko.observable(''), bar: '' }),
+        ko.observable({ foo: ko.observable(''), bar: ko.observable('') })
+    ]))
 
-    const nestedObj: {
+    const plainObservableWithArray: {
+        foo: string
+        bar: string
+    }[] = ko.toJS(ko.observable([
+        ko.observable({ foo: ko.observable(''), bar: '' }),
+        ko.observable({ foo: ko.observable(''), bar: '' })
+    ]))
+
+    // const recursive: string = ko.toJS(ko.observable(ko.observable(ko.observable(''))))
+
+    const recursiveObj: {
         foo: {
             bar: string
         }
     } = ko.toJS(
         ko.observable({
-            foo: ko.observable({ bar: '' })
+            foo: ko.observable({ bar: ko.observable('') })
         })
     )
 

--- a/spec/types/module/test-module.ts
+++ b/spec/types/module/test-module.ts
@@ -727,6 +727,43 @@ function testUnwrapUnion(this: any) {
     const num = ko.unwrap(possibleObs);
 }
 
+function testToJS() {
+    const obj: {
+        foo: string
+        bar: string
+    } = ko.toJS({ foo: ko.observable(''), bar: '' })
+
+    const arr: {
+        foo: string
+        bar: string
+    }[] = ko.toJS([{ foo: ko.observable(''), bar: '' }])
+
+    const observableArr: {
+        foo: string
+        bar: string
+    }[] = ko.toJS(ko.observableArray([ ko.observable({ foo: ko.observable(''), bar: '' }) ]))
+
+    const nestedObj: {
+        foo: {
+            bar: string
+        }
+    } = ko.toJS(
+        ko.observable({
+            foo: ko.observable({ bar: '' })
+        })
+    )
+
+    const builtins: {
+        date: Date
+        regexp: RegExp
+        func: (v: string) => string
+    } = ko.toJS({
+        date: new Date(),
+        regexp: /foo/,
+        func: (v: string) => ''
+    })
+}
+
 
 // *****************************
 // Template and Databinding Tests


### PR DESCRIPTION
Improves types added in #2494 and added test cases.

- Fixes types on deep/recursive unwrapping (observable array of observables)
- Passes through RegExp and Date w/o mapping prototype ([see here](https://stackoverflow.com/questions/59364768/exclude-builtins-when-in-mapped-conditional-type))

In the added test cases, `observableArr` and `builtins` are the two newly covered conditions (the others were good already, but always nice to have tests).

Also, in finding which built-ins get unwrapped correctly (Date and RegExp), I found [this](https://github.com/knockout/knockout/blob/9893233413e467a40919237e524b545e335c1050/src/subscribables/mappingHelpers.js#L27). Should `Map`, `Set`, `WeakMap`, and `WeakSet` (and potentially [others](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)) be added here? They currently do not behave as expected with `ko.toJS`. Theoretically this is a breaking change since the output for a given input will change, but as-is the returned map/set is just an empty object so I can't see any way it would be being used currently.