### PR TITLE
DOM text reinterpreted as HTML Update utils.domManipulation.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.0",
     "typescript": "^3.7.5"
+    "dompurify": "^3.2.4"
   }
 }

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 (function () {
     var none = [0, "", ""],
         table = [1, "<table>", "</table>"],
@@ -42,7 +43,7 @@
 
         // Go to html and back, then peel off extra wrappers
         // Note that we always prefix with some dummy text, because otherwise, IE<9 will strip out leading comment nodes in descendants. Total madness.
-        var markup = "ignored<div>" + wrap[1] + html + wrap[2] + "</div>";
+        var markup = "ignored<div>" + wrap[1] + DOMPurify.sanitize(html) + wrap[2] + "</div>";
         if (typeof windowContext['innerShiv'] == "function") {
             // Note that innerShiv is deprecated in favour of html5shiv. We should consider adding
             // support for html5shiv (except if no explicit support is needed, e.g., if html5shiv


### PR DESCRIPTION
By using DOMPurify it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities.