### PR TITLE
look up tag names and keywords as own properties

### DIFF
--- a/spec/bindingAttributeBehaviors.js
+++ b/spec/bindingAttributeBehaviors.js
@@ -184,6 +184,12 @@ describe('Binding attribute syntax', function() {
         expect(testNode).toContainText("My prop value");
     });
 
+    it('Should bind descendants of an element whose tag name matches an inherited Object property', function() {
+        testNode.innerHTML = "<constructor><div data-bind='text: someProp'></div></constructor>";
+        ko.applyBindings({ someProp: 'My prop value' }, testNode);
+        expect(testNode).toContainText("My prop value");
+    });
+
     it('Bindings can signal that they control descendant bindings by returning a flag from their init function', function() {
         ko.bindingHandlers.test = {
             init: function() { return { controlsDescendantBindings : true } }

--- a/spec/expressionRewritingBehaviors.js
+++ b/spec/expressionRewritingBehaviors.js
@@ -65,6 +65,11 @@ describe('Expression Rewriting', function() {
         expect(result[1].value).toEqual("function(){var regex=/{/g;return/123/;}");
     });
 
+    it('Should treat a division after an inherited Object property name as a division', function() {
+        var result = ko.expressionRewriting.parseObjectLiteral("a: x.constructor/2, b: y/3");
+        expect(result).toEqual([{key: 'a', value: 'x.constructor/2'}, {key: 'b', value: 'y/3'}]);
+    });
+
     it('Should parse a value that begins with a colon', function() {
         var result = ko.expressionRewriting.parseObjectLiteral("a: :-)");
         expect(result.length).toEqual(1);

--- a/spec/parseHtmlFragment.js
+++ b/spec/parseHtmlFragment.js
@@ -17,6 +17,7 @@ describe('Parse HTML fragment', function() {
         { html: '<tfoot-component>foo</tfoot-component>', parsed: ['<tfoot-component>foo</tfoot-component>'], jQueryRequiredVersion: "3.0" },
         { html: '<div></div>', parsed: ['<div></div>'] },
         { html: '<custom-component></custom-component>', parsed: ['<custom-component></custom-component>'] },
+        { html: '<constructor></constructor>', parsed: ['<constructor></constructor>'] },
         { html: '<tr></tr>', parsed: ['<tr></tr>'] },
         { html: '<!-- ko if:true --><tr></tr><!-- /ko -->', parsed: ['<!-- ko if:true -->','<tr></tr>','<!-- /ko -->'] },
         { html: '<!-- this is a table row --><tr></tr>', parsed: ['<!-- this is a table row -->','<tr></tr>'] },

--- a/src/binding/bindingAttributeSyntax.js
+++ b/src/binding/bindingAttributeSyntax.js
@@ -347,7 +347,7 @@
         if (shouldApplyBindings)
             bindingContextForDescendants = applyBindingsToNodeInternal(nodeVerified, null, bindingContext)['bindingContextForDescendants'];
 
-        if (bindingContextForDescendants && !bindingDoesNotRecurseIntoElementTypes[ko.utils.tagNameLower(nodeVerified)]) {
+        if (bindingContextForDescendants && !Object.prototype.hasOwnProperty.call(bindingDoesNotRecurseIntoElementTypes, ko.utils.tagNameLower(nodeVerified))) {
             applyBindingsToDescendantsInternal(bindingContextForDescendants, nodeVerified);
         }
     }

--- a/src/binding/expressionRewriting.js
+++ b/src/binding/expressionRewriting.js
@@ -81,7 +81,7 @@ ko.expressionRewriting = (function () {
                 } else if (c === 47 && i && tok.length > 1) {  // "/"
                     // Look at the end of the previous token to determine if the slash is actually division
                     var match = toks[i-1].match(divisionLookBehind);
-                    if (match && !keywordRegexLookBehind[match[0]]) {
+                    if (match && !Object.prototype.hasOwnProperty.call(keywordRegexLookBehind, match[0])) {
                         // The slash is actually a division punctuator; re-parse the remainder of the string (not including the slash)
                         str = str.substr(str.indexOf(tok) + 1);
                         toks = str.match(bindingToken);

--- a/src/utils.domManipulation.js
+++ b/src/utils.domManipulation.js
@@ -20,7 +20,7 @@
 
     function getWrap(tags) {
         var m = tags.match(/^(?:<!--.*?-->\s*?)*?<([a-z]+)[\s>]/);
-        return (m && lookup[m[1]]) || none;
+        return (m && Object.prototype.hasOwnProperty.call(lookup, m[1]) && lookup[m[1]]) || none;
     }
 
     function simpleHtmlParse(html, documentContext) {

--- a/src/virtualElements.js
+++ b/src/virtualElements.js
@@ -191,7 +191,7 @@
             // Workaround for https://github.com/SteveSanderson/knockout/issues/155
             // (IE <= 8 or IE 9 quirks mode parses your HTML weirdly, treating closing </li> tags as if they don't exist, thereby moving comment nodes
             // that are direct descendants of <ul> into the preceding <li>)
-            if (!htmlTagsWithOptionallyClosingChildren[ko.utils.tagNameLower(elementVerified)])
+            if (!Object.prototype.hasOwnProperty.call(htmlTagsWithOptionallyClosingChildren, ko.utils.tagNameLower(elementVerified)))
                 return;
 
             // Scan immediate children to see if they contain unbalanced comment tags. If they do, those comment tags


### PR DESCRIPTION
getWrap, normaliseVirtualElementDomStructure, applyBindingsToNodeAndDescendantsInternal and parseObjectLiteral index object literals with names taken straight from parsed markup or binding text, so anything that resolves through Object.prototype counts as a table entry. lowercased tag names only match one of them, but it is enough: ko.utils.parseHtmlFragment('<constructor>hi</constructor>') picks Object as the table wrapper and returns two stray "undefined" text nodes around the element (same through the html binding), descendants of such an element are silently left unbound, and the ul/ol comment-moving workaround runs on it. the same thing in the tokenizer costs a binding: "text: a.constructor/2, css: b/3" fails the division-vs-regex check, so the slash starts a regex literal and everything up to the next slash is swallowed, dropping the css binding. guarded each lookup with hasOwnProperty the way the component loader and template rewriting already do, plus specs for the three visible cases.