### PR TITLE
Fixed update input value by attr binding

### DIFF
--- a/src/binding/defaultBindings/attr.js
+++ b/src/binding/defaultBindings/attr.js
@@ -1,6 +1,7 @@
 var attrHtmlToJavaScriptMap = { 'class': 'className', 'for': 'htmlFor' };
 ko.bindingHandlers['attr'] = {
     'update': function(element, valueAccessor, allBindings) {
+        var isInputElement = ko.utils.tagNameLower(element) == "input";
         var value = ko.utils.unwrapObservable(valueAccessor()) || {};
         ko.utils.objectForEach(value, function(attrName, attrValue) {
             attrValue = ko.utils.unwrapObservable(attrValue);
@@ -39,6 +40,16 @@ ko.bindingHandlers['attr'] = {
             // entirely, and there's no strong reason to allow for such casing in HTML.
             if (attrName === "name") {
                 ko.utils.setElementName(element, toRemove ? "" : attrValue);
+            }
+
+            if (isInputElement && attrName == "value") {
+                // If the value binding is placed on a radio/checkbox, then just pass through to checkedValue and quit
+                if (isInputElement && (element.type == "checkbox" || element.type == "radio")) {
+                    ko.applyBindingAccessorsToNode(element, {'checkedValue': valueAccessor});
+                    return;
+                }
+
+                ko.utils.setElementValue(element, attrValue);
             }
         });
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -472,6 +472,10 @@ ko.utils = (function () {
             }
         },
 
+        setElementValue: function(element, value) {
+            element.value = value;
+        },
+
         forceRefresh: function(node) {
             // Workaround for an IE9 rendering bug - https://github.com/SteveSanderson/knockout/issues/209
             if (ieVersion >= 9) {


### PR DESCRIPTION
Reference comment https://github.com/magento/magento2/pull/33027#issuecomment-849443012

This PR fixes input element binding for `value` if it's done by
```
attr: {
    value: someFunc
}
```

Binding to value in attr section will not update input field because it’s bug or feature of HTMLInputElement implementation. Visible value linked to HTMLInputElement value property.
attr section use setAttribute method of Element api implementation and this is don’t effect to value property.
You may try experiment on this page, for example: https://developer.mozilla.org/en-US/docs/Web/API/Element

```
document.querySelectorAll("[id='main-q']")[0].value
""
document.querySelectorAll("[id='main-q']")[0].getAttribute('value')
null
document.querySelectorAll("[id='main-q']")[0].setAttribute('value', 1)
undefined
document.querySelectorAll("[id='main-q']")[0].value=2
2
document.querySelectorAll("[id='main-q']")[0].getAttribute('value')
"1"
document.querySelectorAll("[id='main-q']")[0].value
"2"
```