### PR TITLE
docs: keep hasFocus click-to-edit example usable when name is empty

### DIFF
--- a/documentation/hasfocus-binding.md
+++ b/documentation/hasfocus-binding.md
@@ -39,7 +39,7 @@ Because the `hasFocus` binding works in both directions (setting the associated 
 {% capture live_example_view %}
 <p>
 	Name: 
-	<b data-bind="visible: !editing(), text: name, click: edit">&nbsp;</b>
+	<b data-bind="visible: !editing(), text: name() || '[ none ]', click: edit">&nbsp;</b>
 	<input data-bind="visible: editing, value: name, hasFocus: editing" />
 </p>
 <p><em>Click the name to edit it; click elsewhere to apply changes.</em></p>


### PR DESCRIPTION
## Summary
- Fixes the click-to-edit example on the hasFocus binding docs so clearing the name does not leave an empty, unclickable label.
- Uses a simple placeholder (`[ none ]`) when `name` is empty, matching the suggestion on #2581.

Closes #2581

## Test plan
- [ ] Open the hasFocus docs page click-to-edit example
- [ ] Click the name, clear the input, blur to leave edit mode
- [ ] Confirm the placeholder is shown and clicking it re-enters edit mode