### PR TITLE
docs: Fix a few typos

### DIFF
--- a/spec/asyncBehaviors.js
+++ b/spec/asyncBehaviors.js
@@ -213,7 +213,7 @@ describe('Rate-limited', function() {
             jasmine.Clock.tick(250);
             expect(notifySpy).toHaveBeenCalledWith('a');
 
-            // Second notification happends using later settings
+            // Second notification happens using later settings
             notifySpy.reset();
             jasmine.Clock.tick(250);
             expect(notifySpy).toHaveBeenCalledWith('b');

--- a/spec/defaultBindings/valueBehaviors.js
+++ b/spec/defaultBindings/valueBehaviors.js
@@ -450,7 +450,7 @@ describe('Binding: Value', function() {
 
         it('Should automatically initialize the model property to match the first option value if no option value matches the current model property value', function() {
             // The rationale here is that we always want the model value to match the option that appears to be selected in the UI
-            //  * If there is *any* option value that equals the model value, we'd initalise the select box such that *that* option is the selected one
+            //  * If there is *any* option value that equals the model value, we'd initialise the select box such that *that* option is the selected one
             //  * If there is *no* option value that equals the model value (often because the model value is undefined), we should set the model
             //    value to match an arbitrary option value to avoid inconsistency between the visible UI and the model
             var observable = new ko.observable(); // Undefined by default

--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -64,7 +64,7 @@ describe('Mapping helpers', function() {
         var date = new Date();
         var string = new String();
         var number = new Number();
-        var booleanValue = new Boolean(); // 'boolean' is a resever word in JavaScript
+        var booleanValue = new Boolean(); // 'boolean' is a reserved word in JavaScript
 
         var result = ko.toJS({
             regExp: ko.observable(regExp),

--- a/src/binding/defaultBindings/textInput.js
+++ b/src/binding/defaultBindings/textInput.js
@@ -138,7 +138,7 @@ ko.bindingHandlers['textInput'] = {
                 // IE 8 has a bug where it fails to fire 'propertychange' on the first update following a value change from
                 // JavaScript code. It also doesn't fire if you clear the entire value. To fix this, we bind to the following
                 // events too.
-                onEvent('keyup', updateModel);      // A single keystoke
+                onEvent('keyup', updateModel);      // A single keystroke
                 onEvent('keydown', updateModel);    // The first character when a key is held down
             }
             if (registerForSelectionChangeEvent) {


### PR DESCRIPTION
There are small typos in:
- spec/asyncBehaviors.js
- spec/defaultBindings/valueBehaviors.js
- spec/mappingHelperBehaviors.js
- src/binding/defaultBindings/textInput.js

Fixes:
- Should read `reserved` rather than `resever`.
- Should read `keystroke` rather than `keystoke`.
- Should read `initialise` rather than `initalise`.
- Should read `happens` rather than `happends`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md