### PR TITLE
Remove not needed command from dist task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,7 +181,6 @@ module.exports = function(grunt) {
         grunt.file.copy(buildConfig.min, distConfig.min);
 
         console.log('To publish, run:');
-        console.log('    git add bower.json');
         console.log('    git add -f ' + distConfig.debug);
         console.log('    git add -f ' + distConfig.min);
         console.log('    git checkout head');


### PR DESCRIPTION
Seems to be once build do not update version in bower.json, this line no longer needed.