### PR TITLE
fix catastrophic backtracking in virtual element comment regex

### DIFF
--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -12,7 +12,7 @@
     // So, use node.text where available, and node.nodeValue elsewhere
     var commentNodesHaveTextProperty = document && document.createComment("test").text === "<!--test-->";
 
-    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko(?:\s+([\s\S]+))?\s*-->$/ : /^\s*ko(?:\s+([\s\S]+))?\s*$/;
+    var startCommentRegex = commentNodesHaveTextProperty ? /^<!--\s*ko(?:\s+(\S[\s\S]*?)-->|\s*-->)$/ : /^\s*ko(?:\s+(\S[\s\S]*?)|\s*)$/;
     var endCommentRegex =   commentNodesHaveTextProperty ? /^<!--\s*\/ko\s*-->$/ : /^\s*\/ko\s*$/;
     var htmlTagsWithOptionallyClosingChildren = { 'ul': true, 'ol': true };
 


### PR DESCRIPTION
ko.virtualElements recognises containerless bindings by testing every comment node's text against startCommentRegex during applyBindings, so its input is whatever comment content happens to sit in the bound subtree. The pattern puts three whitespace-capable quantifiers around the captured expression: \s+, a greedy ([\s\S]+), and a trailing \s* before the -->. When a comment starts with "<!-- ko" and is followed by a run of whitespace with no closing token, the matcher tries every way of splitting that whitespace across the three quantifiers before it gives up, which is cubic in the length of the run. I ran into it while pushing crafted comment content through the binding walk: a comment with ~2000 trailing spaces takes about 1.3s to reject and ~4000 about 9.6s, all on the main thread. The rewrite anchors the captured group so it starts at a non-space character and ends at the literal terminator, which means any given whitespace character can only belong to one quantifier and matching stays linear. Captures for every valid virtual-binding comment are unchanged, and the same half-megabyte input that used to hang now rejects in under 2ms.

Timings (regex test on `<!-- ko `+N spaces):

    N chars   before     after
    1000      177 ms     0.07 ms
    2000      1.3 s      0.02 ms
    4000      9.6 s      0.02 ms
    500000    (hangs)    1.6 ms