### PR TITLE
skip __proto__ when copying an object graph in ko.toJS

### DIFF
--- a/spec/mappingHelperBehaviors.js
+++ b/spec/mappingHelperBehaviors.js
@@ -101,6 +101,16 @@ describe('Mapping helpers', function() {
         expect(result.exclude).toEqual(obj.exclude);
     });
 
+    it('ko.toJS should not let a "__proto__" property become the prototype of the result', function() {
+        var data = JSON.parse('{"name":"bob","__proto__":{"isAdmin":true}}');
+        expect(data.isAdmin).toEqual(undefined);
+
+        var result = ko.toJS(data);
+        expect(result.name).toEqual("bob");
+        expect(result.isAdmin).toEqual(undefined);
+        expect(Object.getPrototypeOf(result)).toEqual(Object.prototype);
+    });
+
     it('ko.toJSON should unwrap everything and then stringify', function() {
         var data = ko.observableArray(['a', 1, { someProp : ko.observable('Hey') }]);
         var result = ko.toJSON(data);

--- a/src/subscribables/mappingHelpers.js
+++ b/src/subscribables/mappingHelpers.js
@@ -66,7 +66,10 @@
                 visitorCallback('toJSON');
         } else {
             for (var propertyName in rootObject) {
-                visitorCallback(propertyName);
+                // Assigning "__proto__" on the output object runs the Object.prototype setter, which replaces
+                // the output's prototype instead of adding a property to it, so skip it.
+                if (propertyName !== "__proto__")
+                    visitorCallback(propertyName);
             }
         }
     };


### PR DESCRIPTION
ko.toJS walks an arbitrary object graph and copies each enumerated property onto a fresh output object. View models are routinely built straight from server JSON, and JSON.parse makes "__proto__" an own enumerable data property rather than invoking the setter, so a key like that survives into the graph without polluting the input. Copying it back out with a plain assignment does invoke the Object.prototype setter, so the result of ko.toJS ends up with the supplied object as its prototype, and every property the caller reads that isn't set on the result resolves through it. I noticed it while checking what ko.toJSON silently drops: ko.toJS(JSON.parse('{"name":"bob","__proto__":{"isAdmin":true}}')).isAdmin comes back true even though the parsed input reports undefined for it. Skipping the key in visitPropertiesOrArrayEntries keeps it out of the output entirely, which leaves ko.toJSON output identical since JSON.stringify never emitted the inherited value anyway. Test added alongside the existing mapping specs.