### PR TITLE
Trusted Type Knockout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,9 @@ module.exports = function(grunt) {
         },
         test: {
             puppeteer: 'spec/runner.puppeteer.js',
-            node: 'spec/runner.node.js'
+            node: 'spec/runner.node.js',
+            trustedtypes: 'spec/runner.trusted-types.js',
+            trustedtypesdebug: 'spec/runner.trusted-types.js build/output/knockout-latest.debug.js'
         },
         testtypes: {
             global: "spec/types/global",
@@ -139,7 +141,8 @@ module.exports = function(grunt) {
 
     grunt.registerMultiTask('test', 'Run tests', function () {
         var done = this.async();
-        const spawnOptions = { cmd: "node", args: [this.data] };
+        var args = this.data.split(' ');
+        const spawnOptions = { cmd: "node", args: args };
         grunt.util.spawn(spawnOptions,
             function (error, result, code) {
                 if (code === 127 /*not found*/) {

--- a/spec/defaultBindings/htmlBehaviors.js
+++ b/spec/defaultBindings/htmlBehaviors.js
@@ -51,20 +51,17 @@ describe('Binding: HTML', function() {
         expect('innerText' in td ? td.innerText : td.textContent).toEqual("hello");
     });
 
-    it('Should assign the TrustedHTML directly to innerHTML', function () {
-        // Mock Trusted Types.
-        trustedTypes = {};
-        trustedTypes.isHTML = function(input) {
-            if (input.type == "TrustedHTML") {
-                return true;
-            }
-            return false;
-        };
-
-        var html = {"type": "TrustedHTML"};
-        var model = { htmlProp: html };
+    it('Should pass TrustedHTML directly to innerHTML without stringification', function () {
+        if (typeof trustedTypes === 'undefined') {
+            return; // Skip in environments without Trusted Types
+        }
+        var policy = trustedTypes.createPolicy('knockout-test-html', {
+            createHTML: function(s) { return s; }
+        });
+        var trustedHtml = policy.createHTML('<b>trusted content</b>');
+        var model = { htmlProp: trustedHtml };
         testNode.innerHTML = "<span data-bind='html:htmlProp'></span>";
         ko.applyBindings(model, testNode);
-        expect(testNode.childNodes[0].innerHTML).toEqual("[object Object]");
+        expect(testNode.childNodes[0].innerHTML.toLowerCase()).toEqual('<b>trusted content</b>');
     });
 });

--- a/spec/runner.trusted-types.js
+++ b/spec/runner.trusted-types.js
@@ -1,0 +1,106 @@
+// Trusted Types e2e test runner
+// Verifies Knockout works under Trusted Types CSP enforcement
+//
+// Serves via HTTP with a CSP header to enforce Trusted Types.
+// Usage: node spec/runner.trusted-types.js [knockout-file]
+//   Default: build/output/knockout-latest.js
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const PORT = 0; // auto-assign
+const ROOT = path.resolve(__dirname, '..');
+const koFile = process.argv[2] || 'build/output/knockout-latest.js';
+
+var CSP = "trusted-types knockout knockout-test; require-trusted-types-for 'script'";
+
+function serve(req, res) {
+    if (req.url === '/favicon.ico') {
+        res.writeHead(204);
+        res.end();
+        return;
+    }
+    // Map /spec/knockout.js to the build being tested
+    var filePath = (req.url === '/spec/knockout.js')
+        ? path.join(ROOT, koFile)
+        : path.join(ROOT, req.url === '/' ? '/spec/trusted-types.html' : req.url);
+    var ext = path.extname(filePath);
+    var contentType = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' }[ext] || 'application/octet-stream';
+
+    fs.readFile(filePath, function(err, data) {
+        if (err) {
+            res.writeHead(404);
+            res.end('Not found: ' + req.url);
+        } else {
+            var headers = { 'Content-Type': contentType };
+            if (ext === '.html') {
+                headers['Content-Security-Policy'] = CSP;
+            }
+            res.writeHead(200, headers);
+            res.end(data);
+        }
+    });
+}
+
+(async function() {
+    console.log("Running Knockout Trusted Types e2e tests (" + koFile + ")");
+
+    var server = http.createServer(serve);
+    await new Promise(function(resolve) { server.listen(PORT, resolve); });
+    var port = server.address().port;
+
+    try {
+        var browser = await puppeteer.launch({ headless: true });
+        var page = await browser.newPage();
+
+        var cspErrors = [];
+        page.on('pageerror', function(err) { cspErrors.push(err.message); });
+        page.on('console', function(msg) {
+            var text = msg.text();
+            if (msg.type() !== 'log') console.log('  [page ' + msg.type() + '] ' + text);
+            if (msg.type() === 'error') cspErrors.push('[console] ' + text);
+        });
+        page.on('requestfailed', function(req) {
+            if (req.url().indexOf('favicon') === -1) console.log('  [request failed] ' + req.url());
+        });
+
+        await page.goto('http://localhost:' + port + '/spec/trusted-types.html', { waitUntil: 'load' });
+
+        try {
+            await page.waitForFunction(function() { return window.__ttResults; }, { timeout: 10000 });
+        } catch (waitErr) {
+            console.log('  Timed out waiting for results — page may have crashed');
+        }
+
+        var results = await page.evaluate(function() { return window.__ttResults || []; });
+        var passed = 0, failed = 0;
+
+        results.forEach(function(r) {
+            if (r.pass) {
+                console.log('  ✓ ' + r.name);
+                passed++;
+            } else {
+                console.log('  ✗ ' + r.name + ': ' + r.error);
+                failed++;
+            }
+        });
+
+        if (cspErrors.length > 0) {
+            console.log('\nCSP/Trusted Types violations:');
+            cspErrors.forEach(function(e) { console.log('  ' + e); });
+            failed++;
+        }
+
+        console.log('\n' + passed + ' passed, ' + failed + ' failed');
+
+        await browser.close();
+        server.close();
+        process.exit(failed > 0 ? 1 : 0);
+    } catch (e) {
+        console.error('Error:', e.message);
+        server.close();
+        process.exit(1);
+    }
+})();

--- a/spec/trusted-types.html
+++ b/spec/trusted-types.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Knockout Trusted Types Test</title>
+</head>
+<body>
+    <div id="result"></div>
+    <script src="knockout.js"></script>
+    <script>
+    (function() {
+        var results = [];
+
+        function assert(name, fn) {
+            try {
+                fn();
+                results.push({ name: name, pass: true });
+            } catch (e) {
+                results.push({ name: name, pass: false, error: e.message });
+            }
+        }
+
+        function expect(actual) {
+            return {
+                toBe: function(expected) {
+                    if (actual !== expected) throw new Error('Expected ' + expected + ' but got ' + actual);
+                },
+                toContain: function(expected) {
+                    if (String(actual).indexOf(expected) === -1)
+                        throw new Error('Expected "' + actual + '" to contain "' + expected + '"');
+                }
+            };
+        }
+
+        // Test 1: Basic binding works under TT enforcement
+        assert('Basic text binding', function() {
+            var div = document.createElement('div');
+            div.setAttribute('data-bind', 'text: message');
+            document.body.appendChild(div);
+            ko.applyBindings({ message: 'hello trusted types' }, div);
+            expect(div.textContent).toBe('hello trusted types');
+            ko.cleanNode(div);
+            document.body.removeChild(div);
+        });
+
+        // Test 2: Template/foreach binding works (uses innerHTML internally)
+        assert('Template binding with foreach', function() {
+            var div = document.createElement('div');
+            div.setAttribute('data-bind', 'foreach: items');
+            var span = document.createElement('span');
+            span.setAttribute('data-bind', 'text: $data');
+            div.appendChild(span);
+            document.body.appendChild(div);
+            ko.applyBindings({ items: ['a', 'b', 'c'] }, div);
+            expect(div.textContent).toBe('abc');
+            ko.cleanNode(div);
+            document.body.removeChild(div);
+        });
+
+        // Test 3: html binding with plain string (uses createHTML internally)
+        assert('HTML binding with string', function() {
+            var div = document.createElement('div');
+            div.setAttribute('data-bind', 'html: content');
+            document.body.appendChild(div);
+            ko.applyBindings({ content: '<b>bold</b>' }, div);
+            expect(div.innerHTML.toLowerCase()).toContain('<b>bold</b>');
+            ko.cleanNode(div);
+            document.body.removeChild(div);
+        });
+
+        // Test 4: html binding with TrustedHTML (passthrough)
+        assert('HTML binding with TrustedHTML', function() {
+            var policy = trustedTypes.createPolicy('knockout-test', {
+                createHTML: function(s) { return s; }
+            });
+            var div = document.createElement('div');
+            div.setAttribute('data-bind', 'html: content');
+            document.body.appendChild(div);
+            var trustedHtml = policy.createHTML('<b>bold</b>');
+            ko.applyBindings({ content: trustedHtml }, div);
+            expect(div.innerHTML.toLowerCase()).toContain('<b>bold</b>');
+            ko.cleanNode(div);
+            document.body.removeChild(div);
+        });
+
+        // Test 5: Component binding works
+        assert('Component registration and binding', function() {
+            ko.components.register('tt-test-component', {
+                template: '<span>component content</span>'
+            });
+            var div = document.createElement('div');
+            div.setAttribute('data-bind', 'component: "tt-test-component"');
+            document.body.appendChild(div);
+            ko.applyBindings({}, div);
+            // Components render asynchronously; just verify no TT error was thrown
+            ko.cleanNode(div);
+            document.body.removeChild(div);
+            ko.components.unregister('tt-test-component');
+        });
+
+        // Output results
+        window.__ttResults = results;
+        var resultDiv = document.getElementById('result');
+        resultDiv.textContent = JSON.stringify(results);
+    })();
+    </script>
+</body>
+</html>

--- a/src/binding/bindingProvider.js
+++ b/src/binding/bindingProvider.js
@@ -1,16 +1,6 @@
 (function() {
     var defaultBindingAttributeName = "data-bind";
 
-    if (typeof trustedTypes !== "undefined") {
-        var knockoutPolicy = trustedTypes['createPolicy']('knockout', {
-            // This is relatively safe for DOM-based XSS.
-            // But it is not safe for Store/Reflected XSS.
-            'createScript': function(opaqueScript) {
-                return opaqueScript;
-            }
-        });
-    }
-
     ko.bindingProvider = function() {
         this.bindingCache = {};
     };
@@ -76,14 +66,11 @@
         // Example result: with(sc1) { with(sc0) { return (expression) } }
         var rewrittenBindings = ko.expressionRewriting.preProcessBindings(bindingsString, options),
             functionBody = "with($context){with($data||{}){return{" + rewrittenBindings + "}}}";
-
-        if (typeof trustedTypes !== "undefined") {
-            // Trusted Types has a bug where it throws on new Function
-            // even if we pass TrustedScript. So use eval instead.
-            var f = "(function($context, $element) { " + functionBody + " })";
-            return eval(knockoutPolicy['createScript'](f));
+        if (koTrustedTypesPolicy) {
+            // new Function() doesn't accept TrustedScript in Chrome, so use eval instead. (https://issues.chromium.org/issues/40133092)
+            // eval returns the result of the last expression, so wrap as a function expression.
+            return eval(koTrustedTypesPolicy['createScript']("(function($context,$element){" + functionBody + "})"));
         }
-
         return new Function("$context", "$element", functionBody);
     }
 })();

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -55,12 +55,7 @@
                 documentContext.body.appendChild(div);
             }
 
-            if (typeof trustedTypes !== "undefined" && trustedTypes['isHTML'](html)) {
-                // Pass TrustedHTML as-is.
-                div.innerHTML = html;
-            } else {
-                div.innerHTML = markup;
-            }
+            div.innerHTML = koTrustedTypesPolicy ? koTrustedTypesPolicy['createHTML'](markup) : markup;
 
             if (mayRequireCreateElementHack) {
                 div.parentNode.removeChild(div);
@@ -117,9 +112,13 @@
         html = ko.utils.unwrapObservable(html);
 
         if ((html !== null) && (html !== undefined)) {
-            // If passed html is a TrustedHTML, do not stringify.
-            if (typeof html != 'string' && typeof trustedTypes !== "undefined" && !trustedTypes['isHTML'](html))
+            if (typeof html != 'string') {
+                if (typeof trustedTypes !== 'undefined' && trustedTypes['isHTML'](html)) {
+                    node.innerHTML = html;
+                    return;
+                }
                 html = html.toString();
+            }
 
             // jQuery contains a lot of sophisticated code to parse arbitrary HTML fragments,
             // for example <tr> elements which are not normally allowed to exist on their own.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,16 @@
+// Create a Trusted Types policy for Knockout's internal use (e.g., innerHTML, new Function)
+var koTrustedTypesPolicy;
+if (typeof trustedTypes !== 'undefined') {
+    try {
+        koTrustedTypesPolicy = trustedTypes['createPolicy']('knockout', {
+            'createHTML': function(s) { return s; },
+            'createScript': function(s) { return s; }
+        });
+    } catch (e) {
+        // Policy creation may fail if CSP restricts policy names or 'knockout' already exists
+    }
+}
+
 ko.utils = (function () {
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -41,12 +54,13 @@ ko.utils = (function () {
     });
     var eventsThatMustBeRegisteredUsingAttachEvent = { 'propertychange': true }; // Workaround for an IE9 issue - https://github.com/SteveSanderson/knockout/issues/406
 
-    var ieVersion = undefined;
-    if (typeof trustedTypes === "undefined") {
-        // Detect IE versions for bug workarounds (uses IE conditionals, not UA string, for robustness)
-        // Note that, since IE 10 does not support conditional comments, the following logic only detects IE < 10.
-        // Currently this is by design, since IE 10+ behaves correctly when treated as a standard browser.
-        // If there is a future need to detect specific versions of IE10+, we will amend this.
+    // Detect IE versions for bug workarounds (uses IE conditionals, not UA string, for robustness)
+    // Note that, since IE 10 does not support conditional comments, the following logic only detects IE < 10.
+    // Currently this is by design, since IE 10+ behaves correctly when treated as a standard browser.
+    // If there is a future need to detect specific versions of IE10+, we will amend this.
+    // Skip when Trusted Types is available (IE doesn't support Trusted Types)
+    var ieVersion;
+    if (!koTrustedTypesPolicy) {
         ieVersion = document && (function() {
             var version = 3, div = document.createElement('div'), iElems = div.getElementsByTagName('i');
 
@@ -58,7 +72,6 @@ ko.utils = (function () {
             return version > 4 ? version : undefined;
         }());
     }
-
     var isIe6 = ieVersion === 6,
         isIe7 = ieVersion === 7;
 


### PR DESCRIPTION
This change adds [Trusted Types](https://web.dev/trusted-types/) support to Knockout. 

All the changes are behind `typeof trustedTypes !== 'undefined'`, so this change should only affect Chromium users (where Trusted Types is supported). Unless developers who uses Knockout wants to enforce Trusted Types, this change won't affect anyone.

Note that this only prevents DOM-based XSS, so stored and reflected XSS are still possible.

Fixes #2579.