### PR TITLE
fix exponential backtracking in binding expression tokenizer

### DIFF
--- a/spec/expressionRewritingBehaviors.js
+++ b/spec/expressionRewritingBehaviors.js
@@ -225,4 +225,13 @@ describe('Expression Rewriting', function() {
                 { key: 'd', value: "'empty comment'" }
             ]);
     });
+
+    it('Should not backtrack exponentially on an unterminated string with escape characters', function() {
+        // The string token used to be /"(?:\\.|[^"])*"/, where [^"] also matches the backslash
+        // that the escape branch consumes. A run of backslashes with no closing quote could be
+        // tiled in exponentially many ways, so parsing a short input took seconds.
+        var start = new Date();
+        ko.expressionRewriting.parseObjectLiteral('a: "' + new Array(60).join('\\'));
+        expect(new Date() - start).toBeLessThan(1000);
+    });
 });

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -19,16 +19,16 @@ ko.expressionRewriting = (function () {
         // Create the actual regular expression by or-ing the following regex strings. The order is important.
         bindingToken = RegExp([
             // These match strings, either with double quotes, single quotes, or backticks
-            '"(?:\\\\.|[^"])*"',
-            "'(?:\\\\.|[^'])*'",
-            "`(?:\\\\.|[^`])*`",
+            '"(?:\\\\.|[^"\\\\])*"',
+            "'(?:\\\\.|[^'\\\\])*'",
+            "`(?:\\\\.|[^`\\\\])*`",
             // Match C style comments
             "/\\*(?:[^*]|\\*+[^*/])*\\*+/",
             // Match C++ style comments
             "//.*\n",
             // Match a regular expression (text enclosed by slashes), but will also match sets of divisions
             // as a regular expression (this is handled by the parsing loop below).
-            '/(?:\\\\.|[^/])+/\w*',
+            '/(?:\\\\.|[^/\\\\])+/\w*',
             // Match text (at least two characters) that does not contain any of the above special characters,
             // although some of the special characters are allowed to start it (all but the colon and comma).
             // The text can contain spaces, but leading or trailing spaces are skipped.


### PR DESCRIPTION
The string and regex-literal tokens in bindingToken share the shape (?:\\.|[^"])*, where the negated class also matches the backslash that the escape branch consumes. On an unterminated string with a run of backslashes the engine can tile those backslashes across the two branches in exponentially many ways before it gives up, so parseObjectLiteral (which runs on every data-bind attribute during applyBindings) stalls: around 40 backslashes takes ~0.8s and ~50 freezes the thread for minutes. Excluding the backslash from each negated class ([^"\\], [^'\\], [^`\\], [^/\\]) makes the escape branch unambiguous so matching stays linear, and every valid literal still tokenizes the same.